### PR TITLE
Make chuffed-rs non-default member of workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
 resolver = "2"
+
+default-members = [
+    "conjure_oxide",
+    "crates/conjure_core",
+    "solvers/kissat",
+    "solvers/minion",
+]
+
 members = [
     "conjure_oxide",
     "crates/conjure_core",


### PR DESCRIPTION
Chuffed-rs does not compile on lab machines. 

Making it non default means that running `cargo test` / `cargo build` on the workspace will now succeed on the school lab machines.