### PR TITLE
Minion: point submodule to upstream (minion/minion)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "minion-bindings/vendor"]
 	path = solvers/minion/vendor
-	url = https://github.com/niklasdewally/minion
+	url = https://github.com/minion/minion
 [submodule "solvers/chuffed/vendor"]
 	path = solvers/chuffed/vendor
 	url = https://github.com/Kieranoski702/chuffed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "minion-bindings/vendor"]
 	path = solvers/minion/vendor
 	url = https://github.com/minion/minion
+  ignore = dirty
+
 [submodule "solvers/chuffed/vendor"]
 	path = solvers/chuffed/vendor
 	url = https://github.com/Kieranoski702/chuffed

--- a/solvers/minion/build.rs
+++ b/solvers/minion/build.rs
@@ -57,13 +57,12 @@ fn bind() {
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
-        .header("vendor/minion/minion.h")
+        .header("vendor/minion/libwrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         // Must manually give allow list to stop bindgen accidentally binding something complicated
         // in C++ stdlib that will make it crash.
-        .allowlist_var("MinionVersion")
         .allowlist_function("minion_main")
         .clang_arg("-Ivendor/build/src/") // generated from configure.py
         .clang_arg("-Ivendor/minion/")

--- a/solvers/minion/src/main.rs
+++ b/solvers/minion/src/main.rs
@@ -2,15 +2,10 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use minion_rs::bindings::MinionVersion;
 use std::ffi::c_char;
 use std::ffi::CString;
 
 pub fn main() {
-    unsafe {
-        let minionVersion: &str = std::str::from_utf8_unchecked(MinionVersion);
-        println!("{:?}", minionVersion);
-    }
 
     // https://stackoverflow.com/questions/34379641/how-do-i-convert-rust-args-into-the-argc-and-argv-c-equivalents
     let args = std::env::args()


### PR DESCRIPTION
@ozgurakgun 

The `minion_main` function is now exposed in libminion (https://github.com/minion/minion/pull/10), meaning I no longer need the custom fork of it.

This PR updates the submodule to point to `minion/minion`.


It also suppresses the `vendor (not tracked)` messages that appears in `git status` when Minion has folders untracked by git (such as build files).