### PR TITLE
Fix minion CI

### DIFF
--- a/solvers/minion/src/lib.rs
+++ b/solvers/minion/src/lib.rs
@@ -29,6 +29,7 @@
 //! use minion_rs::ast::*;
 //! use minion_rs::run_minion;
 //! use std::collections::HashMap;
+//! use std::sync::Mutex;
 //!
 //! // Get solutions out of Minion.
 //! // See the documentation for Callback for details.


### PR DESCRIPTION
I may have vastly underestimated the complexity of the issue, but the recent CI failures (addressed in #138) may have been occurring as a result of a missing import in `solvers/minion`.