### PR TITLE
Workspace Refactor: CI paths

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -60,13 +60,13 @@ jobs:
           folder: ./deploy
           target-folder: "coverage/main"
           branch: gh-pages
-          commit-message: "Actions: Update code coverage for main (${{steps.sha.outputs.result}})"
+          commit-message: "Actions: Update code coverage for main (${{ steps.sha.outputs.result }})"
 
       - name: Format summary
         run : |
-          CONJURE_OXIDE_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.output.result }}/conjure-oxide"
-          MINION_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.output.result }}/minion"
-          CHUFFED_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.output.result }}/chuffed"
+          CONJURE_OXIDE_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.outputs.result }}/conjure-oxide"
+          MINION_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.outputs.result }}/minion"
+          CHUFFED_URL="https://conjure-cp.github.io/conjure-oxide/coverage/${{ steps.sha.outputs.result }}/chuffed"
 
           CONJURE_OXIDE_LATEST="https://conjure-cp.github.io/conjure-oxide/coverage/main/conjure-oxide"
           MINION_LATEST="https://conjure-cp.github.io/conjure-oxide/coverage/main/minion"

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -66,7 +66,7 @@ jobs:
           mkdir -p deploy/minion
           mkdir -p deploy/chuffed
 
-          cp -r coverage/html/* deploy/conjure-oxide
+          cp -r conjure_oxide/coverage/html/* deploy/conjure-oxide
           cp -r solvers/minion/coverage/html/* deploy/minion
           cp -r solvers/chuffed/coverage/html/* deploy/chuffed
 

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -111,6 +111,7 @@ jobs:
         run: rustup update nightly && rustup default nightly
 
       - name: Coverage Report
+        working-directory: ./conjure_oxide
         run: |
           echo '```' >> $GITHUB_STEP_SUMMARY
           RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo doc | tee -a /dev/fd/2 >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/oxide.yml
+++ b/.github/workflows/oxide.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main # run for pushes to the main branch
     paths: 
-      - 'src/**'
-      - "Cargo.*"
+      - 'conjure_oxide/**'
   pull_request:
     paths: 
-      - 'src/**'
-      - "Cargo.*"
+      - 'conjure_oxide/**'
   workflow_dispatch:
 
 jobs:
@@ -41,9 +39,11 @@ jobs:
           key: stable-${{ runner.os }}-gitmodules-${{ steps.cache-vars.outputs.submodule_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: stable-${{ runner.os }}-gitmodules-
 
-      - run: rustup update stable && rustup default stable
+      - working-directory: ./conjure_oxide
+        run: rustup update stable && rustup default stable
 
-      - run: cargo build -vv
+      - working-directory: ./conjure_oxide
+        run: cargo build -vv
 
   mac:
     name: "Conjure Oxide: Mac Build"
@@ -72,11 +72,14 @@ jobs:
           key: stable-${{ runner.os }}-gitmodules-${{ steps.cache-vars.outputs.submodule_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: stable-${{ runner.os }}-gitmodules-
 
-      - run: rustup update stable && rustup default stable
+      - working-directory: ./conjure_oxide
+        run: rustup update stable && rustup default stable
 
-      - run: rustup target add aarch64-apple-darwin
+      - working-directory: ./conjure_oxide
+        run: rustup target add aarch64-apple-darwin
 
-      - run: cargo build -vv
+      - working-directory: ./conjure_oxide
+        run: cargo build -vv
 
   tests:
     name: "Conjure Oxide: Tests"
@@ -104,9 +107,11 @@ jobs:
           key: stable-${{ runner.os }}-gitmodules-${{ steps.cache-vars.outputs.submodule_sha }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: stable-${{ runner.os }}-gitmodules-
 
-      - run: rustup update stable && rustup default stable
+      - working-directory: ./conjure_oxide
+        run: rustup update stable && rustup default stable
 
-      - run: cargo test
+      - working-directory: ./conjure_oxide
+        run: cargo test
 
 
       

--- a/etc/scripts/gen_coverage_all.sh
+++ b/etc/scripts/gen_coverage_all.sh
@@ -22,10 +22,10 @@ fi
 cargo locate-project --workspace &>/dev/null || { echo_err "Cannot find a rust workspace"; usage_and_fail; }
 WORKSPACE_ROOT=$(dirname $(cargo locate-project --workspace | jq -r .root 2> /dev/null))
 
-cd "$WORKSPACE_ROOT"
 
 # conjure-oxide coverage
 echo_err "GENERATING COVERAGE FOR CONJURE-OXIDE"
+cd "$WORKSPACE_ROOT/conjure_oxide"
 rm -rf coverage
 bash "$WORKSPACE_ROOT/$PATH_TO_GEN_COV"
 


### PR DESCRIPTION
Fixes the CI paths as discussed in #53.

This is based on-top of #53 so #53 should be merged first.