### PR TITLE
Basic rewriting algorithm/tree walker

### DIFF
--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod error;
 pub mod find_conjure;
 pub mod parse;
+mod rewrite;
 pub mod rules;
 mod solvers;
-mod rewrite;
 
 pub use conjure_core::ast; // re-export core::ast as conjure_oxide::ast
 pub use conjure_core::ast::Model; // rexport core::ast::Model as conjure_oxide::Model

--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -3,6 +3,7 @@ pub mod find_conjure;
 pub mod parse;
 pub mod rules;
 mod solvers;
+mod rewrite;
 
 pub use conjure_core::ast; // re-export core::ast as conjure_oxide::ast
 pub use conjure_core::ast::Model; // rexport core::ast::Model as conjure_oxide::Model

--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod find_conjure;
 pub mod parse;
 mod rewrite;
-pub mod rules;
+mod rules;
 pub mod solvers;
 
 pub use conjure_core::ast; // re-export core::ast as conjure_oxide::ast

--- a/conjure_oxide/src/rewrite.rs
+++ b/conjure_oxide/src/rewrite.rs
@@ -9,17 +9,20 @@ struct RuleResult<'a> {
 
 pub fn rewrite(expression: &Expression) -> Expression {
     let rules = get_rules();
-    let mut new = expression.clone(); 
+    let mut new = expression.clone();
     while let Some(step) = rewrite_iteration(&new, &rules) {
         new = step;
     }
     new
 }
 
-fn apply_all_rules<'a>(expression: &'a Expression, rules: &'a Vec<Rule<'a>>) -> Vec<RuleResult<'a>> {
+fn apply_all_rules<'a>(
+    expression: &'a Expression,
+    rules: &'a Vec<Rule<'a>>,
+) -> Vec<RuleResult<'a>> {
     let mut results = Vec::new();
     for rule in rules {
-        match rule.apply(&expression) {
+        match rule.apply(expression) {
             Ok(new) => {
                 results.push(RuleResult {
                     rule: rule.clone(),
@@ -33,7 +36,7 @@ fn apply_all_rules<'a>(expression: &'a Expression, rules: &'a Vec<Rule<'a>>) -> 
 }
 
 fn choose_rewrite<'a>(results: &Vec<RuleResult<'a>>) -> Option<Expression> {
-    if results.len() == 0 {
+    if results.is_empty() {
         return None;
     }
     // Return the first result for now
@@ -43,7 +46,10 @@ fn choose_rewrite<'a>(results: &Vec<RuleResult<'a>>) -> Option<Expression> {
 /// # Returns
 /// - Some(<new_expression>) after applying the first applicable rule to `expr` or a sub-expression.
 /// - None if no rule is applicable to the expression or any sub-expression.
-fn rewrite_iteration<'a>(expression: &'a Expression, rules: &'a Vec<Rule<'a>>) -> Option<Expression> {
+fn rewrite_iteration<'a>(
+    expression: &'a Expression,
+    rules: &'a Vec<Rule<'a>>,
+) -> Option<Expression> {
     let rule_results = apply_all_rules(expression, rules);
     if let Some(new) = choose_rewrite(&rule_results) {
         return Some(new);

--- a/conjure_oxide/src/rewrite.rs
+++ b/conjure_oxide/src/rewrite.rs
@@ -16,33 +16,6 @@ pub fn rewrite(expression: &Expression) -> Expression {
     new
 }
 
-fn apply_all_rules<'a>(
-    expression: &'a Expression,
-    rules: &'a Vec<Rule<'a>>,
-) -> Vec<RuleResult<'a>> {
-    let mut results = Vec::new();
-    for rule in rules {
-        match rule.apply(expression) {
-            Ok(new) => {
-                results.push(RuleResult {
-                    rule: rule.clone(),
-                    new_expression: new,
-                });
-            }
-            Err(_) => continue,
-        }
-    }
-    results
-}
-
-fn choose_rewrite<'a>(results: &Vec<RuleResult<'a>>) -> Option<Expression> {
-    if results.is_empty() {
-        return None;
-    }
-    // Return the first result for now
-    Some(results[0].new_expression.clone())
-}
-
 /// # Returns
 /// - Some(<new_expression>) after applying the first applicable rule to `expr` or a sub-expression.
 /// - None if no rule is applicable to the expression or any sub-expression.
@@ -63,4 +36,31 @@ fn rewrite_iteration<'a>(
         }
     }
     None // No rules applicable to this branch of the expression
+}
+
+fn apply_all_rules<'a>(
+    expression: &'a Expression,
+    rules: &'a Vec<Rule<'a>>,
+) -> Vec<RuleResult<'a>> {
+    let mut results = Vec::new();
+    for rule in rules {
+        match rule.apply(expression) {
+            Ok(new) => {
+                results.push(RuleResult {
+                    rule: rule.clone(),
+                    new_expression: new,
+                });
+            }
+            Err(_) => continue,
+        }
+    }
+    results
+}
+
+fn choose_rewrite(results: &Vec<RuleResult>) -> Option<Expression> {
+    if results.is_empty() {
+        return None;
+    }
+    // Return the first result for now
+    Some(results[0].new_expression.clone())
 }

--- a/conjure_oxide/src/rewrite.rs
+++ b/conjure_oxide/src/rewrite.rs
@@ -1,0 +1,60 @@
+use conjure_core::ast::Expression;
+use conjure_core::rule::Rule;
+use conjure_rules::get_rules;
+
+struct RuleResult<'a> {
+    rule: Rule<'a>,
+    new_expression: Expression,
+}
+
+pub fn rewrite(expression: &Expression) -> Expression {
+    let rules = get_rules();
+    let mut new = expression.clone(); 
+    while let Some(step) = rewrite_iteration(&new, &rules) {
+        new = step;
+    }
+    new
+}
+
+fn apply_all_rules<'a>(expression: &'a Expression, rules: &'a Vec<Rule<'a>>) -> Vec<RuleResult<'a>> {
+    let mut results = Vec::new();
+    for rule in rules {
+        match rule.apply(&expression) {
+            Ok(new) => {
+                results.push(RuleResult {
+                    rule: rule.clone(),
+                    new_expression: new,
+                });
+            }
+            Err(_) => continue,
+        }
+    }
+    results
+}
+
+fn choose_rewrite<'a>(results: &Vec<RuleResult<'a>>) -> Option<Expression> {
+    if results.len() == 0 {
+        return None;
+    }
+    // Return the first result for now
+    Some(results[0].new_expression.clone())
+}
+
+/// # Returns
+/// - Some(<new_expression>) after applying the first applicable rule to `expr` or a sub-expression.
+/// - None if no rule is applicable to the expression or any sub-expression.
+fn rewrite_iteration<'a>(expression: &'a Expression, rules: &'a Vec<Rule<'a>>) -> Option<Expression> {
+    let rule_results = apply_all_rules(expression, rules);
+    if let Some(new) = choose_rewrite(&rule_results) {
+        return Some(new);
+    } else {
+        let mut sub = expression.sub_expressions();
+        for i in 0..sub.len() {
+            if let Some(new) = rewrite_iteration(sub[i], rules) {
+                sub[i] = &new;
+                return Some(expression.with_sub_expressions(sub));
+            }
+        }
+    }
+    None // No rules applicable to this branch of the expression
+}

--- a/crates/conjure_core/src/ast.rs
+++ b/crates/conjure_core/src/ast.rs
@@ -102,3 +102,77 @@ pub enum Expression {
     SumLeq(Vec<Expression>, Box<Expression>),
     Ineq(Box<Expression>, Box<Expression>, Box<Expression>),
 }
+
+impl Expression {
+    /// Returns a vector of references to the sub-expressions of the expression.
+    pub fn sub_expressions(&self) -> Vec<&Expression> {
+        match self {
+            Expression::ConstantInt(_) => Vec::new(),
+            Expression::Reference(_) => Vec::new(),
+            Expression::Sum(exprs) => exprs.iter().collect(),
+            Expression::Eq(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::Neq(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::Geq(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::Leq(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::Gt(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::Lt(lhs, rhs) => vec![lhs.as_ref(), rhs.as_ref()],
+            Expression::SumGeq(lhs, rhs) => {
+                let mut sub_exprs = lhs.iter().collect::<Vec<_>>();
+                sub_exprs.push(rhs.as_ref());
+                sub_exprs
+            }
+            Expression::SumLeq(lhs, rhs) => {
+                let mut sub_exprs = lhs.iter().collect::<Vec<_>>();
+                sub_exprs.push(rhs.as_ref());
+                sub_exprs
+            }
+            Expression::Ineq(lhs, rhs, _) => vec![lhs.as_ref(), rhs.as_ref()],
+        }
+    }
+
+    /// Returns a clone of the same expression type with the given sub-expressions.
+    pub fn with_sub_expressions(&self, sub: Vec<&Expression>) -> Expression {
+        match self {
+            Expression::ConstantInt(i) => Expression::ConstantInt(*i),
+            Expression::Reference(name) => Expression::Reference(name.clone()),
+            Expression::Sum(_) => Expression::Sum(sub.iter().cloned().cloned().collect()),
+            Expression::Eq(_, _) => Expression::Eq(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::Neq(_, _) => Expression::Neq(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::Geq(_, _) => Expression::Geq(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::Leq(_, _) => Expression::Leq(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::Gt(_, _) => Expression::Gt(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::Lt(_, _) => Expression::Lt(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+            ),
+            Expression::SumGeq(_, _) => Expression::SumGeq(
+                sub.iter().cloned().cloned().collect(),
+                Box::new(sub[2].clone()),
+            ),
+            Expression::SumLeq(_, _) => Expression::SumLeq(
+                sub.iter().cloned().cloned().collect(),
+                Box::new(sub[2].clone()),
+            ),
+            Expression::Ineq(_, _, _) => Expression::Ineq(
+                Box::new(sub[0].clone()),
+                Box::new(sub[1].clone()),
+                Box::new(sub[2].clone()),
+            ),
+        }
+    }
+}

--- a/crates/conjure_core/src/ast.rs
+++ b/crates/conjure_core/src/ast.rs
@@ -136,30 +136,24 @@ impl Expression {
             Expression::ConstantInt(i) => Expression::ConstantInt(*i),
             Expression::Reference(name) => Expression::Reference(name.clone()),
             Expression::Sum(_) => Expression::Sum(sub.iter().cloned().cloned().collect()),
-            Expression::Eq(_, _) => Expression::Eq(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
-            Expression::Neq(_, _) => Expression::Neq(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
-            Expression::Geq(_, _) => Expression::Geq(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
-            Expression::Leq(_, _) => Expression::Leq(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
-            Expression::Gt(_, _) => Expression::Gt(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
-            Expression::Lt(_, _) => Expression::Lt(
-                Box::new(sub[0].clone()),
-                Box::new(sub[1].clone()),
-            ),
+            Expression::Eq(_, _) => {
+                Expression::Eq(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
+            Expression::Neq(_, _) => {
+                Expression::Neq(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
+            Expression::Geq(_, _) => {
+                Expression::Geq(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
+            Expression::Leq(_, _) => {
+                Expression::Leq(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
+            Expression::Gt(_, _) => {
+                Expression::Gt(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
+            Expression::Lt(_, _) => {
+                Expression::Lt(Box::new(sub[0].clone()), Box::new(sub[1].clone()))
+            }
             Expression::SumGeq(_, _) => Expression::SumGeq(
                 sub.iter().cloned().cloned().collect(),
                 Box::new(sub[2].clone()),


### PR DESCRIPTION
As per the rust meeting today, this is the basic form of the tree walker and rewriting algorithm. Currently, this is just a depth-first search that tries to apply all the rules to each expression in the tree - Returning the new expression if it can be rewritten or recursing through the expression's sub-expressions if it cannot.

Very soon I will be optimizing this slightly by marking nodes as dirty or clean and only searching through dirty nodes which will save some work. 

Everything seems to build properly on fedora Linux but there are most likely some errors in here that I have not yet spotted. If you see any errors or spots for improvement please let me know!