### PR TITLE
CI: fix PR number not always appearing in coverage-deploy

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -115,43 +115,8 @@ jobs:
           key: ${{ runner.os }}-${{ env.rust_release }}-${{ github.event.repository.updated_at }}
           restore-keys: ${{ runner.os }}-${{ env.rust_release }}
 
-      - name: Install rust ${{ env.rust_release }}
-        run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}
-
-      # from https://github.com/bewee/rustdoc-coverage-action-example/
-
-      - name: Checkout main
-        uses: actions/checkout@v2
-        with: 
-          ref: main
-
-      - name: Calculate main doc coverage
-        id: maindoc
-        run: |
-           RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo +nightly doc --workspace --no-deps > coverage.md
-           echo 'coverage<<EOFABC' >> $GITHUB_OUTPUT
-           echo "$(cat coverage.md)" >> $GITHUB_OUTPUT
-           echo 'EOFABC' >> $GITHUB_OUTPUT
-
-      - name: Get pr info
-        id: prinfo
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const {data: callee_run } = await github.rest.actions.getWorkflowRun({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-
-            console.log(callee_run.pull_requests[0]);
-
-            // from manual inspection in jq, seems to hold head.sha for PR, not
-            // whatever GITHUB_SHA is. 
-            return callee_run.pull_requests[0];
-
-      - name: Get pr repo
-        id: prrepo
+      - name: Set shas
+        id: sha
         uses: actions/github-script@v6
         with:
           result-encoding: string
@@ -161,21 +126,27 @@ jobs:
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            return callee_run.repository.full_name;
 
-      - name: Checkout this PR
-        uses: actions/checkout@v2
+            console.log(callee_run);
+
+            // from manual inspection in jq, seems to hold head.sha for PR, not
+            // whatever GITHUB_SHA is. 
+            return callee_run.head_sha;
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
-          ref: ${{fromJson(steps.prinfo.outputs.result).head.sha}}
-          repository: ${{steps.prrepo.outputs.result}}
+          name: code-coverage-${{ steps.sha.outputs.result }}
+          workflow: code-coverage.yml
+          path: ./deploy
+      
+      - name: Get PR number
+        id: prnum
+        run: | 
+          echo "num=$(cat deploy/prnumber)" > $GITHUB_OUTPUT
 
-      - name: Calculate PR doc coverage
-        id: prddoc
-        run: |
-           RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo +nightly doc --workspace --no-deps > coverage.md
-           echo 'coverage<<EOFABC' >> $GITHUB_OUTPUT
-           echo "$(cat coverage.md)" >> $GITHUB_OUTPUT
-           echo 'EOFABC' >> $GITHUB_OUTPUT
+      - name: Install rust ${{ env.rust_release }}
+        run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}
 
       - name: Generate lcov summary for main and pr
         continue-on-error: true
@@ -189,11 +160,20 @@ jobs:
           echo "$(cat cov.txt | tail -n +3)" >> $GITHUB_OUTPUT
           echo 'EOFABC' >> $GITHUB_OUTPUT
 
-          rm lcov.info
-          wget https://${{github.repository_owner}}.github.io/conjure-oxide/coverage/${{fromJson(steps.prinfo.outputs.result).head.sha}}/lcov.info
-          lcov --summary lcov.info > cov.txt
+          lcov --summary ./deploy/lcov.info > cov.txt
           echo "pr<<EOFABC" >> $GITHUB_OUTPUT
           echo "$(cat cov.txt | tail -n +3)" >> $GITHUB_OUTPUT
+          echo 'EOFABC' >> $GITHUB_OUTPUT
+
+      - name: Get doc-coverage for main and pr
+        id: doccov 
+        run: |
+          wget https://${{github.repository_owner}}.github.io/conjure-oxide/coverage/main/doc-coverage.txt
+          echo "main<<EOFABC" >> $GITHUB_OUTPUT
+          echo "$(cat doc-coverage.txt)" >> $GITHUB_OUTPUT
+          echo 'EOFABC' >> $GITHUB_OUTPUT
+          echo "pr<<EOFABC" >> $GITHUB_OUTPUT
+          echo "$(cat ./deploy/doc-coverage.txt)" >> $GITHUB_OUTPUT
           echo 'EOFABC' >> $GITHUB_OUTPUT
 
       - name: Find coverage comment
@@ -201,7 +181,7 @@ jobs:
         continue-on-error: true
         id: fc
         with:
-          issue-number: ${{fromJson(steps.prinfo.outputs.result).number}}
+          issue-number: ${{steps.prnum.outputs.num}}
           comment-author: "github-actions[bot]"
           body-includes: "## Documentation Coverage"
 
@@ -219,7 +199,7 @@ jobs:
       - name: Create coverage comment
         uses: peter-evans/create-or-update-comment@v1
         with:
-          issue-number: ${{fromJson(steps.prinfo.outputs.result).number}}
+          issue-number: ${{steps.prnum.outputs.num}}
           body: |
             ## Documentation Coverage
 
@@ -227,7 +207,7 @@ jobs:
             <summary>This PR</summary>
 
             ```
-            ${{steps.prddoc.outputs.coverage}}
+            ${{steps.doccov.outputs.pr}}
             ```
 
             </details>
@@ -236,14 +216,15 @@ jobs:
             <summary>Main</summary>
             
             ```
-            ${{steps.maindoc.outputs.coverage}}
+            ${{steps.doccov.outputs.main}}
             ```
 
             </details>
 
             ## Code Coverage
 
-            [This PR](https://${{github.repository_owner}}.github.io/conjure-oxide/coverage/${{fromJson(steps.prinfo.outputs.result).head.sha}})
+            [This PR](https://${{github.repository_owner}}.github.io/conjure-oxide/coverage/${{steps.sha.outputs.result}})
+
             ```
             ${{steps.lcov.outputs.pr}}
             ```

--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -44,22 +44,20 @@ jobs:
         run: |
           ./tools/coverage.sh
           
-      - name: Print documentation coverage to job summary
+      - name: Generate documentation coverage
         run: |
-           echo '```' >> $GITHUB_STEP_SUMMARY
-           RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo +nightly doc --workspace --no-deps | tee -a /dev/fd/2 >> $GITHUB_STEP_SUMMARY
-           echo '```' >> $GITHUB_STEP_SUMMARY
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo +nightly doc --workspace --no-deps > doc-coverage.txt
 
-      - name: Generate documentation coverage JSON for diffs in PRs
+      - name: Generate documentation coverage JSON
         run: |
-           RUSTDOCFLAGS='-Z unstable-options --output-format json --show-coverage' cargo +nightly doc --workspace --no-deps > rustdoc-coverage-report.json
+          RUSTDOCFLAGS='-Z unstable-options --output-format json --show-coverage' cargo +nightly doc --workspace --no-deps > doc-coverage.json
 
-          
       - run: |
           mkdir -p deploy/
           cp -r target/debug/coverage/* deploy/     # html
           cp target/debug/lcov.info deploy/         # used for diffing code coverage in PR comments
-          cp rustdoc-coverage-report.json deploy/   # used for diffing doc coverage in PR comments
+          cp doc-coverage.json deploy/
+          cp doc-coverage.txt deploy/
           
       - name: Copy coverage report to /main.
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -58,10 +58,21 @@ jobs:
         run: |
           ./tools/coverage.sh
           
+      - name: Generate documentation coverage
+        run: |
+          RUSTDOCFLAGS='-Z unstable-options --show-coverage' cargo +nightly doc --workspace --no-deps > doc-coverage.txt
+
+      - name: Generate documentation coverage JSON
+        run: |
+          RUSTDOCFLAGS='-Z unstable-options --output-format json --show-coverage' cargo +nightly doc --workspace --no-deps > doc-coverage.json
+
       - run: |
           mkdir -p deploy/
           cp -r target/debug/coverage/* deploy/     # html
           cp target/debug/lcov.info deploy/         # used for comments
+          cp doc-coverage.json deploy/
+          cp doc-coverage.txt deploy/
+          echo "${{github.event.pull_request.number}}" > deploy/prnumber
 
       - name: Archive code coverage results for deployment
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
@ozgurakgun this should work reliably now (i.e. not just in my fork). In short, the API call i was making may but is not guaranteed to give the PR that calls the workflow 🙄. Now doing it the way to docs recommend, which is to write the PR number to a file and put it in the artifact that goes to the second workflow. 

Works on my fork but, as usual, no guarantees.

