### PR TITLE
Add wrappers for basic chuffed functions and example program using these wrappers

### DIFF
--- a/solvers/chuffed/build.rs
+++ b/solvers/chuffed/build.rs
@@ -72,6 +72,8 @@ fn bind() {
         .allowlist_function("var_sym_break")
         .allowlist_function("new_dummy_problem")
         .allowlist_function("get_idx")
+        .allowlist_function("make_vec_intvar")
+        .allowlist_function("destroy_vec_intvar")
         .allowlist_function("p_addVars")
         .allowlist_function("p_setcallback")
         .allowlist_function("branch_IntVar")

--- a/solvers/chuffed/build.rs
+++ b/solvers/chuffed/build.rs
@@ -16,6 +16,8 @@ fn main() {
     println!("cargo:rustc-link-search=all=./solvers/chuffed/vendor/build/");
     println!("cargo:rustc-link-lib=static=chuffed");
     println!("cargo:rustc-link-lib=static=chuffed_fzn");
+    println!("cargo:rustc-link-search=all=./solvers/chuffed/");
+    println!("cargo:rustc-link-lib=static=wrapper");
 
     // also need to (dynamically) link to c++ stdlib
     // https://flames-of-code.netlify.app/blog/rust-and-cmake-cplusplus/
@@ -64,6 +66,15 @@ fn bind() {
         // in C++ stdlib that will make it crash.
         .allowlist_function("createVars")
         .allowlist_function("createVar")
+        .allowlist_function("all_different")
+        .allowlist_function("branch")
+        .allowlist_function("output_vars")
+        .allowlist_function("var_sym_break")
+        .allowlist_function("new_dummy_problem")
+        .allowlist_function("get_idx")
+        .allowlist_function("p_addVars")
+        .allowlist_function("p_setcallback")
+        .allowlist_function("branch_IntVar")
         .clang_arg("-Ivendor/build") // generated from configure.py
         .clang_arg("-Ivendor")
         .clang_arg(r"--std=gnu++11")

--- a/solvers/chuffed/build.sh
+++ b/solvers/chuffed/build.sh
@@ -13,5 +13,5 @@ cmake --build build
 cd ..
 
 # Build wrapper.cpp as static library
-g++ -c wrapper.cpp -Ivendor
+c++ -c wrapper.cpp -Ivendor --std=c++11
 ar rvs libwrapper.a wrapper.o

--- a/solvers/chuffed/build.sh
+++ b/solvers/chuffed/build.sh
@@ -4,9 +4,14 @@ SCRIPT_DIR=$(dirname "$0")
 
 git submodule init
 git submodule update
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR" || exit
 
 echo "------ BUILDING ------"
 cd vendor || exit
 cmake -B build -S .
 cmake --build build
+cd ..
+
+# Build wrapper.cpp as static library
+g++ -c wrapper.cpp -Ivendor
+ar rvs libwrapper.a wrapper.o

--- a/solvers/chuffed/clean.sh
+++ b/solvers/chuffed/clean.sh
@@ -2,3 +2,5 @@
 
 cargo clean
 rm -rf vendor/build
+rm libwrapper.a
+rm wrapper.o

--- a/solvers/chuffed/compile_flags.txt
+++ b/solvers/chuffed/compile_flags.txt
@@ -1,0 +1,3 @@
+-I./vendor
+-xc++
+--std=c++11

--- a/solvers/chuffed/src/lib.rs
+++ b/solvers/chuffed/src/lib.rs
@@ -4,3 +4,45 @@ pub mod bindings {
     #![allow(non_snake_case)]
     include!(concat!(env!("OUT_DIR"), "/chuffed_bindings.rs"));
 }
+
+pub mod wrappers{
+    use crate::bindings::{IntVar, createVar, createVars, vec, all_different, ConLevel, VarBranch, branch_IntVar, ValBranch};
+    use core::ptr;
+
+    // The signature of createVar is below for reference.
+    // createVar(x: *mut *mut IntVar, min: ::std::os::raw::c_int, max: ::std::os::raw::c_int, el: bool)
+    pub fn create_var(min: i32, max: i32, el: bool) -> *mut IntVar {
+        let mut ptr: *mut IntVar = ptr::null_mut();
+
+        unsafe {
+            createVar(&mut ptr, min, max, el);
+            ptr 
+        }
+    }
+
+    // createVars void createVars(vec<IntVar*>& x, int n, int min, int max, bool el)
+    pub fn create_vars(n: i32, min:i32, max:i32, el:bool) -> *mut vec<*mut IntVar> {
+    
+        let ptr: *mut vec<*mut IntVar> = ptr::null_mut();
+
+        unsafe {
+            createVars(ptr, n, min, max, el);
+            ptr 
+        }
+    }
+
+    // void all_different(vec<IntVar*>& x, ConLevel cl)
+    pub unsafe fn all_different_wrapper(x: *mut vec<*mut IntVar>, cl: ConLevel) {
+        unsafe {
+            all_different(x, cl);
+        }
+    }
+
+    // void branch(vec<Branching*> x, VarBranch var_branch, ValBranch val_branch);
+    pub unsafe fn branch_wrapper(x: *mut vec<*mut IntVar>, var_branch: VarBranch, val_branch: ValBranch) {
+        unsafe {
+            branch_IntVar(x, var_branch, val_branch);
+        }
+    }
+}
+

--- a/solvers/chuffed/src/lib.rs
+++ b/solvers/chuffed/src/lib.rs
@@ -7,8 +7,8 @@ pub mod bindings {
 
 pub mod wrappers {
     use crate::bindings::{
-        all_different, branch_IntVar, createVar, createVars, vec, ConLevel, IntVar, ValBranch,
-        VarBranch,
+        all_different, branch_IntVar, createVar, createVars, make_vec_intvar, vec, ConLevel,
+        IntVar, ValBranch, VarBranch,
     };
     use core::ptr;
 
@@ -25,7 +25,7 @@ pub mod wrappers {
 
     // createVars void createVars(vec<IntVar*>& x, int n, int min, int max, bool el)
     pub fn create_vars(n: i32, min: i32, max: i32, el: bool) -> *mut vec<*mut IntVar> {
-        let ptr: *mut vec<*mut IntVar> = ptr::null_mut();
+        let ptr: *mut vec<*mut IntVar> = unsafe { make_vec_intvar() };
 
         unsafe {
             createVars(ptr, n, min, max, el);

--- a/solvers/chuffed/src/lib.rs
+++ b/solvers/chuffed/src/lib.rs
@@ -5,8 +5,11 @@ pub mod bindings {
     include!(concat!(env!("OUT_DIR"), "/chuffed_bindings.rs"));
 }
 
-pub mod wrappers{
-    use crate::bindings::{IntVar, createVar, createVars, vec, all_different, ConLevel, VarBranch, branch_IntVar, ValBranch};
+pub mod wrappers {
+    use crate::bindings::{
+        all_different, branch_IntVar, createVar, createVars, vec, ConLevel, IntVar, ValBranch,
+        VarBranch,
+    };
     use core::ptr;
 
     // The signature of createVar is below for reference.
@@ -16,18 +19,17 @@ pub mod wrappers{
 
         unsafe {
             createVar(&mut ptr, min, max, el);
-            ptr 
+            ptr
         }
     }
 
     // createVars void createVars(vec<IntVar*>& x, int n, int min, int max, bool el)
-    pub fn create_vars(n: i32, min:i32, max:i32, el:bool) -> *mut vec<*mut IntVar> {
-    
+    pub fn create_vars(n: i32, min: i32, max: i32, el: bool) -> *mut vec<*mut IntVar> {
         let ptr: *mut vec<*mut IntVar> = ptr::null_mut();
 
         unsafe {
             createVars(ptr, n, min, max, el);
-            ptr 
+            ptr
         }
     }
 
@@ -39,10 +41,13 @@ pub mod wrappers{
     }
 
     // void branch(vec<Branching*> x, VarBranch var_branch, ValBranch val_branch);
-    pub unsafe fn branch_wrapper(x: *mut vec<*mut IntVar>, var_branch: VarBranch, val_branch: ValBranch) {
+    pub unsafe fn branch_wrapper(
+        x: *mut vec<*mut IntVar>,
+        var_branch: VarBranch,
+        val_branch: ValBranch,
+    ) {
         unsafe {
             branch_IntVar(x, var_branch, val_branch);
         }
     }
 }
-

--- a/solvers/chuffed/src/main.rs
+++ b/solvers/chuffed/src/main.rs
@@ -1,8 +1,44 @@
-use chuffed_rs::bindings::createVar;
-use chuffed_rs::bindings::IntVar;
-pub fn main() {
-    let mut var = std::mem::MaybeUninit::<IntVar>::uninit();
-    unsafe {
-        createVar(&mut var.as_mut_ptr(), 0, 5, false);
+use chuffed_rs::wrappers::{create_vars, all_different_wrapper, branch_wrapper};
+use chuffed_rs::bindings::{IntVar, ConLevel_CL_DEF, VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN, vec, new_dummy_problem, get_idx, p_addVars, p_setcallback}; 
+
+unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
+    // Create constant
+    let n: i32 = _n;
+    // Create some variables
+    let x: *mut vec<*mut IntVar> = create_vars(n, 0, n, false);
+
+    // Post some constraints
+    all_different_wrapper(x, ConLevel_CL_DEF);
+
+    // Post some branchings
+    branch_wrapper(x as _, VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN); 
+
+    x
+}
+
+// Custom printing function for this problem
+#[no_mangle]
+pub unsafe extern "C" fn callback(x: *mut vec<*mut IntVar>) {
+   print!("First output is: {:?}", get_idx(x, 0));
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 2 {
+        println!("Invalid number of arguments");
+        return;
+    }
+
+    let n: i32 = args[1].parse().expect("Invalid input");
+    
+    unsafe{
+        let x = post_constraints(n);
+        // make new dummy problem
+        let p = new_dummy_problem();
+        // Call problem.addvars()
+        p_addVars(p, x);
+        // Call problem.setcallback()
+        p_setcallback(p, Some(callback));
     }
 }

--- a/solvers/chuffed/src/main.rs
+++ b/solvers/chuffed/src/main.rs
@@ -1,5 +1,8 @@
-use chuffed_rs::wrappers::{create_vars, all_different_wrapper, branch_wrapper};
-use chuffed_rs::bindings::{IntVar, ConLevel_CL_DEF, VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN, vec, new_dummy_problem, get_idx, p_addVars, p_setcallback}; 
+use chuffed_rs::bindings::{
+    get_idx, new_dummy_problem, p_addVars, p_setcallback, vec, ConLevel_CL_DEF, IntVar,
+    VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN,
+};
+use chuffed_rs::wrappers::{all_different_wrapper, branch_wrapper, create_vars};
 
 unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
     // Create constant
@@ -11,7 +14,7 @@ unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
     all_different_wrapper(x, ConLevel_CL_DEF);
 
     // Post some branchings
-    branch_wrapper(x as _, VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN); 
+    branch_wrapper(x as _, VarBranch_VAR_INORDER, VarBranch_VAR_MIN_MIN);
 
     x
 }
@@ -19,7 +22,7 @@ unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
 // Custom printing function for this problem
 #[no_mangle]
 pub unsafe extern "C" fn callback(x: *mut vec<*mut IntVar>) {
-   print!("First output is: {:?}", get_idx(x, 0));
+    print!("First output is: {:?}", get_idx(x, 0));
 }
 
 fn main() {
@@ -31,8 +34,8 @@ fn main() {
     }
 
     let n: i32 = args[1].parse().expect("Invalid input");
-    
-    unsafe{
+
+    unsafe {
         let x = post_constraints(n);
         // make new dummy problem
         let p = new_dummy_problem();

--- a/solvers/chuffed/wrapper.cpp
+++ b/solvers/chuffed/wrapper.cpp
@@ -7,7 +7,15 @@ void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars) {
 void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *)) {
   p->setcallback(_callback);
 }
-IntVar get_idx(vec<IntVar *> *x, int i) { return **x[i]; }
+IntVar* get_idx(vec<IntVar *> *x, int i) { return *x[i]; }
+
+vec<IntVar*>* make_vec_intvar() {
+  return new vec<IntVar*>();
+}
+
+void destroy_vec_intvar(vec<IntVar*>* v) {
+  delete v;
+}
 
 void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
                    ValBranch val_branch) {

--- a/solvers/chuffed/wrapper.cpp
+++ b/solvers/chuffed/wrapper.cpp
@@ -1,0 +1,15 @@
+#include "./wrapper.h"
+
+DummyProblem *new_dummy_problem() { return new DummyProblem(); }
+void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars) {
+  p->addVars(_searchVars);
+}
+void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *)) {
+  p->setcallback(_callback);
+}
+IntVar get_idx(vec<IntVar *> *x, int i) { return **x[i]; }
+
+void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
+                   ValBranch val_branch) {
+  branch(*x, var_branch, val_branch);
+}

--- a/solvers/chuffed/wrapper.h
+++ b/solvers/chuffed/wrapper.h
@@ -1,1 +1,23 @@
+#include "chuffed/branching/branching.h"
+#include "chuffed/core/engine.h"
+#include "chuffed/core/propagator.h"
 #include "chuffed/vars/modelling.h"
+
+class DummyProblem {
+public:
+  vec<IntVar *> *searchVars;
+  // callback
+  void (*callback)(vec<IntVar *> *);
+
+  void print() { callback(searchVars); }
+  void setcallback(void (*_callback)(vec<IntVar *> *)) { callback = _callback; }
+  void addVars(vec<IntVar *> *_searchVars) { searchVars = _searchVars; }
+};
+
+DummyProblem *new_dummy_problem();
+void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars);
+void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *));
+IntVar get_idx(vec<IntVar *> *x, int i);
+
+void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
+                   ValBranch val_branch);

--- a/solvers/chuffed/wrapper.h
+++ b/solvers/chuffed/wrapper.h
@@ -17,7 +17,10 @@ public:
 DummyProblem *new_dummy_problem();
 void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars);
 void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *));
-IntVar get_idx(vec<IntVar *> *x, int i);
+IntVar* get_idx(vec<IntVar *> *x, int i);
+
+vec<IntVar*>* make_vec_intvar();
+void destroy_vec_intvar(vec<IntVar*>* v);
 
 void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
                    ValBranch val_branch);


### PR DESCRIPTION
This pull request is mainly to commit my progress to the main branch. Everything compiles correctly but running main causing an address boundary error that needs to be solved.

I have based main.rs off vendor/examples/template.cpp as this was the simplest chuffed problem I could find. I have implemented the required rust wrappers in lib.rs to implement template.cpp in rust. I think that trying to re create a simple Chuffed problem before trying to implement the XYZ problem will make the process much simpler as I want to stick as close to chuffed as possible to minimize mistakes

My initial approach for figuring out what functions to implement in Rust was to look at the minizinc parser that Chuffed uses. The problem with this is that the entire parser is auto-generated and therefore extremely hard to follow. Instead, I decided that the example cpp files would be a good starting point as those should contain everything necessary to complete some problem.

My approach here is most likely flawed due to my limited knowledge of both cpp and rust so any suggestions to improve this before being merged are greatly appreciated!

Some notes about chuffed:
- It uses global state to keep track of a problem which is quite different from something like minion I believe. This means that the `Problem` class found in each example cpp file is simply a way to organise the problem. The only thing a problem needs to implement is some way to print out/return the output variables.
- Chuffed uses a lot of inheritance and classes so I have had to use a few ffi hacks inside wrapper.h/wrapper.cpp. For example, the `branch` function usually takes in a `vec<Branching*>`. The `IntVar` type, which is the main type for variables, inherits Branching so I had to create my own `branch_IntVar` function that takes in a `vec<IntVar *>` instead of `vec<Branching *>