### PR TITLE
Use cargo fmt directly, instead of an action

### DIFF
--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -16,8 +16,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - name: rust-rustfmt-check
-        uses: mbrobbel/rustfmt-check@0.8.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          mode: review
+      - name: Check rust formatting
+        run: cargo fmt --check


### PR DESCRIPTION
This is a suggested alternative way to do the rust formatting check -- rather than using an action, just run `cargo fmt --check`. This will output a diff, and fail, if `cargo fmt` hasn't been run.

Disadvantages: Doesn't automatically edit your commit to do the formatting.

Advantages: Should work and not require nightly and other things :)