### PR TITLE
Add test that checks if the write function can simplify the xyz problem

### DIFF
--- a/conjure_oxide/src/rewrite.rs
+++ b/conjure_oxide/src/rewrite.rs
@@ -7,7 +7,6 @@ struct RuleResult<'a> {
     new_expression: Expression,
 }
 
-
 /// # Returns
 /// - A new expression after applying the rules to `expression` and its sub-expressions.
 /// - The same expression if no rules are applicable.

--- a/conjure_oxide/src/rewrite.rs
+++ b/conjure_oxide/src/rewrite.rs
@@ -7,6 +7,10 @@ struct RuleResult<'a> {
     new_expression: Expression,
 }
 
+
+/// # Returns
+/// - A new expression after applying the rules to `expression` and its sub-expressions.
+/// - The same expression if no rules are applicable.
 pub fn rewrite(expression: &Expression) -> Expression {
     let rules = get_rules();
     let mut new = expression.clone();
@@ -42,6 +46,9 @@ fn rewrite_iteration<'a>(
     None // No rules applicable to this branch of the expression
 }
 
+/// # Returns
+/// - A list of RuleResults after applying all rules to `expression`.
+/// - An empty list if no rules are applicable.
 fn apply_all_rules<'a>(
     expression: &'a Expression,
     rules: &'a Vec<Rule<'a>>,
@@ -61,6 +68,9 @@ fn apply_all_rules<'a>(
     results
 }
 
+/// # Returns
+/// - Some(<new_expression>) after applying the first rule in `results`.
+/// - None if `results` is empty.
 fn choose_rewrite(results: &Vec<RuleResult>) -> Option<Expression> {
     if results.is_empty() {
         return None;
@@ -70,6 +80,10 @@ fn choose_rewrite(results: &Vec<RuleResult>) -> Option<Expression> {
     Some(results[0].new_expression.clone())
 }
 
+/// This rewrites the model by applying the rules to all constraints.
+/// # Returns
+/// - A new model with rewritten constraints.
+/// - The same model if no rules are applicable.
 pub fn rewrite_model(model: &Model) -> Model {
     let mut new_model = model.clone();
 

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -558,10 +558,8 @@ fn rewrite_solve_xyz() {
         ),
     ]);
 
-    println!("Running rewrite on: {:?}", nested_expr);
     // Apply rewrite function to the nested expression
     let rewritten_expr = rewrite(&nested_expr);
-    println!("Rewritten expression: {:?}", rewritten_expr);
 
     // Create model with variables and constraints
     let mut model = Model {

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -1,11 +1,11 @@
 // Tests for rewriting/simplifying parts of the AST
 
-use core::panic;
 use conjure_core::rule::Rule;
 use conjure_rules::get_rules;
+use core::panic;
 use std::collections::HashMap;
 
-use conjure_oxide::{ast::*, solvers::FromConjureModel, rewrite::rewrite};
+use conjure_oxide::{ast::*, rewrite::rewrite, solvers::FromConjureModel};
 use conjure_rules::get_rule_by_name;
 use minion_rs::ast::{Constant, VarName};
 
@@ -574,9 +574,24 @@ fn rewrite_solve_xyz() {
     };
 
     // Insert variables and domains
-    model.variables.insert(variable_a.clone(), DecisionVariable { domain: domain.clone() });
-    model.variables.insert(variable_b.clone(), DecisionVariable { domain: domain.clone() });
-    model.variables.insert(variable_c.clone(), DecisionVariable { domain: domain.clone() });
+    model.variables.insert(
+        variable_a.clone(),
+        DecisionVariable {
+            domain: domain.clone(),
+        },
+    );
+    model.variables.insert(
+        variable_b.clone(),
+        DecisionVariable {
+            domain: domain.clone(),
+        },
+    );
+    model.variables.insert(
+        variable_c.clone(),
+        DecisionVariable {
+            domain: domain.clone(),
+        },
+    );
 
     // Convert the model to MinionModel
     let minion_model = conjure_oxide::solvers::minion::MinionModel::from_conjure(model).unwrap();
@@ -601,7 +616,6 @@ pub fn is_simple(expression: &Expression) -> bool {
     }
     new == *expression
 }
-
 
 /// # Returns
 /// - Some(<new_expression>) after applying the first applicable rule to `expr` or a sub-expression.


### PR DESCRIPTION
Just a small PR that adds a test for the rewrite function using the xyz problem which has been made into a nested expression compared to previous tests. 

My only question, before I think this is ready to merge, is whether I should add an assert that checks whether the rewritten expression is in the "simplest form". My reason for not including one was that I believe the simplest expression will change over time as we add more rules so this will have to be updated constantly but honestly, I am not sure how true this is as I have not been working on the actual rules themselves. Could someone closer to the work on rules let me know if an assert should be added?