### PR TITLE
CI Fix: Doc generation needs rust nightly

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  rust_release: stable
+  rust_release: nightly
 
 jobs:
   coverage:


### PR DESCRIPTION
My last PR had some changes to doc generation.

This needs nightly rust, so changed the CI to use nightly. Should hopefully work now :)