### PR TITLE
Do not run github actions on all branches

### DIFF
--- a/.github/workflows/chuffed.yml
+++ b/.github/workflows/chuffed.yml
@@ -1,9 +1,12 @@
 # https://doc.rust-lang.org/cargo/guide/continuous-integration.html
 # https://ectobit.com/blog/speed-up-github-actions-rust-pipelines/
 name: "solvers/chuffed"
+
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main # run for pushes to the main branch
     paths:
       - "solvers/chuffed/**"
       - "Cargo.*"

--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -1,4 +1,5 @@
 name: "Code Coverage (Deploy)"
+
 on:
   workflow_run:
     workflows: ["Code Coverage (Generate)"]

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,7 +1,11 @@
 name: "Code Coverage (Generate)"
+
 on:
   push:
+    branches:
+      - main # run for pushes to the main branch
   pull_request:
+  workflow_dispatch:
 
 
 jobs:

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -1,6 +1,9 @@
 name: "Documentation Coverage"
+
 on:
   push:
+    branches:
+      - main # run for pushes to the main branch
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/essence-feature-stats.yml
+++ b/.github/workflows/essence-feature-stats.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main # run for pushes to the main branch
-  pull_request:
   workflow_dispatch:  
 
 env:

--- a/.github/workflows/essence-feature-stats.yml
+++ b/.github/workflows/essence-feature-stats.yml
@@ -1,66 +1,68 @@
-  name: "tools/essence-feature-stats - Deploy to Github Pages"
+name: "tools/essence-feature-stats - Deploy to Github Pages"
 
-  on:
-    push:
-      branches:
-        - main
+on:
+  push:
+    branches:
+      - main # run for pushes to the main branch
+  pull_request:
+  workflow_dispatch:  
 
-  env:
-    ESSENCE_DIR: "./EssenceCatalog"
-    CONJURE_DIR: "./conjure"
-    ESSENCE_EXAMPLES_REPO: "https://github.com/conjure-cp/EssenceCatalog.git"
-    CONJURE_REPO: "https://github.com/conjure-cp/conjure"
-    OUTPUT_PATH: "./web/static/index.html"
-    KEYWORD_BLOCKLIST: >
-                    mInfo,finds,givens,enumGivens,enumLettings,lettings,
-                    unnameds,strategyQ,Auto,Interactive,strategyA,trailCompact,
-                    nameGenState,nbExtraGivens,representations,representationsTree,
-                    originalDomains,trailGeneralised,trailVerbose,trailRewrites,
-                    mLanguage,language,version,mStatements,Name,Declaration,Op
+env:
+  ESSENCE_DIR: "./EssenceCatalog"
+  CONJURE_DIR: "./conjure"
+  ESSENCE_EXAMPLES_REPO: "https://github.com/conjure-cp/EssenceCatalog.git"
+  CONJURE_REPO: "https://github.com/conjure-cp/conjure"
+  OUTPUT_PATH: "./web/static/index.html"
+  KEYWORD_BLOCKLIST: >
+                  mInfo,finds,givens,enumGivens,enumLettings,lettings,
+                  unnameds,strategyQ,Auto,Interactive,strategyA,trailCompact,
+                  nameGenState,nbExtraGivens,representations,representationsTree,
+                  originalDomains,trailGeneralised,trailVerbose,trailRewrites,
+                  mLanguage,language,version,mStatements,Name,Declaration,Op
 
-  jobs:
-    build:
-      name: "tools/essence-feature-stats: Build the tool and clone EssenceCatalog repo"
+jobs:
+  build:
+    name: "tools/essence-feature-stats: Build the tool and clone EssenceCatalog repo"
 
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      strategy:
-        matrix:
-          python-version: ["3.11"]
+    strategy:
+      matrix:
+        python-version: ["3.11"]
 
-      permissions:
-        contents: write
+    permissions:
+      contents: write
 
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-        - name: Install Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v4
-          with:
-            python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-        - name: Install python dependencies
-          run: pip install -r requirements.txt
-          working-directory: ./tools/essence-feature-usage-stats
+      - name: Install python dependencies
+        run: pip install -r requirements.txt
+        working-directory: ./tools/essence-feature-usage-stats
 
-        - name: Run main.py to generate the table
-          run: python main.py
-          working-directory: ./tools/essence-feature-usage-stats
+      - name: Run main.py to generate the table
+        run: python main.py
+        working-directory: ./tools/essence-feature-usage-stats
 
-        - name: Fix file permissions
-          run: chmod -v -R +rwx ./web/static/
-          working-directory: ./tools/essence-feature-usage-stats
+      - name: Fix file permissions
+        run: chmod -v -R +rwx ./web/static/
+        working-directory: ./tools/essence-feature-usage-stats
 
-        - name: Add the .nojekyll file
-          run: touch ./web/static/.nojekyll
-          working-directory: ./tools/essence-feature-usage-stats
-          
-        - name: Deploy to GitHub Pages
-          uses: JamesIves/github-pages-deploy-action@v4.4.3
-          with:
-            branch: gh-pages
-            folder: ./tools/essence-feature-usage-stats/web/static
-            target-folder: tools/essence-feature-usage-stats
-            commit-message: "Actions: Deploy the essence features usage table 🚀"
- 
+      - name: Add the .nojekyll file
+        run: touch ./web/static/.nojekyll
+        working-directory: ./tools/essence-feature-usage-stats
+        
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        with:
+          branch: gh-pages
+          folder: ./tools/essence-feature-usage-stats/web/static
+          target-folder: tools/essence-feature-usage-stats
+          commit-message: "Actions: Deploy the essence features usage table 🚀"
+

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,8 +3,11 @@
 name: "Formatting"
 
 on:
-  pull_request:
   push:
+    branches:
+      - main # run for pushes to the main branch
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   rust:

--- a/.github/workflows/kissat.yml
+++ b/.github/workflows/kissat.yml
@@ -1,8 +1,11 @@
 # https://doc.rust-lang.org/cargo/guide/continuous-integration.html
 # https://ectobit.com/blog/speed-up-github-actions-rust-pipelines/
 name: 'solvers/kissat'
+
 on:
   push:
+    branches:
+      - main # run for pushes to the main branch
   pull_request:
     paths: 
       - 'solvers/kissat/**'

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -1,6 +1,9 @@
 name: "solvers/minion"
+
 on:
   push:
+    branches:
+      - main # run for pushes to the main branch
     paths: 
       - 'solvers/minion/**'
       - "Cargo.*"

--- a/.github/workflows/oxide.yml
+++ b/.github/workflows/oxide.yml
@@ -1,6 +1,9 @@
 name: "conjure-oxide"
+
 on:
   push:
+    branches:
+      - main # run for pushes to the main branch
     paths: 
       - 'src/**'
       - "Cargo.*"

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,8 +1,10 @@
 name: Full Caches
+
 on:
   push:
     branches:
-      - main
+      - main # run for pushes to the main branch
+  workflow_dispatch:
 
 env:
     GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Modifying github actions to only run for pushes to the main branch.

One visible effect of running it on all branches was that PRs made from branches in the repository were being triggered twice. For example depandabot.

Also add workflow_dispath to more actions, since I don't see why not...