### PR TITLE
dependabot: group pip updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
   - package-ecosystem: pip
     directory: /tools/essence-feature-usage-stats/
     schedule:
-      interval: weekly
+      interval: monthly
     assignees:
       - ozgurakgun
+    groups:
+      npm-essence-feature-usage-stats:
+        patterns:
+          - "*"


### PR DESCRIPTION
and also check them once a month instead of once a week.