### PR TITLE
Add metadata to all enum variants

### DIFF
--- a/conjure_oxide/src/parse.rs
+++ b/conjure_oxide/src/parse.rs
@@ -135,40 +135,57 @@ fn parse_int_domain(v: &JsonValue) -> Result<Domain> {
 }
 
 // this needs an explicit type signature to force the closures to have the same type
-type BinOp = Box<dyn Fn(Box<Expression>, Box<Expression>) -> Expression>;
-type UnaryOp = Box<dyn Fn(Box<Expression>) -> Expression>;
-type VecOp = Box<dyn Fn(Vec<Expression>) -> Expression>;
+type BinOp = Box<dyn Fn(Metadata, Box<Expression>, Box<Expression>) -> Expression>;
+type UnaryOp = Box<dyn Fn(Metadata, Box<Expression>) -> Expression>;
+type VecOp = Box<dyn Fn(Metadata, Vec<Expression>) -> Expression>;
 
 fn parse_expression(obj: &JsonValue) -> Option<Expression> {
     let binary_operators: HashMap<&str, BinOp> = [
-        ("MkOpEq", Box::new(Expression::Eq) as Box<dyn Fn(_, _) -> _>),
+        (
+            "MkOpEq",
+            Box::new(Expression::Eq) as Box<dyn Fn(_, _, _) -> _>,
+        ),
         (
             "MkOpNeq",
-            Box::new(Expression::Neq) as Box<dyn Fn(_, _) -> _>,
+            Box::new(Expression::Neq) as Box<dyn Fn(_, _, _) -> _>,
         ),
         (
             "MkOpGeq",
-            Box::new(Expression::Geq) as Box<dyn Fn(_, _) -> _>,
+            Box::new(Expression::Geq) as Box<dyn Fn(_, _, _) -> _>,
         ),
         (
             "MkOpLeq",
-            Box::new(Expression::Leq) as Box<dyn Fn(_, _) -> _>,
+            Box::new(Expression::Leq) as Box<dyn Fn(_, _, _) -> _>,
         ),
-        ("MkOpGt", Box::new(Expression::Gt) as Box<dyn Fn(_, _) -> _>),
-        ("MkOpLt", Box::new(Expression::Lt) as Box<dyn Fn(_, _) -> _>),
+        (
+            "MkOpGt",
+            Box::new(Expression::Gt) as Box<dyn Fn(_, _, _) -> _>,
+        ),
+        (
+            "MkOpLt",
+            Box::new(Expression::Lt) as Box<dyn Fn(_, _, _) -> _>,
+        ),
     ]
     .into_iter()
     .collect();
 
-    let unary_operators: HashMap<&str, UnaryOp> =
-        [("MkOpNot", Box::new(Expression::Not) as Box<dyn Fn(_) -> _>)]
-            .into_iter()
-            .collect();
+    let unary_operators: HashMap<&str, UnaryOp> = [(
+        "MkOpNot",
+        Box::new(Expression::Not) as Box<dyn Fn(_, _) -> _>,
+    )]
+    .into_iter()
+    .collect();
 
     let vec_operators: HashMap<&str, VecOp> = [
-        ("MkOpSum", Box::new(Expression::Sum) as Box<dyn Fn(_) -> _>),
-        ("MkOpAnd", Box::new(Expression::And) as Box<dyn Fn(_) -> _>),
-        ("MkOpOr", Box::new(Expression::Or) as Box<dyn Fn(_) -> _>),
+        (
+            "MkOpSum",
+            Box::new(Expression::Sum) as Box<dyn Fn(_, _) -> _>,
+        ),
+        (
+            "MkOpAnd",
+            Box::new(Expression::And) as Box<dyn Fn(_, _) -> _>,
+        ),
+        ("MkOpOr", Box::new(Expression::Or) as Box<dyn Fn(_, _) -> _>),
     ]
     .into_iter()
     .collect();
@@ -192,7 +209,10 @@ fn parse_expression(obj: &JsonValue) -> Option<Expression> {
         },
         Value::Object(refe) if refe.contains_key("Reference") => {
             let name = refe["Reference"].as_array()?[0].as_object()?["Name"].as_str()?;
-            Some(Expression::Reference(Name::UserName(name.to_string())))
+            Some(Expression::Reference(
+                Metadata::new(),
+                Name::UserName(name.to_string()),
+            ))
         }
         Value::Object(constant) if constant.contains_key("Constant") => parse_constant(constant),
         otherwise => panic!("Unhandled Expression {:#?}", otherwise),
@@ -213,7 +233,7 @@ fn parse_bin_op(
         Value::Array(bin_op_args) if bin_op_args.len() == 2 => {
             let arg1 = parse_expression(&bin_op_args[0])?;
             let arg2 = parse_expression(&bin_op_args[1])?;
-            Some(constructor(Box::new(arg1), Box::new(arg2)))
+            Some(constructor(Metadata::new(), Box::new(arg1), Box::new(arg2)))
         }
         otherwise => panic!("Unhandled parse_bin_op {:#?}", otherwise),
     }
@@ -227,7 +247,7 @@ fn parse_unary_op(
     let constructor = unary_operators.get(key.as_str())?;
 
     let arg = parse_expression(value)?;
-    Some(constructor(Box::new(arg)))
+    Some(constructor(Metadata::new(), Box::new(arg)))
 }
 
 fn parse_vec_op(
@@ -242,7 +262,7 @@ fn parse_vec_op(
         .iter()
         .map(|x| parse_expression(x).unwrap())
         .collect();
-    Some(constructor(args_parsed))
+    Some(constructor(Metadata::new(), args_parsed))
 }
 
 fn parse_constant(constant: &serde_json::Map<String, Value>) -> Option<Expression> {

--- a/conjure_oxide/src/solvers/kissat.rs
+++ b/conjure_oxide/src/solvers/kissat.rs
@@ -1,5 +1,6 @@
 use super::{FromConjureModel, SolverError};
 use crate::Solver;
+use conjure_core::metadata::Metadata;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -130,7 +131,7 @@ impl CNF {
             expr_clauses.push(self.clause_to_expression(clause)?);
         }
 
-        Ok(ConjureExpression::And(expr_clauses))
+        Ok(ConjureExpression::And(Metadata::new(), expr_clauses))
     }
 
     /**
@@ -144,17 +145,20 @@ impl CNF {
                 None => return Err(CNFError::ClauseIndexNotFound(*idx)),
                 Some(name) => {
                     if *idx > 0 {
-                        ans.push(ConjureExpression::Reference(name.clone()))
+                        ans.push(ConjureExpression::Reference(Metadata::new(), name.clone()));
                     } else {
                         let expression: ConjureExpression =
-                            ConjureExpression::Reference(name.clone());
-                        ans.push(ConjureExpression::Not(Box::from(expression)))
+                            ConjureExpression::Reference(Metadata::new(), name.clone());
+                        ans.push(ConjureExpression::Not(
+                            Metadata::new(),
+                            Box::from(expression),
+                        ))
                     }
                 }
             }
         }
 
-        Ok(ConjureExpression::Or(ans))
+        Ok(ConjureExpression::Or(Metadata::new(), ans))
     }
 
     /**
@@ -185,7 +189,9 @@ impl CNF {
         let expr = expr_box.as_ref();
         match expr {
             // Expression inside the Not()
-            ConjureExpression::Reference(name) => Ok(vec![-self.get_reference_index(name)?]),
+            ConjureExpression::Reference(metadata, name) => {
+                Ok(vec![-self.get_reference_index(name)?])
+            }
             _ => Err(CNFError::UnexpectedExpressionInsideNot(expr.clone())),
         }
     }
@@ -211,9 +217,9 @@ impl CNF {
      */
     fn handle_flat_expression(&self, expression: &ConjureExpression) -> Result<Vec<i32>, CNFError> {
         match expression {
-            ConjureExpression::Reference(name) => self.handle_reference(name),
-            ConjureExpression::Not(var_box) => self.handle_not(var_box),
-            ConjureExpression::Or(expressions) => self.handle_or(expressions),
+            ConjureExpression::Reference(metadata, name) => self.handle_reference(name),
+            ConjureExpression::Not(metadata, var_box) => self.handle_not(var_box),
+            ConjureExpression::Or(metadata, expressions) => self.handle_or(expressions),
             _ => Err(CNFError::UnexpectedExpression(expression.clone())),
         }
     }
@@ -226,7 +232,7 @@ impl CNF {
 
         for expression in expressions {
             match expression {
-                ConjureExpression::And(_expressions) => {
+                ConjureExpression::And(_metadata, _expressions) => {
                     return Err(CNFError::NestedAnd(expression.clone()));
                 }
                 _ => {
@@ -243,7 +249,7 @@ impl CNF {
      */
     fn handle_expression(&self, expression: &ConjureExpression) -> Result<Vec<Vec<i32>>, CNFError> {
         match expression {
-            ConjureExpression::And(expressions) => self.handle_and(expressions),
+            ConjureExpression::And(_metadata, expressions) => self.handle_and(expressions),
             _ => Ok(vec![self.handle_flat_expression(expression)?]),
         }
     }
@@ -310,6 +316,8 @@ impl FromConjureModel for CNF {
 
 #[cfg(test)]
 mod tests {
+    use conjure_core::metadata::Metadata;
+
     use crate::ast::Domain::{BoolDomain, IntDomain};
     use crate::ast::Expression::{And, Not, Or, Reference};
     use crate::ast::{DecisionVariable, Model};
@@ -326,7 +334,7 @@ mod tests {
 
         let x: Name = Name::UserName(String::from('x'));
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
-        model.add_constraint(Reference(x.clone()));
+        model.add_constraint(Reference(Metadata::new(), x.clone()));
 
         let res: Result<CNF, SolverError> = CNF::from_conjure(model);
         assert!(res.is_ok());
@@ -348,7 +356,10 @@ mod tests {
 
         let x: Name = Name::UserName(String::from('x'));
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
-        model.add_constraint(Not(Box::from(Reference(x.clone()))));
+        model.add_constraint(Not(
+            Metadata::new(),
+            Box::from(Reference(Metadata::new(), x.clone())),
+        ));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
         assert_eq!(cnf.get_index(&x), Some(1));
@@ -356,7 +367,16 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![Or(vec![Not(Box::from(Reference(x.clone())))])])
+            And(
+                Metadata::new(),
+                vec![Or(
+                    Metadata::new(),
+                    vec![Not(
+                        Metadata::new(),
+                        Box::from(Reference(Metadata::new(), x.clone()))
+                    )]
+                )]
+            )
         )
     }
 
@@ -372,7 +392,13 @@ mod tests {
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
 
-        model.add_constraint(Or(vec![Reference(x.clone()), Reference(y.clone())]));
+        model.add_constraint(Or(
+            Metadata::new(),
+            vec![
+                Reference(Metadata::new(), x.clone()),
+                Reference(Metadata::new(), y.clone()),
+            ],
+        ));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
 
@@ -382,7 +408,16 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![Or(vec![Reference(x.clone()), Reference(y.clone())])])
+            And(
+                Metadata::new(),
+                vec![Or(
+                    Metadata::new(),
+                    vec![
+                        Reference(Metadata::new(), x.clone()),
+                        Reference(Metadata::new(), y.clone())
+                    ]
+                )]
+            )
         )
     }
 
@@ -398,10 +433,16 @@ mod tests {
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
 
-        model.add_constraint(Or(vec![
-            Reference(x.clone()),
-            Not(Box::from(Reference(y.clone()))),
-        ]));
+        model.add_constraint(Or(
+            Metadata::new(),
+            vec![
+                Reference(Metadata::new(), x.clone()),
+                Not(
+                    Metadata::new(),
+                    Box::from(Reference(Metadata::new(), y.clone())),
+                ),
+            ],
+        ));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
 
@@ -411,10 +452,19 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![Or(vec![
-                Reference(x.clone()),
-                Not(Box::from(Reference(y.clone())))
-            ])])
+            And(
+                Metadata::new(),
+                vec![Or(
+                    Metadata::new(),
+                    vec![
+                        Reference(Metadata::new(), x.clone()),
+                        Not(
+                            Metadata::new(),
+                            Box::from(Reference(Metadata::new(), y.clone()))
+                        )
+                    ]
+                )]
+            )
         )
     }
 
@@ -430,8 +480,8 @@ mod tests {
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
 
-        model.add_constraint(Reference(x.clone()));
-        model.add_constraint(Reference(y.clone()));
+        model.add_constraint(Reference(Metadata::new(), x.clone()));
+        model.add_constraint(Reference(Metadata::new(), y.clone()));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
 
@@ -441,10 +491,13 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![
-                Or(vec![Reference(x.clone())]),
-                Or(vec![Reference(y.clone())])
-            ])
+            And(
+                Metadata::new(),
+                vec![
+                    Or(Metadata::new(), vec![Reference(Metadata::new(), x.clone())]),
+                    Or(Metadata::new(), vec![Reference(Metadata::new(), y.clone())])
+                ]
+            )
         )
     }
 
@@ -460,7 +513,13 @@ mod tests {
         model.add_variable(x.clone(), DecisionVariable { domain: BoolDomain });
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
 
-        model.add_constraint(And(vec![Reference(x.clone()), Reference(y.clone())]));
+        model.add_constraint(And(
+            Metadata::new(),
+            vec![
+                Reference(Metadata::new(), x.clone()),
+                Reference(Metadata::new(), y.clone()),
+            ],
+        ));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
 
@@ -470,10 +529,13 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![
-                Or(vec![Reference(x.clone())]),
-                Or(vec![Reference(y.clone())])
-            ])
+            And(
+                Metadata::new(),
+                vec![
+                    Or(Metadata::new(), vec![Reference(Metadata::new(), x.clone())]),
+                    Or(Metadata::new(), vec![Reference(Metadata::new(), y.clone())])
+                ]
+            )
         )
     }
 
@@ -491,10 +553,19 @@ mod tests {
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
         model.add_variable(z.clone(), DecisionVariable { domain: BoolDomain });
 
-        model.add_constraint(Or(vec![
-            Reference(x.clone()),
-            Or(vec![Reference(y.clone()), Reference(z.clone())]),
-        ]));
+        model.add_constraint(Or(
+            Metadata::new(),
+            vec![
+                Reference(Metadata::new(), x.clone()),
+                Or(
+                    Metadata::new(),
+                    vec![
+                        Reference(Metadata::new(), y.clone()),
+                        Reference(Metadata::new(), z.clone()),
+                    ],
+                ),
+            ],
+        ));
 
         let cnf: CNF = CNF::from_conjure(model).unwrap();
 
@@ -505,11 +576,17 @@ mod tests {
 
         assert_eq!(
             if_ok(cnf.as_expression()),
-            And(vec![Or(vec![
-                Reference(x.clone()),
-                Reference(y.clone()),
-                Reference(z.clone())
-            ])])
+            And(
+                Metadata::new(),
+                vec![Or(
+                    Metadata::new(),
+                    vec![
+                        Reference(Metadata::new(), x.clone()),
+                        Reference(Metadata::new(), y.clone()),
+                        Reference(Metadata::new(), z.clone())
+                    ]
+                )]
+            )
         )
     }
 
@@ -530,8 +607,8 @@ mod tests {
             },
         );
 
-        model.add_constraint(Reference(x.clone()));
-        model.add_constraint(Reference(y.clone()));
+        model.add_constraint(Reference(Metadata::new(), x.clone()));
+        model.add_constraint(Reference(Metadata::new(), y.clone()));
 
         let cnf: Result<CNF, SolverError> = CNF::from_conjure(model);
         assert!(cnf.is_err());
@@ -550,8 +627,9 @@ mod tests {
         model.add_variable(y.clone(), DecisionVariable { domain: BoolDomain });
 
         model.add_constraint(Expression::Eq(
-            Box::from(Reference(x.clone())),
-            Box::from(Reference(y.clone())),
+            Metadata::new(),
+            Box::from(Reference(Metadata::new(), x.clone())),
+            Box::from(Reference(Metadata::new(), y.clone())),
         ));
 
         let cnf: Result<CNF, SolverError> = CNF::from_conjure(model);

--- a/conjure_oxide/src/solvers/minion.rs
+++ b/conjure_oxide/src/solvers/minion.rs
@@ -128,19 +128,19 @@ fn parse_exprs(
 
 fn parse_expr(expr: ConjureExpression, minion_model: &mut MinionModel) -> Result<(), SolverError> {
     match expr {
-        ConjureExpression::SumLeq(lhs, rhs) => {
+        ConjureExpression::SumLeq(metadata, lhs, rhs) => {
             minion_model
                 .constraints
                 .push(MinionConstraint::SumLeq(read_vars(lhs)?, read_var(*rhs)?));
             Ok(())
         }
-        ConjureExpression::SumGeq(lhs, rhs) => {
+        ConjureExpression::SumGeq(metadata, lhs, rhs) => {
             minion_model
                 .constraints
                 .push(MinionConstraint::SumGeq(read_vars(lhs)?, read_var(*rhs)?));
             Ok(())
         }
-        ConjureExpression::Ineq(a, b, c) => {
+        ConjureExpression::Ineq(metadata, a, b, c) => {
             minion_model.constraints.push(MinionConstraint::Ineq(
                 read_var(*a)?,
                 read_var(*b)?,
@@ -148,7 +148,7 @@ fn parse_expr(expr: ConjureExpression, minion_model: &mut MinionModel) -> Result
             ));
             Ok(())
         }
-        ConjureExpression::Neq(a, b) => {
+        ConjureExpression::Neq(metadata, a, b) => {
             minion_model
                 .constraints
                 .push(MinionConstraint::WatchNeq(read_var(*a)?, read_var(*b)?));
@@ -180,7 +180,7 @@ fn read_var(e: ConjureExpression) -> Result<MinionVar, SolverError> {
 
 fn _read_ref(e: ConjureExpression) -> Result<String, SolverError> {
     let name = match e {
-        ConjureExpression::Reference(n) => Ok(n),
+        ConjureExpression::Reference(metdata, n) => Ok(n),
         x => Err(SolverError::InvalidInstance(
             SOLVER,
             format!("expected a reference, but got `{0:?}`", x),
@@ -224,27 +224,33 @@ mod tests {
         // TODO: convert to use public interfaces when these exist.
         let mut model = ConjureModel {
             variables: HashMap::new(),
-            constraints: Expression::And(Vec::new()),
+            constraints: Expression::And(Metadata::new(), Vec::new()),
         };
 
         add_int_with_range(&mut model, "x", 1, 3)?;
         add_int_with_range(&mut model, "y", 2, 4)?;
         add_int_with_range(&mut model, "z", 1, 5)?;
 
-        let x = ConjureExpression::Reference(ConjureName::UserName("x".to_owned()));
-        let y = ConjureExpression::Reference(ConjureName::UserName("y".to_owned()));
-        let z = ConjureExpression::Reference(ConjureName::UserName("z".to_owned()));
+        let x =
+            ConjureExpression::Reference(Metadata::new(), ConjureName::UserName("x".to_owned()));
+        let y =
+            ConjureExpression::Reference(Metadata::new(), ConjureName::UserName("y".to_owned()));
+        let z =
+            ConjureExpression::Reference(Metadata::new(), ConjureName::UserName("z".to_owned()));
         let four = ConjureExpression::Constant(Metadata::new(), ConjureConstant::Int(4));
 
         let geq = ConjureExpression::SumGeq(
+            Metadata::new(),
             vec![x.to_owned(), y.to_owned(), z.to_owned()],
             Box::from(four.to_owned()),
         );
         let leq = ConjureExpression::SumLeq(
+            Metadata::new(),
             vec![x.to_owned(), y.to_owned(), z.to_owned()],
             Box::from(four.to_owned()),
         );
-        let ineq = ConjureExpression::Ineq(Box::from(x), Box::from(y), Box::from(four));
+        let ineq =
+            ConjureExpression::Ineq(Metadata::new(), Box::from(x), Box::from(y), Box::from(four));
 
         model.add_constraints(vec![geq, leq, ineq]);
 

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
@@ -2,14 +2,27 @@
   "constraints": {
     "Neq": [
       {
-        "Reference": {
-          "UserName": "x"
-        }
+        "dirtyclean": false
       },
       {
-        "Reference": {
-          "UserName": "y"
-        }
+        "Reference": [
+          {
+            "dirtyclean": false
+          },
+          {
+            "UserName": "x"
+          }
+        ]
+      },
+      {
+        "Reference": [
+          {
+            "dirtyclean": false
+          },
+          {
+            "UserName": "y"
+          }
+        ]
       }
     ]
   },

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
@@ -2,14 +2,27 @@
   "constraints": {
     "Neq": [
       {
-        "Reference": {
-          "UserName": "x"
-        }
+        "dirtyclean": false
       },
       {
-        "Reference": {
-          "UserName": "y"
-        }
+        "Reference": [
+          {
+            "dirtyclean": false
+          },
+          {
+            "UserName": "x"
+          }
+        ]
+      },
+      {
+        "Reference": [
+          {
+            "dirtyclean": false
+          },
+          {
+            "UserName": "y"
+          }
+        ]
       }
     ]
   },

--- a/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
@@ -2,56 +2,102 @@
   "constraints": {
     "And": [
       {
-        "Eq": [
-          {
-            "Sum": [
-              {
-                "Sum": [
+        "dirtyclean": false
+      },
+      [
+        {
+          "Eq": [
+            {
+              "dirtyclean": false
+            },
+            {
+              "Sum": [
+                {
+                  "dirtyclean": false
+                },
+                [
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Sum": [
+                      {
+                        "dirtyclean": false
+                      },
+                      [
+                        {
+                          "Reference": [
+                            {
+                              "dirtyclean": false
+                            },
+                            {
+                              "UserName": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "Reference": [
+                            {
+                              "dirtyclean": false
+                            },
+                            {
+                              "UserName": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "b"
-                    }
+                    "Reference": [
+                      {
+                        "dirtyclean": false
+                      },
+                      {
+                        "UserName": "c"
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "Reference": {
-                  "UserName": "c"
+              ]
+            },
+            {
+              "Constant": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "Int": 4
                 }
-              }
-            ]
-          },
-          {
-            "Constant": [
-              {
-                "dirtyclean": false
-              },
-              {
-                "Int": 4
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "Geq": [
-          {
-            "Reference": {
-              "UserName": "a"
+              ]
             }
-          },
-          {
-            "Reference": {
-              "UserName": "b"
+          ]
+        },
+        {
+          "Geq": [
+            {
+              "dirtyclean": false
+            },
+            {
+              "Reference": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "UserName": "a"
+                }
+              ]
+            },
+            {
+              "Reference": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "UserName": "b"
+                }
+              ]
             }
-          }
-        ]
-      }
+          ]
+        }
+      ]
     ]
   },
   "variables": [

--- a/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
@@ -2,91 +2,145 @@
   "constraints": {
     "And": [
       {
-        "SumGeq": [
-          [
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            },
-            {
-              "Reference": {
-                "UserName": "b"
-              }
-            },
-            {
-              "Reference": {
-                "UserName": "c"
-              }
-            }
-          ],
-          {
-            "Constant": [
-              {
-                "dirtyclean": false
-              },
-              {
-                "Int": 4
-              }
-            ]
-          }
-        ]
+        "dirtyclean": false
       },
-      {
-        "SumLeq": [
-          [
+      [
+        {
+          "SumGeq": [
             {
-              "Reference": {
-                "UserName": "a"
-              }
+              "dirtyclean": false
             },
-            {
-              "Reference": {
-                "UserName": "b"
-              }
-            },
-            {
-              "Reference": {
-                "UserName": "c"
-              }
-            }
-          ],
-          {
-            "Constant": [
+            [
               {
-                "dirtyclean": false
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "a"
+                  }
+                ]
               },
               {
-                "Int": 4
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "Ineq": [
-          {
-            "Reference": {
-              "UserName": "b"
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "a"
-            }
-          },
-          {
-            "Constant": [
-              {
-                "dirtyclean": false
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "b"
+                  }
+                ]
               },
               {
-                "Int": 0
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "c"
+                  }
+                ]
               }
-            ]
-          }
-        ]
-      }
+            ],
+            {
+              "Constant": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "Int": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "SumLeq": [
+            {
+              "dirtyclean": false
+            },
+            [
+              {
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "a"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "b"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "dirtyclean": false
+                  },
+                  {
+                    "UserName": "c"
+                  }
+                ]
+              }
+            ],
+            {
+              "Constant": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "Int": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Ineq": [
+            {
+              "dirtyclean": false
+            },
+            {
+              "Reference": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "UserName": "b"
+                }
+              ]
+            },
+            {
+              "Reference": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "UserName": "a"
+                }
+              ]
+            },
+            {
+              "Constant": [
+                {
+                  "dirtyclean": false
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
     ]
   },
   "variables": [

--- a/conjure_oxide/tests/model_tests.rs
+++ b/conjure_oxide/tests/model_tests.rs
@@ -1,5 +1,6 @@
 // Tests for various functionalities of the Model
 
+use conjure_core::metadata::Metadata;
 use conjure_oxide::ast::*;
 use std::collections::HashMap;
 
@@ -15,7 +16,7 @@ fn modify_domain() {
 
     let mut m = Model {
         variables,
-        constraints: Expression::And(Vec::new()),
+        constraints: Expression::And(Metadata::new(), Vec::new()),
     };
 
     assert_eq!(m.variables.get(&a).unwrap().domain, d1);

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -16,16 +16,22 @@ fn rules_present() {
 
 #[test]
 fn sum_of_constants() {
-    let valid_sum_expression = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::Constant(Metadata::new(), Constant::Int(2)),
-        Expression::Constant(Metadata::new(), Constant::Int(3)),
-    ]);
+    let valid_sum_expression = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::Constant(Metadata::new(), Constant::Int(2)),
+            Expression::Constant(Metadata::new(), Constant::Int(3)),
+        ],
+    );
 
-    let invalid_sum_expression = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::Reference(Name::UserName(String::from("a"))),
-    ]);
+    let invalid_sum_expression = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+        ],
+    );
 
     match evaluate_sum_of_constants(&valid_sum_expression) {
         Some(result) => assert_eq!(result, 6),
@@ -39,7 +45,7 @@ fn sum_of_constants() {
 
 fn evaluate_sum_of_constants(expr: &Expression) -> Option<i32> {
     match expr {
-        Expression::Sum(expressions) => {
+        Expression::Sum(metadata, expressions) => {
             let mut sum = 0;
             for e in expressions {
                 match e {
@@ -58,24 +64,35 @@ fn evaluate_sum_of_constants(expr: &Expression) -> Option<i32> {
 #[test]
 fn recursive_sum_of_constants() {
     let complex_expression = Expression::Eq(
-        Box::new(Expression::Sum(vec![
-            Expression::Constant(Metadata::new(), Constant::Int(1)),
-            Expression::Constant(Metadata::new(), Constant::Int(2)),
-            Expression::Sum(vec![
+        Metadata::new(),
+        Box::new(Expression::Sum(
+            Metadata::new(),
+            vec![
                 Expression::Constant(Metadata::new(), Constant::Int(1)),
                 Expression::Constant(Metadata::new(), Constant::Int(2)),
-            ]),
-            Expression::Reference(Name::UserName(String::from("a"))),
-        ])),
+                Expression::Sum(
+                    Metadata::new(),
+                    vec![
+                        Expression::Constant(Metadata::new(), Constant::Int(1)),
+                        Expression::Constant(Metadata::new(), Constant::Int(2)),
+                    ],
+                ),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+            ],
+        )),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(3))),
     );
     let correct_simplified_expression = Expression::Eq(
-        Box::new(Expression::Sum(vec![
-            Expression::Constant(Metadata::new(), Constant::Int(1)),
-            Expression::Constant(Metadata::new(), Constant::Int(2)),
-            Expression::Constant(Metadata::new(), Constant::Int(3)),
-            Expression::Reference(Name::UserName(String::from("a"))),
-        ])),
+        Metadata::new(),
+        Box::new(Expression::Sum(
+            Metadata::new(),
+            vec![
+                Expression::Constant(Metadata::new(), Constant::Int(1)),
+                Expression::Constant(Metadata::new(), Constant::Int(2)),
+                Expression::Constant(Metadata::new(), Constant::Int(3)),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+            ],
+        )),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(3))),
     );
 
@@ -85,18 +102,25 @@ fn recursive_sum_of_constants() {
 
 fn simplify_expression(expr: Expression) -> Expression {
     match expr {
-        Expression::Sum(expressions) => {
-            if let Some(result) = evaluate_sum_of_constants(&Expression::Sum(expressions.clone())) {
+        Expression::Sum(metadata, expressions) => {
+            if let Some(result) =
+                evaluate_sum_of_constants(&Expression::Sum(Metadata::new(), expressions.clone()))
+            {
                 Expression::Constant(Metadata::new(), Constant::Int(result))
             } else {
-                Expression::Sum(expressions.into_iter().map(simplify_expression).collect())
+                Expression::Sum(
+                    Metadata::new(),
+                    expressions.into_iter().map(simplify_expression).collect(),
+                )
             }
         }
-        Expression::Eq(left, right) => Expression::Eq(
+        Expression::Eq(metadata, left, right) => Expression::Eq(
+            Metadata::new(),
             Box::new(simplify_expression(*left)),
             Box::new(simplify_expression(*right)),
         ),
-        Expression::Geq(left, right) => Expression::Geq(
+        Expression::Geq(metadata, left, right) => Expression::Geq(
+            Metadata::new(),
             Box::new(simplify_expression(*left)),
             Box::new(simplify_expression(*right)),
         ),
@@ -109,11 +133,14 @@ fn rule_sum_constants() {
     let sum_constants = get_rule_by_name("sum_constants").unwrap();
     let unwrap_sum = get_rule_by_name("unwrap_sum").unwrap();
 
-    let mut expr = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::Constant(Metadata::new(), Constant::Int(2)),
-        Expression::Constant(Metadata::new(), Constant::Int(3)),
-    ]);
+    let mut expr = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::Constant(Metadata::new(), Constant::Int(2)),
+            Expression::Constant(Metadata::new(), Constant::Int(3)),
+        ],
+    );
 
     expr = sum_constants.apply(&expr).unwrap();
     expr = unwrap_sum.apply(&expr).unwrap();
@@ -128,20 +155,26 @@ fn rule_sum_constants() {
 fn rule_sum_mixed() {
     let sum_constants = get_rule_by_name("sum_constants").unwrap();
 
-    let mut expr = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::Constant(Metadata::new(), Constant::Int(2)),
-        Expression::Reference(Name::UserName(String::from("a"))),
-    ]);
+    let mut expr = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::Constant(Metadata::new(), Constant::Int(2)),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+        ],
+    );
 
     expr = sum_constants.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::Sum(vec![
-            Expression::Reference(Name::UserName(String::from("a"))),
-            Expression::Constant(Metadata::new(), Constant::Int(3)),
-        ])
+        Expression::Sum(
+            Metadata::new(),
+            vec![
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                Expression::Constant(Metadata::new(), Constant::Int(3)),
+            ]
+        )
     );
 }
 
@@ -150,10 +183,14 @@ fn rule_sum_geq() {
     let flatten_sum_geq = get_rule_by_name("flatten_sum_geq").unwrap();
 
     let mut expr = Expression::Geq(
-        Box::new(Expression::Sum(vec![
-            Expression::Constant(Metadata::new(), Constant::Int(1)),
-            Expression::Constant(Metadata::new(), Constant::Int(2)),
-        ])),
+        Metadata::new(),
+        Box::new(Expression::Sum(
+            Metadata::new(),
+            vec![
+                Expression::Constant(Metadata::new(), Constant::Int(1)),
+                Expression::Constant(Metadata::new(), Constant::Int(2)),
+            ],
+        )),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(3))),
     );
 
@@ -162,6 +199,7 @@ fn rule_sum_geq() {
     assert_eq!(
         expr,
         Expression::SumGeq(
+            Metadata::new(),
             vec![
                 Expression::Constant(Metadata::new(), Constant::Int(1)),
                 Expression::Constant(Metadata::new(), Constant::Int(2)),
@@ -192,11 +230,14 @@ fn reduce_solve_xyz() {
     let sum_leq_to_sumleq = get_rule_by_name("sum_leq_to_sumleq").unwrap();
 
     // 2 + 3 - 1
-    let mut expr1 = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(2)),
-        Expression::Constant(Metadata::new(), Constant::Int(3)),
-        Expression::Constant(Metadata::new(), Constant::Int(-1)),
-    ]);
+    let mut expr1 = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(2)),
+            Expression::Constant(Metadata::new(), Constant::Int(3)),
+            Expression::Constant(Metadata::new(), Constant::Int(-1)),
+        ],
+    );
 
     expr1 = sum_constants.apply(&expr1).unwrap();
     expr1 = unwrap_sum.apply(&expr1).unwrap();
@@ -207,21 +248,26 @@ fn reduce_solve_xyz() {
 
     // a + b + c = 4
     expr1 = Expression::Leq(
-        Box::new(Expression::Sum(vec![
-            Expression::Reference(Name::UserName(String::from("a"))),
-            Expression::Reference(Name::UserName(String::from("b"))),
-            Expression::Reference(Name::UserName(String::from("c"))),
-        ])),
+        Metadata::new(),
+        Box::new(Expression::Sum(
+            Metadata::new(),
+            vec![
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("c"))),
+            ],
+        )),
         Box::new(expr1),
     );
     expr1 = sum_leq_to_sumleq.apply(&expr1).unwrap();
     assert_eq!(
         expr1,
         Expression::SumLeq(
+            Metadata::new(),
             vec![
-                Expression::Reference(Name::UserName(String::from("a"))),
-                Expression::Reference(Name::UserName(String::from("b"))),
-                Expression::Reference(Name::UserName(String::from("c"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("c"))),
             ],
             Box::new(Expression::Constant(Metadata::new(), Constant::Int(4)))
         )
@@ -229,22 +275,36 @@ fn reduce_solve_xyz() {
 
     // a < b
     let mut expr2 = Expression::Lt(
-        Box::new(Expression::Reference(Name::UserName(String::from("a")))),
-        Box::new(Expression::Reference(Name::UserName(String::from("b")))),
+        Metadata::new(),
+        Box::new(Expression::Reference(
+            Metadata::new(),
+            Name::UserName(String::from("a")),
+        )),
+        Box::new(Expression::Reference(
+            Metadata::new(),
+            Name::UserName(String::from("b")),
+        )),
     );
     expr2 = lt_to_ineq.apply(&expr2).unwrap();
     assert_eq!(
         expr2,
         Expression::Ineq(
-            Box::new(Expression::Reference(Name::UserName(String::from("a")))),
-            Box::new(Expression::Reference(Name::UserName(String::from("b")))),
+            Metadata::new(),
+            Box::new(Expression::Reference(
+                Metadata::new(),
+                Name::UserName(String::from("a"))
+            )),
+            Box::new(Expression::Reference(
+                Metadata::new(),
+                Name::UserName(String::from("b"))
+            )),
             Box::new(Expression::Constant(Metadata::new(), Constant::Int(-1)))
         )
     );
 
     let mut model = Model {
         variables: HashMap::new(),
-        constraints: Expression::And(vec![expr1, expr2]),
+        constraints: Expression::And(Metadata::new(), vec![expr1, expr2]),
     };
     model.variables.insert(
         Name::UserName(String::from("a")),
@@ -274,10 +334,13 @@ fn reduce_solve_xyz() {
 fn rule_remove_double_negation() {
     let remove_double_negation = get_rule_by_name("remove_double_negation").unwrap();
 
-    let mut expr = Expression::Not(Box::new(Expression::Not(Box::new(Expression::Constant(
+    let mut expr = Expression::Not(
         Metadata::new(),
-        Constant::Bool(true),
-    )))));
+        Box::new(Expression::Not(
+            Metadata::new(),
+            Box::new(Expression::Constant(Metadata::new(), Constant::Bool(true))),
+        )),
+    );
 
     expr = remove_double_negation.apply(&expr).unwrap();
 
@@ -291,23 +354,32 @@ fn rule_remove_double_negation() {
 fn rule_unwrap_nested_or() {
     let unwrap_nested_or = get_rule_by_name("unwrap_nested_or").unwrap();
 
-    let mut expr = Expression::Or(vec![
-        Expression::Or(vec![
+    let mut expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::Or(
+                Metadata::new(),
+                vec![
+                    Expression::Constant(Metadata::new(), Constant::Bool(true)),
+                    Expression::Constant(Metadata::new(), Constant::Bool(false)),
+                ],
+            ),
             Expression::Constant(Metadata::new(), Constant::Bool(true)),
-            Expression::Constant(Metadata::new(), Constant::Bool(false)),
-        ]),
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-    ]);
+        ],
+    );
 
     expr = unwrap_nested_or.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::Or(vec![
-            Expression::Constant(Metadata::new(), Constant::Bool(true)),
-            Expression::Constant(Metadata::new(), Constant::Bool(false)),
-            Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        ])
+        Expression::Or(
+            Metadata::new(),
+            vec![
+                Expression::Constant(Metadata::new(), Constant::Bool(true)),
+                Expression::Constant(Metadata::new(), Constant::Bool(false)),
+                Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            ]
+        )
     );
 }
 
@@ -315,23 +387,32 @@ fn rule_unwrap_nested_or() {
 fn rule_unwrap_nested_and() {
     let unwrap_nested_and = get_rule_by_name("unwrap_nested_and").unwrap();
 
-    let mut expr = Expression::And(vec![
-        Expression::And(vec![
+    let mut expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::And(
+                Metadata::new(),
+                vec![
+                    Expression::Constant(Metadata::new(), Constant::Bool(true)),
+                    Expression::Constant(Metadata::new(), Constant::Bool(false)),
+                ],
+            ),
             Expression::Constant(Metadata::new(), Constant::Bool(true)),
-            Expression::Constant(Metadata::new(), Constant::Bool(false)),
-        ]),
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-    ]);
+        ],
+    );
 
     expr = unwrap_nested_and.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::And(vec![
-            Expression::Constant(Metadata::new(), Constant::Bool(true)),
-            Expression::Constant(Metadata::new(), Constant::Bool(false)),
-            Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        ])
+        Expression::And(
+            Metadata::new(),
+            vec![
+                Expression::Constant(Metadata::new(), Constant::Bool(true)),
+                Expression::Constant(Metadata::new(), Constant::Bool(false)),
+                Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            ]
+        )
     );
 }
 
@@ -339,10 +420,13 @@ fn rule_unwrap_nested_and() {
 fn unwrap_nested_or_not_changed() {
     let unwrap_nested_or = get_rule_by_name("unwrap_nested_or").unwrap();
 
-    let expr = Expression::Or(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-    ]);
+    let expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+        ],
+    );
 
     let result = unwrap_nested_or.apply(&expr);
 
@@ -353,10 +437,13 @@ fn unwrap_nested_or_not_changed() {
 fn unwrap_nested_and_not_changed() {
     let unwrap_nested_and = get_rule_by_name("unwrap_nested_and").unwrap();
 
-    let expr = Expression::And(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-    ]);
+    let expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+        ],
+    );
 
     let result = unwrap_nested_and.apply(&expr);
 
@@ -368,14 +455,14 @@ fn remove_trivial_and_or() {
     let remove_trivial_and = get_rule_by_name("remove_trivial_and").unwrap();
     let remove_trivial_or = get_rule_by_name("remove_trivial_or").unwrap();
 
-    let mut expr_and = Expression::And(vec![Expression::Constant(
+    let mut expr_and = Expression::And(
         Metadata::new(),
-        Constant::Bool(true),
-    )]);
-    let mut expr_or = Expression::Or(vec![Expression::Constant(
+        vec![Expression::Constant(Metadata::new(), Constant::Bool(true))],
+    );
+    let mut expr_or = Expression::Or(
         Metadata::new(),
-        Constant::Bool(false),
-    )]);
+        vec![Expression::Constant(Metadata::new(), Constant::Bool(false))],
+    );
 
     expr_and = remove_trivial_and.apply(&expr_and).unwrap();
     expr_or = remove_trivial_or.apply(&expr_or).unwrap();
@@ -394,11 +481,14 @@ fn remove_trivial_and_or() {
 fn rule_remove_constants_from_or() {
     let remove_constants_from_or = get_rule_by_name("remove_constants_from_or").unwrap();
 
-    let mut expr = Expression::Or(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-        Expression::Reference(Name::UserName(String::from("a"))),
-    ]);
+    let mut expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+        ],
+    );
 
     expr = remove_constants_from_or.apply(&expr).unwrap();
 
@@ -412,11 +502,14 @@ fn rule_remove_constants_from_or() {
 fn rule_remove_constants_from_and() {
     let remove_constants_from_and = get_rule_by_name("remove_constants_from_and").unwrap();
 
-    let mut expr = Expression::And(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-        Expression::Reference(Name::UserName(String::from("a"))),
-    ]);
+    let mut expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+        ],
+    );
 
     expr = remove_constants_from_and.apply(&expr).unwrap();
 
@@ -430,10 +523,13 @@ fn rule_remove_constants_from_and() {
 fn remove_constants_from_or_not_changed() {
     let remove_constants_from_or = get_rule_by_name("remove_constants_from_or").unwrap();
 
-    let expr = Expression::Or(vec![
-        Expression::Reference(Name::UserName(String::from("a"))),
-        Expression::Reference(Name::UserName(String::from("b"))),
-    ]);
+    let expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+        ],
+    );
 
     let result = remove_constants_from_or.apply(&expr);
 
@@ -444,10 +540,13 @@ fn remove_constants_from_or_not_changed() {
 fn remove_constants_from_and_not_changed() {
     let remove_constants_from_and = get_rule_by_name("remove_constants_from_and").unwrap();
 
-    let expr = Expression::And(vec![
-        Expression::Reference(Name::UserName(String::from("a"))),
-        Expression::Reference(Name::UserName(String::from("b"))),
-    ]);
+    let expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+            Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+        ],
+    );
 
     let result = remove_constants_from_and.apply(&expr);
 
@@ -458,23 +557,40 @@ fn remove_constants_from_and_not_changed() {
 fn rule_distribute_not_over_and() {
     let distribute_not_over_and = get_rule_by_name("distribute_not_over_and").unwrap();
 
-    let mut expr = Expression::Not(Box::new(Expression::And(vec![
-        Expression::Reference(Name::UserName(String::from("a"))),
-        Expression::Reference(Name::UserName(String::from("b"))),
-    ])));
+    let mut expr = Expression::Not(
+        Metadata::new(),
+        Box::new(Expression::And(
+            Metadata::new(),
+            vec![
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+            ],
+        )),
+    );
 
     expr = distribute_not_over_and.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::Or(vec![
-            Expression::Not(Box::new(Expression::Reference(Name::UserName(
-                String::from("a")
-            )))),
-            Expression::Not(Box::new(Expression::Reference(Name::UserName(
-                String::from("b")
-            )))),
-        ])
+        Expression::Or(
+            Metadata::new(),
+            vec![
+                Expression::Not(
+                    Metadata::new(),
+                    Box::new(Expression::Reference(
+                        Metadata::new(),
+                        Name::UserName(String::from("a"))
+                    ))
+                ),
+                Expression::Not(
+                    Metadata::new(),
+                    Box::new(Expression::Reference(
+                        Metadata::new(),
+                        Name::UserName(String::from("b"))
+                    ))
+                ),
+            ]
+        )
     );
 }
 
@@ -482,23 +598,40 @@ fn rule_distribute_not_over_and() {
 fn rule_distribute_not_over_or() {
     let distribute_not_over_or = get_rule_by_name("distribute_not_over_or").unwrap();
 
-    let mut expr = Expression::Not(Box::new(Expression::Or(vec![
-        Expression::Reference(Name::UserName(String::from("a"))),
-        Expression::Reference(Name::UserName(String::from("b"))),
-    ])));
+    let mut expr = Expression::Not(
+        Metadata::new(),
+        Box::new(Expression::Or(
+            Metadata::new(),
+            vec![
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                Expression::Reference(Metadata::new(), Name::UserName(String::from("b"))),
+            ],
+        )),
+    );
 
     expr = distribute_not_over_or.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::And(vec![
-            Expression::Not(Box::new(Expression::Reference(Name::UserName(
-                String::from("a")
-            )))),
-            Expression::Not(Box::new(Expression::Reference(Name::UserName(
-                String::from("b")
-            )))),
-        ])
+        Expression::And(
+            Metadata::new(),
+            vec![
+                Expression::Not(
+                    Metadata::new(),
+                    Box::new(Expression::Reference(
+                        Metadata::new(),
+                        Name::UserName(String::from("a"))
+                    ))
+                ),
+                Expression::Not(
+                    Metadata::new(),
+                    Box::new(Expression::Reference(
+                        Metadata::new(),
+                        Name::UserName(String::from("b"))
+                    ))
+                ),
+            ]
+        )
     );
 }
 
@@ -506,9 +639,13 @@ fn rule_distribute_not_over_or() {
 fn rule_distribute_not_over_and_not_changed() {
     let distribute_not_over_and = get_rule_by_name("distribute_not_over_and").unwrap();
 
-    let expr = Expression::Not(Box::new(Expression::Reference(Name::UserName(
-        String::from("a"),
-    ))));
+    let expr = Expression::Not(
+        Metadata::new(),
+        Box::new(Expression::Reference(
+            Metadata::new(),
+            Name::UserName(String::from("a")),
+        )),
+    );
 
     let result = distribute_not_over_and.apply(&expr);
 
@@ -519,9 +656,13 @@ fn rule_distribute_not_over_and_not_changed() {
 fn rule_distribute_not_over_or_not_changed() {
     let distribute_not_over_or = get_rule_by_name("distribute_not_over_or").unwrap();
 
-    let expr = Expression::Not(Box::new(Expression::Reference(Name::UserName(
-        String::from("a"),
-    ))));
+    let expr = Expression::Not(
+        Metadata::new(),
+        Box::new(Expression::Reference(
+            Metadata::new(),
+            Name::UserName(String::from("a")),
+        )),
+    );
 
     let result = distribute_not_over_or.apply(&expr);
 
@@ -532,28 +673,43 @@ fn rule_distribute_not_over_or_not_changed() {
 fn rule_distribute_or_over_and() {
     let distribute_or_over_and = get_rule_by_name("distribute_or_over_and").unwrap();
 
-    let mut expr = Expression::Or(vec![
-        Expression::And(vec![
-            Expression::Reference(Name::MachineName(1)),
-            Expression::Reference(Name::MachineName(2)),
-        ]),
-        Expression::Reference(Name::MachineName(3)),
-    ]);
+    let mut expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::And(
+                Metadata::new(),
+                vec![
+                    Expression::Reference(Metadata::new(), Name::MachineName(1)),
+                    Expression::Reference(Metadata::new(), Name::MachineName(2)),
+                ],
+            ),
+            Expression::Reference(Metadata::new(), Name::MachineName(3)),
+        ],
+    );
 
     expr = distribute_or_over_and.apply(&expr).unwrap();
 
     assert_eq!(
         expr,
-        Expression::And(vec![
-            Expression::Or(vec![
-                Expression::Reference(Name::MachineName(3)),
-                Expression::Reference(Name::MachineName(1)),
-            ]),
-            Expression::Or(vec![
-                Expression::Reference(Name::MachineName(3)),
-                Expression::Reference(Name::MachineName(2)),
-            ]),
-        ]),
+        Expression::And(
+            Metadata::new(),
+            vec![
+                Expression::Or(
+                    Metadata::new(),
+                    vec![
+                        Expression::Reference(Metadata::new(), Name::MachineName(3)),
+                        Expression::Reference(Metadata::new(), Name::MachineName(1)),
+                    ]
+                ),
+                Expression::Or(
+                    Metadata::new(),
+                    vec![
+                        Expression::Reference(Metadata::new(), Name::MachineName(3)),
+                        Expression::Reference(Metadata::new(), Name::MachineName(2)),
+                    ]
+                ),
+            ]
+        ),
     );
 }
 
@@ -578,20 +734,28 @@ fn rewrite_solve_xyz() {
     let domain = Domain::IntDomain(vec![Range::Bounded(1, 3)]);
 
     // Construct nested expression
-    let nested_expr = Expression::And(vec![
-        Expression::Eq(
-            Box::new(Expression::Sum(vec![
-                Expression::Reference(variable_a.clone()),
-                Expression::Reference(variable_b.clone()),
-                Expression::Reference(variable_c.clone()),
-            ])),
-            Box::new(Expression::Constant(Metadata::new(), Constant::Int(4))),
-        ),
-        Expression::Lt(
-            Box::new(Expression::Reference(variable_a.clone())),
-            Box::new(Expression::Reference(variable_b.clone())),
-        ),
-    ]);
+    let nested_expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Eq(
+                Metadata::new(),
+                Box::new(Expression::Sum(
+                    Metadata::new(),
+                    vec![
+                        Expression::Reference(Metadata::new(), variable_a.clone()),
+                        Expression::Reference(Metadata::new(), variable_b.clone()),
+                        Expression::Reference(Metadata::new(), variable_c.clone()),
+                    ],
+                )),
+                Box::new(Expression::Constant(Metadata::new(), Constant::Int(4))),
+            ),
+            Expression::Lt(
+                Metadata::new(),
+                Box::new(Expression::Reference(Metadata::new(), variable_a.clone())),
+                Box::new(Expression::Reference(Metadata::new(), variable_b.clone())),
+            ),
+        ],
+    );
 
     // Apply rewrite function to the nested expression
     let rewritten_expr = rewrite(&nested_expr);
@@ -726,30 +890,39 @@ fn eval_const_bool() {
 
 #[test]
 fn eval_const_and() {
-    let expr = Expression::And(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-    ]);
+    let expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+        ],
+    );
     let result = eval_constant(&expr);
     assert_eq!(result, Some(Constant::Bool(false)));
 }
 
 #[test]
 fn eval_const_ref() {
-    let expr = Expression::Reference(Name::UserName(String::from("a")));
+    let expr = Expression::Reference(Metadata::new(), Name::UserName(String::from("a")));
     let result = eval_constant(&expr);
     assert_eq!(result, None);
 }
 
 #[test]
 fn eval_const_nested_ref() {
-    let expr = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::And(vec![
-            Expression::Constant(Metadata::new(), Constant::Bool(true)),
-            Expression::Reference(Name::UserName(String::from("a"))),
-        ]),
-    ]);
+    let expr = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::And(
+                Metadata::new(),
+                vec![
+                    Expression::Constant(Metadata::new(), Constant::Bool(true)),
+                    Expression::Reference(Metadata::new(), Name::UserName(String::from("a"))),
+                ],
+            ),
+        ],
+    );
     let result = eval_constant(&expr);
     assert_eq!(result, None);
 }
@@ -757,6 +930,7 @@ fn eval_const_nested_ref() {
 #[test]
 fn eval_const_eq_int() {
     let expr = Expression::Eq(
+        Metadata::new(),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(1))),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(1))),
     );
@@ -767,6 +941,7 @@ fn eval_const_eq_int() {
 #[test]
 fn eval_const_eq_bool() {
     let expr = Expression::Eq(
+        Metadata::new(),
         Box::new(Expression::Constant(Metadata::new(), Constant::Bool(true))),
         Box::new(Expression::Constant(Metadata::new(), Constant::Bool(true))),
     );
@@ -777,6 +952,7 @@ fn eval_const_eq_bool() {
 #[test]
 fn eval_const_eq_mixed() {
     let expr = Expression::Eq(
+        Metadata::new(),
         Box::new(Expression::Constant(Metadata::new(), Constant::Int(1))),
         Box::new(Expression::Constant(Metadata::new(), Constant::Bool(true))),
     );
@@ -786,40 +962,60 @@ fn eval_const_eq_mixed() {
 
 #[test]
 fn eval_const_sum_mixed() {
-    let expr = Expression::Sum(vec![
-        Expression::Constant(Metadata::new(), Constant::Int(1)),
-        Expression::Constant(Metadata::new(), Constant::Bool(true)),
-    ]);
+    let expr = Expression::Sum(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Int(1)),
+            Expression::Constant(Metadata::new(), Constant::Bool(true)),
+        ],
+    );
     let result = eval_constant(&expr);
     assert_eq!(result, None);
 }
 
 #[test]
 fn eval_const_sum_xyz() {
-    let expr = Expression::And(vec![
-        Expression::Eq(
-            Box::new(Expression::Sum(vec![
-                Expression::Reference(Name::UserName(String::from("x"))),
-                Expression::Reference(Name::UserName(String::from("y"))),
-                Expression::Reference(Name::UserName(String::from("z"))),
-            ])),
-            Box::new(Expression::Constant(Metadata::new(), Constant::Int(4))),
-        ),
-        Expression::Geq(
-            Box::new(Expression::Reference(Name::UserName(String::from("x")))),
-            Box::new(Expression::Reference(Name::UserName(String::from("y")))),
-        ),
-    ]);
+    let expr = Expression::And(
+        Metadata::new(),
+        vec![
+            Expression::Eq(
+                Metadata::new(),
+                Box::new(Expression::Sum(
+                    Metadata::new(),
+                    vec![
+                        Expression::Reference(Metadata::new(), Name::UserName(String::from("x"))),
+                        Expression::Reference(Metadata::new(), Name::UserName(String::from("y"))),
+                        Expression::Reference(Metadata::new(), Name::UserName(String::from("z"))),
+                    ],
+                )),
+                Box::new(Expression::Constant(Metadata::new(), Constant::Int(4))),
+            ),
+            Expression::Geq(
+                Metadata::new(),
+                Box::new(Expression::Reference(
+                    Metadata::new(),
+                    Name::UserName(String::from("x")),
+                )),
+                Box::new(Expression::Reference(
+                    Metadata::new(),
+                    Name::UserName(String::from("y")),
+                )),
+            ),
+        ],
+    );
     let result = eval_constant(&expr);
     assert_eq!(result, None);
 }
 
 #[test]
 fn eval_const_or() {
-    let expr = Expression::Or(vec![
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-        Expression::Constant(Metadata::new(), Constant::Bool(false)),
-    ]);
+    let expr = Expression::Or(
+        Metadata::new(),
+        vec![
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+            Expression::Constant(Metadata::new(), Constant::Bool(false)),
+        ],
+    );
     let result = eval_constant(&expr);
     assert_eq!(result, Some(Constant::Bool(false)));
 }


### PR DESCRIPTION
This PR adds metadata to all the current enum variants and should close [Issue 182](https://github.com/conjure-cp/conjure-oxide/issues/182). I have added metadata to all match calls on `Expression`, cloned existing metadata when `Expression` objects are being manipulated, and created new metadata where new `Expression` objects are being made. 

This is currently building and all tests are passing. Please note that I ran cargo test with the `ACCEPT=true` environment variable which has changed the expected json for some of the integration tests. I have looked over this and it seems to have changed it sensibly but if others could take a look at those changes specifically that would be great!

Additionally, I believe there might be some places where I have created new metadata instead of cloning existing metadata. I have checked through my changes and I don't think I have left any lines where this is the case but if somebody else could double check that would also be really helpful!

When those two points are addressed this should be ready to merge :)

I have requested reviews from @ozgurakgun, @lixitrixi, @gskorokhod and @niklasdewally because this PR directly changes code written by you. It is worth checking if I have messed up some of your code as this has touched most files but the tests do pass so hopefully there are no issues there.

