### PR TITLE
Docs Generation Tweaks: Simplify script, add index.html

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 default-members = [
     "conjure_oxide",
     "crates/conjure_core",
+    "crates/conjure_rules",
     "solvers/kissat",
     "solvers/minion",
 ]

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,3 @@
+This folder contains the index.md to be used by rustdoc to create a homepage for our documentation (at docs/index.html)
+
+Nothing else in here will do anything or be generated into docs.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,22 @@
+# Conjure Oxide
+
+[Github](https://github.com/conjure-cp/conjure-oxide)
+
+Welcome to the documentation of Conjure Oxide.
+
+* [conjure_oxide - Main Documentation](conjure_oxide/index.html)
+
+## Solvers
+
+These crates contain Rust bindings for solvers:
+
+* [minion_rs](minion_rs/index.html)
+* [chuffed_rs](chuffed_rs/index.html)
+
+## Developer Documentation
+
+The following are internal crates. Documentation is provided for developer
+reference:
+
+* [conjure_core](conjure_core/index.html)
+* [conjure_rules](conjure_rules/index.html)

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,10 @@ This repository hosts the following projects:
 This project is being produced by staff and students of University of St
 Andrews, and is licenced under the [MPL 2.0](./LICENCE).
 
+## Documentation
+
+API documentation can be found [here](https://conjure-cp.github.io/conjure-oxide/docs/).
+
 ## Contributing
 
 See the [Contributors Guide](https://github.com/conjure-cp/conjure-oxide/wiki/Contributing).

--- a/tools/gen_docs.sh
+++ b/tools/gen_docs.sh
@@ -24,19 +24,6 @@ PROJECT_ROOT=$(dirname $(cargo locate-project | jq -r .root 2> /dev/null))
 TARGET_DIR=$(cargo metadata 2> /dev/null | jq -r .target_directory 2>/dev/null)
 
 cd "$PROJECT_ROOT"
-rm -rf "$TARGET_DIR/docs"
+rm -rf "$TARGET_DIR/doc"
 
-echo_err "=== DOCS FOR CONJURE OXIDE ==="
-cd "conjure_oxide"
-cargo doc --no-deps
-cd -
-
-echo_err "=== DOCS FOR MINION ==="
-cd "solvers/minion"
-cargo doc --no-deps
-cd -
-
-echo_err "=== DOCS FOR CHUFFED ==="
-cd "solvers/chuffed"
-cargo doc --no-deps
-cd -
+RUSTDOCFLAGS="-Zunstable-options --markdown-no-toc --index-page ${PROJECT_ROOT}/doc/index.md" cargo +nightly doc --no-deps -p conjure_oxide -p conjure_core -p minion_rs -p chuffed_rs -p conjure_rules


### PR DESCRIPTION
This PR adds a few documentation generation tweaks:

* Add an index.html to the conjure-cp.github.io/conjure-oxide/docs URL giving a directory of all documentation available.
* Simplify doc generation script.
* Put a link to the docs in the README.

To look at this locally, do ./tools/gen_docs.sh, then open target/doc/index.html in your browser.