### PR TITLE
Hotfix: fix minion and chuffed always rebuilding

### DIFF
--- a/solvers/chuffed/build.rs
+++ b/solvers/chuffed/build.rs
@@ -65,9 +65,6 @@ fn bind() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         // Must manually give allow list to stop bindgen accidentally binding something complicated
         // in C++ stdlib that will make it crash.
         .allowlist_function("createVars")

--- a/solvers/minion/build.rs
+++ b/solvers/minion/build.rs
@@ -13,12 +13,13 @@ use std::process::Command;
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    println!("cargo:rustc-link-search=all={}/build", out_dir);
+    println!("cargo:rustc-link-lib=static=minion");
     println!("cargo:rerun-if-changed=vendor");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=build.sh");
 
-    println!("cargo:rustc-link-search=all={}/build", out_dir);
-    println!("cargo:rustc-link-lib=static=minion");
+    build();
 
     // also need to (dynamically) link to c++ stdlib
     // https://flames-of-code.netlify.app/blog/rust-and-cmake-cplusplus/
@@ -31,7 +32,6 @@ fn main() {
         unimplemented!();
     }
 
-    build();
     bind();
 }
 
@@ -63,9 +63,6 @@ fn bind() {
         // The input header we would like to generate
         // bindings for.
         .header("vendor/minion/libwrapper.h")
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Make all templates opaque as reccomended by bindgen
         .opaque_type("std::.*")
         // Manually allow C++ functions to stop bindgen getting confused.


### PR DESCRIPTION
We were using the .parse_callbacks(Box::new(bindgen::CargoCallbacks))
option of bindgen to invalidate the build based on included files.

We always re-run ./configure in build.sh - this was invalidating the
build because the configure script updates the last modified timestamps
of generated headerfiles, even if the file contents themselves have not
changed.

We already rebuild on C++ changes as both chuffed and minion have
rerun-if-changed=vendor, rerun-if-changed=wrapper.h added manually.
Therefore, the bindgen functionality that does this is not needed. We
can assume if vendor/ has changed, then the configure generated headers
have changed - we do not need to track these directly.
