### PR TITLE
Documentation Coverage CI

### DIFF
--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./solvers/minion
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/2 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   chuffed:
@@ -68,7 +68,7 @@ jobs:
         working-directory: ./solvers/chuffed
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/2 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   conjure-oxide:
@@ -96,5 +96,5 @@ jobs:
       - name: Coverage Report
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/2 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Coverage Report
         working-directory: ./solvers/minion
         run: |
-          echo -e "# Coverage Report \n\n" > $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
   chuffed:
     name: 'Chuffed'
@@ -67,7 +68,7 @@ jobs:
         working-directory: ./solvers/chuffed
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   conjure-oxide:
@@ -95,5 +96,5 @@ jobs:
       - name: Coverage Report
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./solvers/minion
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   chuffed:
@@ -68,7 +68,7 @@ jobs:
         working-directory: ./solvers/chuffed
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   conjure-oxide:
@@ -96,5 +96,5 @@ jobs:
       - name: Coverage Report
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-
 jobs:
   minion:
     name: 'Minion'
@@ -12,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get minion hash for cache invalidation
+        id: minion-cache
+        run: |
+          echo "minion_sha=$(git rev-parse HEAD:solvers/minion/vendor)" >> "$GITHUB_OUTPUT"
+
       - name: Set up cache
         uses: actions/cache@v3
         with:
@@ -21,18 +25,15 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/            
-          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # match minion exactly, cargo inexactly
-          restore-keys: doccoverage-${{ runner.os }}-cargo
-
-      - working-directory: ./solvers/minion
-        run: rustup update nightly && rustup default nightly
+            solvers/minion/vendor
+          key: nightly-${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: nightly-${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha}}-cargo-
 
       - name: Coverage Report
         working-directory: ./solvers/minion
         run: |
           echo -e "# Coverage Report \n\n" > $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
 
   chuffed:
     name: 'Chuffed'
@@ -40,6 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get chuffed hash for cache invalidation
+        id: chuffed-cache
+        run: |
+          echo "chuffed_sha=$(git rev-parse HEAD:solvers/chuffed/vendor)" >> "$GITHUB_OUTPUT"
+
       - name: Set up cache
         uses: actions/cache@v3
         with:
@@ -49,9 +55,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/            
-          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # match minion exactly, cargo inexactly
-          restore-keys: doccoverage-${{ runner.os }}-cargo
+            solvers/chuffed/vendor
+          key: nightly-${{ runner.os }}-chuffed-${{ steps.chuffed-cache.outputs.chuffed_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # match chuffed exactly, cargo inexactly
+          restore-keys: nightly-${{ runner.os }}-chuffed-${{ steps.chuffed-cache.outputs.chuffed_sha}}-cargo-
 
       - working-directory: ./solvers/chuffed
         run: rustup update nightly && rustup default nightly
@@ -60,7 +67,7 @@ jobs:
         working-directory: ./solvers/chuffed
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   conjure-oxide:
@@ -77,15 +84,16 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            ~/solvers/minion/vendor
+            ~/solvers/chuffed/vendor
             target/            
-          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # match minion exactly, cargo inexactly
-          restore-keys: doccoverage-${{ runner.os }}-cargo
+          key: nightly-conjureoxide-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: nightly-conjureoxide-${{ runner.os }}-cargo
 
       - run: rustup update nightly && rustup default nightly
 
       - name: Coverage Report
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a >($GITHUB_STEP_SUMMARY)
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./solvers/minion
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   chuffed:
@@ -68,7 +68,7 @@ jobs:
         working-directory: ./solvers/chuffed
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   conjure-oxide:
@@ -96,5 +96,5 @@ jobs:
       - name: Coverage Report
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc 2>&1 | tee -a >($GITHUB_STEP_SUMMARY)
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee /dev/fd/1 >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+
       - name: Get minion hash for cache invalidation
         id: minion-cache
         run: |
@@ -28,6 +29,9 @@ jobs:
             solvers/minion/vendor
           key: nightly-${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: nightly-${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha}}-cargo-
+
+      - name: Use nightly 
+        run: rustup update nightly && rustup default nightly
 
       - name: Coverage Report
         working-directory: ./solvers/minion
@@ -61,7 +65,7 @@ jobs:
           # match chuffed exactly, cargo inexactly
           restore-keys: nightly-${{ runner.os }}-chuffed-${{ steps.chuffed-cache.outputs.chuffed_sha}}-cargo-
 
-      - working-directory: ./solvers/chuffed
+      - name: Use nightly 
         run: rustup update nightly && rustup default nightly
 
       - name: Coverage Report
@@ -91,7 +95,8 @@ jobs:
           key: nightly-conjureoxide-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: nightly-conjureoxide-${{ runner.os }}-cargo
 
-      - run: rustup update nightly && rustup default nightly
+      - name: Use nightly 
+        run: rustup update nightly && rustup default nightly
 
       - name: Coverage Report
         run: |

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -1,0 +1,91 @@
+name: 'Info: Documentation Coverage'
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+
+jobs:
+  minion:
+    name: 'Minion'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # match minion exactly, cargo inexactly
+          restore-keys: doccoverage-${{ runner.os }}-cargo
+
+      - working-directory: ./solvers/minion
+        run: rustup update nightly && rustup default nightly
+
+      - name: Coverage Report
+        working-directory: ./solvers/minion
+        run: |
+          echo -e "# Coverage Report \n\n" > $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+
+  chuffed:
+    name: 'Chuffed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # match minion exactly, cargo inexactly
+          restore-keys: doccoverage-${{ runner.os }}-cargo
+
+      - working-directory: ./solvers/chuffed
+        run: rustup update nightly && rustup default nightly
+
+      - name: Coverage Report
+        working-directory: ./solvers/chuffed
+        run: |
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+  conjure-oxide:
+    name: 'Conjure Oxide'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+          key: doccoverage-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # match minion exactly, cargo inexactly
+          restore-keys: doccoverage-${{ runner.os }}-cargo
+
+      - run: rustup update nightly && rustup default nightly
+
+      - name: Coverage Report
+        run: |
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/minion-tests.yml
+++ b/.github/workflows/minion-tests.yml
@@ -113,39 +113,6 @@ jobs:
       - working-directory: ./solvers/minion
         run: cargo test -- --test-threads=1
 
-  doc-coverage:
-    name: 'solvers/minion: Documentation Coverage Report'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Get minion hash for cache invalidation
-        id: minion-cache
-        run: |
-          echo "minion_sha=$(git rev-parse HEAD:solvers/minion/vendor)" >> "$GITHUB_OUTPUT"
-
-      - name: Set up cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/            
-            solvers/minion/vendor
-          key: ${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          # match minion exactly, cargo inexactly
-          restore-keys: ${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha}}-cargo-
-
-      - working-directory: ./solvers/minion
-        run: rustup update nightly && rustup default nightly
-
-      - name: Coverage Report
-        working-directory: ./solvers/minion
-        run: |
-          echo -e "# Coverage Report \n\n" > $GITHUB_STEP_SUMMARY
-          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
-
 
       
 

--- a/.github/workflows/minion-tests.yml
+++ b/.github/workflows/minion-tests.yml
@@ -113,6 +113,38 @@ jobs:
       - working-directory: ./solvers/minion
         run: cargo test -- --test-threads=1
 
+  doc-coverage:
+    name: 'solvers/minion: Documentation Coverage Report'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get minion hash for cache invalidation
+        id: minion-cache
+        run: |
+          echo "minion_sha=$(git rev-parse HEAD:solvers/minion/vendor)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/            
+            solvers/minion/vendor
+          key: ${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          # match minion exactly, cargo inexactly
+          restore-keys: ${{ runner.os }}-minion-${{ steps.minion-cache.outputs.minion_sha}}-cargo-
+
+      - working-directory: ./solvers/minion
+        run: rustup update nightly && rustup default nightly
+
+      - name: Coverage Report
+        working-directory: ./solvers/minion
+        run: |
+          echo -e "# Coverage Report \n\n" > $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc >> $GITHUB_STEP_SUMMARY
 
 
       


### PR DESCRIPTION
This PR adds a Github action to generate documentation coverage reports.
This is currently will just be for informational purposes, and is viewable in the CI job summary.



Would appreciate this to be squash merged when done.