### PR TITLE
Update code-coverage-deploy.yml

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -54,7 +54,7 @@ jobs:
           commit-message: "Actions: Code Coverage for ${{ steps.sha.outputs.result }}"
 
       - name: If on main branch, copy coverage report to /main.
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref_name == 'main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: ./deploy


### PR DESCRIPTION
event name may be workflow_run, not push, not entirely sure.

The fact we are pushing doesn't matter, as we cant make PRs that go main->main, so by elimination we will know its a push anyways.
