### PR TITLE
Turn example main program into rust test

### DIFF
--- a/solvers/chuffed/build.rs
+++ b/solvers/chuffed/build.rs
@@ -76,6 +76,7 @@ fn bind() {
         .allowlist_function("destroy_vec_intvar")
         .allowlist_function("p_addVars")
         .allowlist_function("p_setcallback")
+        .allowlist_function("p_print")
         .allowlist_function("branch_IntVar")
         .clang_arg("-Ivendor/build") // generated from configure.py
         .clang_arg("-Ivendor")

--- a/solvers/chuffed/src/lib.rs
+++ b/solvers/chuffed/src/lib.rs
@@ -7,8 +7,8 @@ pub mod bindings {
 
 pub mod wrappers {
     use crate::bindings::{
-        all_different, branch_IntVar, createVar, createVars, make_vec_intvar, vec, ConLevel,
-        IntVar, ValBranch, VarBranch,
+        all_different, branch_IntVar, createVar, createVars, make_vec_intvar, output_vars1,
+        var_sym_break, vec, ConLevel, IntVar, ValBranch, VarBranch,
     };
     use core::ptr;
 
@@ -48,6 +48,19 @@ pub mod wrappers {
     ) {
         unsafe {
             branch_IntVar(x, var_branch, val_branch);
+        }
+    }
+
+    pub unsafe fn output_vars_wrapper(x: *mut vec<*mut IntVar>) {
+        unsafe {
+            // output_vars1 takes in an vec<IntVar*> instead of branching
+            output_vars1(x);
+        }
+    }
+
+    pub unsafe fn var_sym_break_wrapper(x: *mut vec<*mut IntVar>) {
+        unsafe {
+            var_sym_break(x);
         }
     }
 }

--- a/solvers/chuffed/tests/chuffed_basic_run.rs
+++ b/solvers/chuffed/tests/chuffed_basic_run.rs
@@ -6,6 +6,8 @@ use chuffed_rs::wrappers::{
     all_different_wrapper, branch_wrapper, create_vars, output_vars_wrapper, var_sym_break_wrapper,
 };
 
+/// Creates the variable for the test problem and posts some constraints and
+/// branchings on it.
 unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
     // Create constant
     let n: i32 = _n;
@@ -28,14 +30,16 @@ unsafe fn post_constraints(_n: i32) -> *mut vec<*mut IntVar> {
     x
 }
 
-// Custom printing function for this problem
+/// Custom printing function for this test problem
 #[no_mangle]
 pub unsafe extern "C" fn callback(x: *mut vec<*mut IntVar>) {
     print!("First output is: {}", get_idx(x, 0));
 }
 
-// Entry point for running this problem
-fn main() {
+/// Basic test to make sure that running the ffi bindings and wrappers does not
+/// crash
+#[test]
+fn run_basic_problem() {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() != 2 {
@@ -56,5 +60,8 @@ fn main() {
         // Commented out currently as trying to print causes the assertion of
         // isFixed() in IntVar::getVal() to fail.
         // p_print(p);
+
+        // Pass test if no crash occurs
+        assert!(true);
     }
 }

--- a/solvers/chuffed/wrapper.cpp
+++ b/solvers/chuffed/wrapper.cpp
@@ -7,15 +7,17 @@ void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars) {
 void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *)) {
   p->setcallback(_callback);
 }
-IntVar* get_idx(vec<IntVar *> *x, int i) { return *x[i]; }
+void p_print(DummyProblem *p) { p->print(); }
 
-vec<IntVar*>* make_vec_intvar() {
-  return new vec<IntVar*>();
+int get_idx(vec<IntVar *> *x, int i) {
+  IntVar *var = *x[i];
+  int t = var->getVal();
+  return t;
 }
 
-void destroy_vec_intvar(vec<IntVar*>* v) {
-  delete v;
-}
+vec<IntVar *> *make_vec_intvar() { return new vec<IntVar *>(); }
+
+void destroy_vec_intvar(vec<IntVar *> *v) { delete v; }
 
 void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
                    ValBranch val_branch) {

--- a/solvers/chuffed/wrapper.h
+++ b/solvers/chuffed/wrapper.h
@@ -17,10 +17,11 @@ public:
 DummyProblem *new_dummy_problem();
 void p_addVars(DummyProblem *p, vec<IntVar *> *_searchVars);
 void p_setcallback(DummyProblem *p, void (*_callback)(vec<IntVar *> *));
-IntVar* get_idx(vec<IntVar *> *x, int i);
+void p_print(DummyProblem *p);
+int get_idx(vec<IntVar *> *x, int i);
 
-vec<IntVar*>* make_vec_intvar();
-void destroy_vec_intvar(vec<IntVar*>* v);
+vec<IntVar *> *make_vec_intvar();
+void destroy_vec_intvar(vec<IntVar *> *v);
 
 void branch_IntVar(vec<IntVar *> *x, VarBranch var_branch,
                    ValBranch val_branch);


### PR DESCRIPTION
As discussed in https://github.com/conjure-cp/conjure-oxide/pull/34, I have turned the example program main into a test called `chuffed_basic_run.rs`.

I have decided to keep the `main.rs` file for now as I believe it will be useful for further development. The test simply checks that running the ffi bindings/wrappers does not cause a crash. In order to show the test case has passed I have used an `assert!(true)` at the end of the test function as without any kind of assert the test doesn't seem to run. Is there a better way of doing this? Happy to get suggestions on this as well as the test as a whole