### PR TITLE
an initial go at representing a model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -39,7 +39,7 @@ version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -52,7 +52,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.38",
  "which",
 ]
 
@@ -64,9 +64,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "cc"
@@ -113,6 +113,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "conjure-oxide"
+version = "0.0.1"
+
+[[package]]
 name = "derive-try-from-primitive"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,23 +135,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -167,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
@@ -214,9 +207,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libloading"
@@ -230,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -242,9 +235,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "minimal-lexical"
@@ -290,14 +283,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -313,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -325,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -336,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustc-hash"
@@ -348,11 +341,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -378,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -404,7 +397,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,8 @@
-[workspace]
+[package]
+name = "conjure-oxide"
+version = "0.0.1"
+edition = "2021"
 
+[workspace]
 members = ["solvers/kissat", "solvers/minion", "solvers/chuffed"]
 exclude = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,22 @@
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 fn main() {
     let a = Name::UserName(String::from("a"));
     let b = Name::UserName(String::from("b"));
     let c = Name::UserName(String::from("c"));
 
-    let a_decision_variable = Rc::new(DecisionVariable {
+    let a_decision_variable = Rc::new(RefCell::new(DecisionVariable {
         name: a,
         domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
-    });
-    let b_decision_variable = Rc::new(DecisionVariable {
+    }));
+    let b_decision_variable = Rc::new(RefCell::new(DecisionVariable {
         name: b,
         domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
-    });
-    let c_decision_variable = Rc::new(DecisionVariable {
+    }));
+    let c_decision_variable = Rc::new(RefCell::new(DecisionVariable {
         name: c,
         domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
-    });
+    }));
 
     // find a,b,c : int(1..3)
     // such that a + b + c = 4
@@ -42,6 +42,13 @@ fn main() {
     };
 
     println!("{:#?}", m);
+
+    {
+        let mut decision_var_borrowed = a_decision_variable.borrow_mut();
+        decision_var_borrowed.domain = Domain::IntDomain(vec![Range::Bounded(1, 2)]);
+    }
+
+    println!("{:#?}", m);
 }
 
 #[derive(Debug)]
@@ -63,7 +70,7 @@ struct DecisionVariable {
 
 #[derive(Debug)]
 enum Statement {
-    Declaration(Rc<DecisionVariable>),
+    Declaration(Rc<RefCell<DecisionVariable>>),
     Constraint(Expression),
 }
 
@@ -82,7 +89,7 @@ enum Range<A> {
 #[derive(Debug)]
 enum Expression {
     ConstantInt(i32),
-    Reference(Rc<DecisionVariable>),
+    Reference(Rc<RefCell<DecisionVariable>>),
     Sum(Vec<Expression>),
     Eq(Box<Expression>, Box<Expression>),
     Geq(Box<Expression>, Box<Expression>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,80 @@
+fn main() {
+    let a = Name::UserName(String::from("a"));
+    let b = Name::UserName(String::from("b"));
+    let c = Name::UserName(String::from("c"));
+
+    let a_decision_variable = DecisionVariable {
+        name: a,
+        domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
+    };
+    let a_reference = Expression::Reference(&a_decision_variable);
+
+    let b_decision_variable = DecisionVariable {
+        name: b,
+        domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
+    };
+    let b_reference = Expression::Reference(&b_decision_variable);
+
+    let c_decision_variable = DecisionVariable {
+        name: c,
+        domain: Domain::IntDomain(vec![Range::Bounded(1, 3)]),
+    };
+    let c_reference = Expression::Reference(&c_decision_variable);
+
+    let m = Model {
+        statements: vec![
+            Statement::Declaration(&a_decision_variable),
+            Statement::Declaration(&b_decision_variable),
+            Statement::Declaration(&c_decision_variable),
+            Statement::Constraint(Expression::Eq(
+                Box::from(Expression::Sum(vec![a_reference, b_reference, c_reference])),
+                Box::from(Expression::ConstantInt(4)),
+            )),
+        ],
+    };
+
+    println!("{:#?}", m);
+}
+
+#[derive(Debug)]
+enum Name {
+    UserName(String),
+    MachineName(i32),
+}
+
+#[derive(Debug)]
+struct Model<'a> {
+    statements: Vec<Statement<'a>>,
+}
+
+#[derive(Debug)]
+struct DecisionVariable {
+    name: Name,
+    domain: Domain,
+}
+
+#[derive(Debug)]
+enum Statement<'a> {
+    Declaration(&'a DecisionVariable),
+    Constraint(Expression<'a>),
+}
+
+#[derive(Debug)]
+enum Domain {
+    BoolDomain,
+    IntDomain(Vec<Range<i32>>),
+}
+
+#[derive(Debug)]
+enum Range<A> {
+    Single(A),
+    Bounded(A, A),
+}
+
+#[derive(Debug)]
+enum Expression<'a> {
+    ConstantInt(i32),
+    Reference(&'a DecisionVariable),
+    Sum(Vec<Expression<'a>>),
+    Eq(Box<Expression<'a>>, Box<Expression<'a>>),
+}


### PR DESCRIPTION
We are trying to represent:

```
find a,b,c : int(1..3)
such that a + b + c = 4
```

Influenced by Conjure's internal representation, not sure about refs/boxes etc yet.

Creating PR to get feedback, will add simple testing before I am ready to merge.

Next steps:
- [ ] convert to one solver backend
- [ ] construct model from `conjure pretty --output-format=astjson` output
- [ ] test conjure-oxide and conjure agree on full set of solutions
- [ ] parameterise so we test a few instances
- [ ] refactor into a sensible code layout + write comments