### PR TITLE
rename #[solver] to #[compatible]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "conjure_core"
 version = "0.0.1"
 dependencies = [
- "doc_solver_support",
+ "enum_compatability_macro",
  "serde",
  "serde_json",
  "serde_with",
@@ -373,19 +373,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc_solver_support"
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "enum_compatability_macro"
 version = "0.1.0"
 dependencies = [
  "itertools",
  "quote",
  "syn 2.0.49",
 ]
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default-members = [
 members = [
     "conjure_oxide",
     "crates/conjure_core",
-    "crates/doc_solver_support",
+    "crates/enum_compatability_macro",
     "crates/conjure_rules_proc_macro",
     "crates/conjure_rules",
     "crates/uniplate",

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -10,7 +10,7 @@ serde_with = "3.6.1"
 strum = "0.26.1"
 strum_macros = "0.26.1"
 thiserror = "1.0.57"
-doc_solver_support = {path= "../doc_solver_support"}
+enum_compatability_macro = {path= "../enum_compatability_macro"}
 
 [lints]
 workspace = true

--- a/crates/conjure_core/src/ast.rs
+++ b/crates/conjure_core/src/ast.rs
@@ -1,4 +1,4 @@
-use doc_solver_support::doc_solver_support;
+use enum_compatability_macro::document_compatibility;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::HashMap;
@@ -154,7 +154,7 @@ impl TryFrom<Constant> for bool {
     }
 }
 
-#[doc_solver_support]
+#[document_compatibility]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Expression {
@@ -164,26 +164,40 @@ pub enum Expression {
      */
     Nothing,
 
-    #[solver(Minion, SAT)]
+    #[compatible(Minion, JsonInput)]
     Constant(Metadata, Constant),
 
-    #[solver(Minion)]
+    #[compatible(Minion, JsonInput, SAT)]
     Reference(Metadata, Name),
 
+    #[compatible(Minion, JsonInput)]
     Sum(Metadata, Vec<Expression>),
 
-    #[solver(SAT)]
+    #[compatible(JsonInput, SAT)]
     Not(Metadata, Box<Expression>),
-    #[solver(SAT)]
+
+    #[compatible(JsonInput, SAT)]
     Or(Metadata, Vec<Expression>),
-    #[solver(SAT)]
+
+    #[compatible(JsonInput, SAT)]
     And(Metadata, Vec<Expression>),
 
+    #[compatible(JsonInput)]
     Eq(Metadata, Box<Expression>, Box<Expression>),
+
+    #[compatible(JsonInput)]
     Neq(Metadata, Box<Expression>, Box<Expression>),
+
+    #[compatible(JsonInput)]
     Geq(Metadata, Box<Expression>, Box<Expression>),
+
+    #[compatible(JsonInput)]
     Leq(Metadata, Box<Expression>, Box<Expression>),
+
+    #[compatible(JsonInput)]
     Gt(Metadata, Box<Expression>, Box<Expression>),
+
+    #[compatible(JsonInput)]
     Lt(Metadata, Box<Expression>, Box<Expression>),
 
     /* Flattened SumEq.
@@ -196,11 +210,13 @@ pub enum Expression {
     SumEq(Metadata, Vec<Expression>, Box<Expression>),
 
     // Flattened Constraints
-    #[solver(Minion)]
+    #[compatible(Minion)]
     SumGeq(Metadata, Vec<Expression>, Box<Expression>),
-    #[solver(Minion)]
+
+    #[compatible(Minion)]
     SumLeq(Metadata, Vec<Expression>, Box<Expression>),
-    #[solver(Minion)]
+
+    #[compatible(Minion)]
     Ineq(Metadata, Box<Expression>, Box<Expression>, Box<Expression>),
 }
 

--- a/crates/enum_compatability_macro/Cargo.toml
+++ b/crates/enum_compatability_macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "doc_solver_support"
+name = "enum_compatability_macro"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/enum_compatability_macro/src/lib.rs
+++ b/crates/enum_compatability_macro/src/lib.rs
@@ -1,3 +1,22 @@
+//! A macro to document enum variants with the things that they are compatible with.
+//!
+//!
+//! As well as documenting each variant, this macro also generates lists of all compatible variants
+//! for each "thing".
+//!
+//! # Motivation
+//!
+//! This macro is used in Conjure-Oxide, a constraint modelling tool with support for multiple
+//! backend solvers (e.g. Minion, SAT).
+//!
+//! The Conjure-Oxide AST is used as the singular representation for constraints models throughout
+//! its crate. A consequence of this is that the AST must contain all possible supported
+//! expressions for all solvers, as well as the high level Essence language it takes as input.
+//! Therefore, only a small subset of AST nodes are useful for a particular solver.
+//!
+//! The documentation this generates helps rewrite rule implementers determine which AST nodes are
+//! used for which backends by grouping AST nodes per solver.
+
 use std::collections::HashMap;
 
 use itertools::Itertools;
@@ -11,17 +30,17 @@ use syn::{
 // A nice S.O answer that helped write the syn code :)
 // https://stackoverflow.com/a/65182902
 
-struct RemoveSolverAttrs;
-impl VisitMut for RemoveSolverAttrs {
+struct RemoveCompatibleAttrs;
+impl VisitMut for RemoveCompatibleAttrs {
     fn visit_variant_mut(&mut self, i: &mut Variant) {
         // 1. generate docstring for variant
         // Supported by: minion, sat ...
         //
-        // 2. delete #[solver] attributes
+        // 2. delete #[compatible] attributes
 
         let mut solvers: Vec<String> = vec![];
         for attr in i.attrs.iter() {
-            if !attr.path().is_ident("solver") {
+            if !attr.path().is_ident("compatible") {
                 continue;
             }
             let nested = attr
@@ -41,32 +60,24 @@ impl VisitMut for RemoveSolverAttrs {
             i.attrs.push(doc_attr);
         }
 
-        i.attrs.retain(|attr| !attr.path().is_ident("solver"));
+        i.attrs.retain(|attr| !attr.path().is_ident("compatible"));
     }
 }
 
-/// A macro to document the AST's variants by the solvers they support.
+/// A macro to document enum variants by the things that they are compatible with.
 ///
-/// The Conjure-Oxide AST is used as the singular intermediate language between input and solvers.
-/// A consequence of this is that the AST contains all possible supported expressions for all
-/// solvers, as well as the high level Essence language we take as input. A given
-/// solver only "supports" a small subset of the AST, and will reject the rest.
-///
-/// The documentation this generates helps determine which AST nodes are used for which backends,
-/// to help rule writers.
-///
-/// # Example
+/// # Examples
 ///
 /// ```
-/// use doc_solver_support::doc_solver_support;
+/// use enum_compatability_macro::document_compatibility;
 ///
-/// #[doc_solver_support]
+/// #[document_compatibility]
 /// pub enum Expression {
-///    #[solver(Minion)]
+///    #[compatible(Minion)]
 ///    ConstantInt(i32),
 ///    // ...
-///    #[solver(Chuffed)]
-///    #[solver(Minion)]
+///    #[compatible(Chuffed)]
+///    #[compatible(Minion)]
 ///    Sum(Vec<Expression>)
 ///    }
 /// ```
@@ -87,34 +98,34 @@ impl VisitMut for RemoveSolverAttrs {
 /// Two equivalent syntaxes exist for specifying supported solvers:
 ///
 /// ```
-///# use doc_solver_support::doc_solver_support;
+///# use enum_compatability_macro::document_compatibility;
 ///#
-///# #[doc_solver_support]
+///# #[document_compatibility]
 ///# pub enum Expression {
-///#    #[solver(Minion)]
+///#    #[compatible(Minion)]
 ///#    ConstantInt(i32),
 ///#    // ...
-///     #[solver(Chuffed)]
-///     #[solver(Minion)]
+///     #[compatible(Chuffed)]
+///     #[compatible(Minion)]
 ///     Sum(Vec<Expression>)
 ///#    }
 /// ```
 ///
 /// ```
-///# use doc_solver_support::doc_solver_support;
+///# use enum_compatability_macro::document_compatibility;
 ///#
-///# #[doc_solver_support]
+///# #[document_compatibility]
 ///# pub enum Expression {
-///#    #[solver(Minion)]
+///#    #[compatible(Minion)]
 ///#    ConstantInt(i32),
 ///#    // ...
-///     #[solver(Minion,Chuffed)]
+///     #[compatible(Minion,Chuffed)]
 ///     Sum(Vec<Expression>)
 ///#    }
 /// ```
 ///
 #[proc_macro_attribute]
-pub fn doc_solver_support(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub fn document_compatibility(_attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let mut input = parse_macro_input!(input as ItemEnum);
     let mut nodes_supported_by_solver: HashMap<String, Vec<syn::Ident>> = HashMap::new();
@@ -123,7 +134,7 @@ pub fn doc_solver_support(_attr: TokenStream, input: TokenStream) -> TokenStream
     for variant in input.variants.iter() {
         let variant_ident = variant.ident.clone();
         for attr in variant.attrs.iter() {
-            if !attr.path().is_ident("solver") {
+            if !attr.path().is_ident("compatible") {
                 continue;
             }
 
@@ -147,16 +158,16 @@ pub fn doc_solver_support(_attr: TokenStream, input: TokenStream) -> TokenStream
         }
     }
 
-    // we must remove all references to #[solver] before we finish expanding the macro,
+    // we must remove all references to #[compatible] before we finish expanding the macro,
     // as it does not exist outside of the context of this macro.
-    RemoveSolverAttrs.visit_item_enum_mut(&mut input);
+    RemoveCompatibleAttrs.visit_item_enum_mut(&mut input);
 
     // Build the doc string.
 
     // Note that quote wants us to build the doc message first, as it cannot interpolate doc
     // comments well.
     // https://docs.rs/quote/latest/quote/macro.quote.html#interpolating-text-inside-of-doc-comments
-    let mut doc_msg: String = "# Solver Support\n".into();
+    let mut doc_msg: String = "# Compatability\n".into();
     for solver in nodes_supported_by_solver.keys() {
         // a nice title
         doc_msg.push_str(&format!("## {}\n", solver));


### PR DESCRIPTION
AST nodes (and enum variants generally) can support things that arn't just solvers!

Closes #166 