### PR TITLE
(WIP) Derive macros for uniplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,9 +606,9 @@ checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -949,6 +949,7 @@ version = "0.1.0"
 name = "uniplate_derive"
 version = "0.1.0"
 dependencies = [
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.52",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,8 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "uniplate",
+ "uniplate_derive",
  "versions",
  "walkdir",
 ]
@@ -942,6 +944,15 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 [[package]]
 name = "uniplate"
 version = "0.1.0"
+
+[[package]]
+name = "uniplate_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/conjure_rules_proc_macro",
     "crates/conjure_rules",
     "crates/uniplate",
+    "crates/uniplate_derive",
     "solvers/kissat",
     "solvers/minion",
     "solvers/chuffed",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -11,6 +11,8 @@ walkdir = "2.5.0"
 [dependencies]
 conjure_core = {path = "../crates/conjure_core" }
 conjure_rules = {path = "../crates/conjure_rules" }
+uniplate = {path = "../crates/uniplate"}
+uniplate_derive = {path = "../crates/uniplate_derive" }
 
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"

--- a/conjure_oxide/tests/macro_tests.rs
+++ b/conjure_oxide/tests/macro_tests.rs
@@ -1,0 +1,13 @@
+use uniplate_derive::Uniplate;
+use uniplate::uniplate::Uniplate;
+
+#[test]
+fn derive_children() {
+    #[derive(Clone, PartialEq, Eq, Uniplate)]
+    enum TestEnum {
+        A(i32),
+        B(bool),
+    }
+
+
+}

--- a/conjure_oxide/tests/macro_tests.rs
+++ b/conjure_oxide/tests/macro_tests.rs
@@ -29,6 +29,15 @@ fn derive_context_box() {
 }
 
 #[test]
+fn derive_context_vec() {
+    let a = TestEnum::A(1);
+    let b = TestEnum::B(Box::new(TestEnum::A(2)));
+    let c = TestEnum::C(vec![a.clone(), b.clone()]);
+    let context = c.uniplate().1;
+    assert_eq!(context(vec![a.clone(), b.clone()]), c);
+}
+
+#[test]
 fn derive_children_empty() {
     let a = TestEnum::A(42);
     let children = a.uniplate().0;

--- a/conjure_oxide/tests/macro_tests.rs
+++ b/conjure_oxide/tests/macro_tests.rs
@@ -6,8 +6,11 @@ fn derive_children() {
     #[derive(Clone, PartialEq, Eq, Uniplate)]
     enum TestEnum {
         A(i32),
-        B(bool),
+        B(Box<TestEnum>),
+        C(Vec<TestEnum>),
+        // D([Box<TestEnum>; 2]),
+        // E((Box<TestEnum>, Box<TestEnum>)),
+        F((Box<TestEnum>, i32)),
+        I,
     }
-
-
 }

--- a/conjure_oxide/tests/macro_tests.rs
+++ b/conjure_oxide/tests/macro_tests.rs
@@ -14,6 +14,21 @@ enum TestEnum {
 }
 
 #[test]
+fn derive_context_empty() {
+    let a = TestEnum::A(42);
+    let context = a.uniplate().1;
+    assert_eq!(context(vec![]), a)
+}
+
+#[test]
+fn derive_context_box() {
+    let a = TestEnum::A(42);
+    let b = TestEnum::B(Box::new(a.clone()));
+    let context = b.uniplate().1;
+    assert_eq!(context(vec![a.clone()]), b);
+}
+
+#[test]
 fn derive_children_empty() {
     let a = TestEnum::A(42);
     let children = a.uniplate().0;

--- a/conjure_oxide/tests/macro_tests.rs
+++ b/conjure_oxide/tests/macro_tests.rs
@@ -1,16 +1,90 @@
-use uniplate_derive::Uniplate;
 use uniplate::uniplate::Uniplate;
+use uniplate_derive::Uniplate;
+
+#[derive(Clone, Debug, PartialEq, Eq, Uniplate)]
+enum TestEnum {
+    A(i32),
+    B(Box<TestEnum>),
+    C(Vec<TestEnum>),
+    D(bool, Box<TestEnum>),
+    E(Box<TestEnum>, Box<TestEnum>),
+    F((Box<TestEnum>, Box<TestEnum>)),
+    G((Box<TestEnum>, (Box<TestEnum>, i32))),
+    H(Vec<Vec<TestEnum>>),
+}
 
 #[test]
-fn derive_children() {
-    #[derive(Clone, PartialEq, Eq, Uniplate)]
-    enum TestEnum {
-        A(i32),
-        B(Box<TestEnum>),
-        C(Vec<TestEnum>),
-        // D([Box<TestEnum>; 2]),
-        // E((Box<TestEnum>, Box<TestEnum>)),
-        F((Box<TestEnum>, i32)),
-        I,
-    }
+fn derive_children_empty() {
+    let a = TestEnum::A(42);
+    let children = a.uniplate().0;
+    assert_eq!(children, vec![]);
+}
+
+#[test]
+fn derive_children_box() {
+    let b = TestEnum::B(Box::new(TestEnum::A(42)));
+    let children = b.uniplate().0;
+    assert_eq!(children, vec![TestEnum::A(42)]);
+}
+
+#[test]
+fn derive_children_vec() {
+    let c = TestEnum::C(vec![TestEnum::A(1), TestEnum::B(Box::new(TestEnum::A(2)))]);
+    let children = c.uniplate().0;
+    assert_eq!(
+        children,
+        vec![TestEnum::A(1), TestEnum::B(Box::new(TestEnum::A(2))),]
+    );
+}
+
+#[test]
+fn derive_children_two() {
+    let d = TestEnum::D(true, Box::new(TestEnum::A(42)));
+    let children = d.uniplate().0;
+    assert_eq!(children, vec![TestEnum::A(42)]);
+}
+
+#[test]
+fn derive_children_tuple() {
+    let e = TestEnum::F((Box::new(TestEnum::A(1)), Box::new(TestEnum::A(2))));
+    let children = e.uniplate().0;
+    assert_eq!(children, vec![TestEnum::A(1), TestEnum::A(2),]);
+}
+
+#[test]
+fn derive_children_different_variants() {
+    let f = TestEnum::E(
+        Box::new(TestEnum::A(1)),
+        Box::new(TestEnum::B(Box::new(TestEnum::A(2)))),
+    );
+    let children = f.uniplate().0;
+    assert_eq!(
+        children,
+        vec![TestEnum::A(1), TestEnum::B(Box::new(TestEnum::A(2)))]
+    );
+}
+
+#[test]
+fn derive_children_nested_tuples() {
+    let g = TestEnum::G((Box::new(TestEnum::A(1)), (Box::new(TestEnum::A(2)), 42)));
+    let children = g.uniplate().0;
+    assert_eq!(children, vec![TestEnum::A(1), TestEnum::A(2)])
+}
+
+#[test]
+fn derive_children_nested_vectors() {
+    let h = TestEnum::H(vec![
+        vec![TestEnum::A(1), TestEnum::A(2)],
+        vec![TestEnum::A(3), TestEnum::A(4)],
+    ]);
+    let children = h.uniplate().0;
+    assert_eq!(
+        children,
+        vec![
+            TestEnum::A(1),
+            TestEnum::A(2),
+            TestEnum::A(3),
+            TestEnum::A(4)
+        ]
+    )
 }

--- a/crates/uniplate/src/lib.rs
+++ b/crates/uniplate/src/lib.rs
@@ -104,6 +104,4 @@
 //! * Huet G. The Zipper. Journal of Functional Programming. 1997;7(5):549–54. <https://doi.org/10.1017/S0956796897002864>
 //! [(free copy)](https://www.cambridge.org/core/services/aop-cambridge-core/content/view/0C058890B8A9B588F26E6D68CF0CE204/S0956796897002864a.pdf/zipper.pdf)
 
-//!
-
 pub mod uniplate;

--- a/crates/uniplate_derive/Cargo.toml
+++ b/crates/uniplate_derive/Cargo.toml
@@ -1,13 +1,17 @@
 [package]
-name = "uniplate"
+name = "uniplate_derive"
 version = "0.1.0"
 edition = "2021"
 description="Boilerplate-free generic operations on data, Haskell style."
 license = "MPL-2.0"
 
 [lib]
+proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.78"
+syn = "2.0.52"
+quote = "1.0.35"
 
 [lints]
 workspace = true

--- a/crates/uniplate_derive/Cargo.toml
+++ b/crates/uniplate_derive/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 proc-macro2 = "1.0.78"
 syn = "2.0.52"
 quote = "1.0.35"
+log = "0.4.21"
 
 [lints]
 workspace = true

--- a/crates/uniplate_derive/src/lib.rs
+++ b/crates/uniplate_derive/src/lib.rs
@@ -1,60 +1,247 @@
 use proc_macro::{self, TokenStream};
-use proc_macro2::{TokenStream as TokenStream2};
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, DeriveInput, Data, DataEnum, Fields, Ident};
+use syn::{parse_macro_input, DeriveInput, Data, DataEnum, Fields, Ident, Type, PathArguments, GenericArgument, Expr};
+use syn::spanned::Spanned;
+use syn::token::Underscore;
+use crate::UniplateField::Unknown;
+
+enum ParseTypeArgumentError {
+    NoTypeArguments,
+    EmptyTypeArguments,
+    MultipleTypeArguments,
+    TypeArgumentNotAType,
+    TypeArgumentValueNotPath,
+    TypeArgumentEmptyPath,
+}
+
+enum UniplateField {
+    Identifier(Ident),
+    Box(Span, Box<UniplateField>),
+    Vector(Span, Box<UniplateField>),
+    Tuple(Span, Vec<UniplateField>),
+    Array(Span, Box<UniplateField>, Expr),
+    Unknown(Span),
+}
+
+fn get_span(field: &UniplateField) -> Span {
+    match field {
+        UniplateField::Identifier(idnt) => idnt.span(),
+        UniplateField::Box(spn, _) => *spn,
+        UniplateField::Vector(spn, _) => *spn,
+        UniplateField::Tuple(spn, _) => *spn,
+        UniplateField::Array(spn, _, _) => *spn,
+        UniplateField::Unknown(spn) => *spn
+    }
+}
+
+fn parse_type_argument(seg_args: &PathArguments) -> Result<&Ident, ParseTypeArgumentError> {
+    match seg_args {
+        PathArguments::AngleBracketed(type_args) => {
+            if type_args.args.len() > 1 {
+                return Err(ParseTypeArgumentError::MultipleTypeArguments);
+            }
+
+            match type_args.args.last() {
+                None => Err(ParseTypeArgumentError::EmptyTypeArguments),
+                Some(arg) => {
+                    match arg {
+                        GenericArgument::Type(tp) => {
+                            match tp {
+                                Type::Path(pth) => {
+                                    match pth.path.segments.last() {
+                                        Some(seg) => Ok(&seg.ident),
+                                        None => Err(ParseTypeArgumentError::TypeArgumentEmptyPath)
+                                    }
+                                }
+                                _ => Err(ParseTypeArgumentError::TypeArgumentValueNotPath)
+                            }
+                        }
+                        _ => Err(ParseTypeArgumentError::TypeArgumentNotAType)
+                    }
+                }
+            }
+        }
+        _ => Err(ParseTypeArgumentError::NoTypeArguments)
+    }
+}
+
+fn parse_field_type(field_type: &Type) -> UniplateField {
+    match field_type {
+        Type::Path(path) => match path.path.segments.last() {
+            None => Unknown(path.span()),
+            Some(seg) => {
+                let ident = &seg.ident;
+                let span = ident.span();
+                let args = &seg.arguments;
+
+                let box_ident = &Ident::new("Box", span);
+                let vec_ident = &Ident::new("Vec", span);
+
+                if ident.eq(box_ident) {
+                    match parse_type_argument(args) {
+                        Ok(idnt) => UniplateField::Box(path.span(), Box::new(UniplateField::Identifier(idnt.clone()))),
+                        Err(_) => Unknown(ident.span())
+                    }
+                } else if ident.eq(vec_ident) {
+                    match parse_type_argument(args) {
+                        Ok(idnt) => UniplateField::Vector(path.span(), Box::new(UniplateField::Identifier(idnt.clone()))),
+                        Err(_) => Unknown(ident.span())
+                    }
+                } else {
+                    UniplateField::Identifier(ident.clone())
+                }
+            }
+        }
+        Type::Tuple(tpl) => UniplateField::Tuple(tpl.span(), tpl.elems.iter().map(parse_field_type).collect()),
+        Type::Array(arr) => UniplateField::Array(arr.span(), Box::new(parse_field_type(arr.elem.as_ref())), arr.len.clone()),
+        _ => Unknown(field_type.span()) // ToDo discuss - Can we support any of: BareFn, Group, ImplTrait, Infer, Macro, Never, Paren, Ptr, Reference, TraitObject, Verbatim
+    }
+}
+
+fn check_field_type(ft: &UniplateField, root_ident: &Ident) -> bool {
+    match ft {
+        UniplateField::Identifier(ident) => ident.eq(root_ident),
+        UniplateField::Box(_, subfield) => check_field_type(subfield.as_ref(), root_ident),
+        UniplateField::Vector(_, subfield) => check_field_type(subfield.as_ref(), root_ident),
+        UniplateField::Tuple(_, subfields) => {
+            for sft in subfields {
+                if check_field_type(sft, root_ident) {
+                    return true;
+                }
+            }
+            false
+        }
+        UniplateField::Array(_, arr_type, _) => check_field_type(arr_type.as_ref(), root_ident),
+        UniplateField::Unknown(_) => false
+    }
+}
+
+fn field_type_to_ident(ft: &UniplateField, field_name: String, root_ident: &Ident) -> TokenStream2 {
+    let span = get_span(ft);
+
+    match ft {
+        UniplateField::Identifier(_) => {
+            if check_field_type(ft, root_ident) {
+                return Ident::new(&format!("{}_idn", field_name), span).into_token_stream()
+            }
+        }
+        UniplateField::Vector(_, sft) => {
+            if check_field_type(sft, root_ident) {
+                return Ident::new(&format!("{}_vec", field_name), span).into_token_stream()
+            }
+        }
+        UniplateField::Box(_, sft) => {
+            if check_field_type(sft, root_ident) {
+                return Ident::new(&format!("{}_box", field_name), span).into_token_stream()
+            }
+        }
+        UniplateField::Tuple(_, subfields) => {
+            let mut subfield_idents: Vec<TokenStream2> = Vec::new();
+
+            for (i, sft) in subfields.iter().enumerate() {
+                let sfname = format!("{}_tpl_{}", field_name, i);
+                subfield_idents.push(field_type_to_ident(sft, sfname, root_ident));
+            }
+
+            return quote! {
+                (#(#subfield_idents,)*)
+            }
+        },
+        UniplateField::Array(_, of_type, _) => {
+            if check_field_type(of_type, root_ident) {
+                return Ident::new(&format!("{}_arr", field_name), span).into_token_stream()
+            }
+        }
+        UniplateField::Unknown(_) => {}
+    }
+
+    Underscore(span).into_token_stream()
+}
+
+fn get_field_identifiers(fields: &Fields, root_ident: &Ident) -> Vec<TokenStream2> {
+    return fields.iter().enumerate().map(|(idx, field)| {
+        let span = field.span();
+        let field_name = match &field.ident {
+            None => format!("field{}", idx),
+            Some(ident) => ident.to_string()
+        };
+        let field_type = parse_field_type(&field.ty);
+
+        field_type_to_ident(&field_type, field_name, root_ident)
+    }).collect()
+}
+
+fn get_field_clones(fields: &Fields, root_ident: &Ident) -> Vec<TokenStream2> {
+    let mut ans: Vec<TokenStream2> = Vec::new();
+
+    ans
+}
 
 #[proc_macro_derive(Uniplate)]
 pub fn derive(macro_input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(macro_input as DeriveInput);
-    let enum_ident = &input.ident;
+    let root_ident = &input.ident;
     let data = &input.data;
 
     let children_impl: TokenStream2 = match data {
-        Data::Struct(_) => {unimplemented!("Structs currently not supported")}
-        Data::Union(_) => {unimplemented!("Unions currently not supported")}
-        Data::Enum(DataEnum {variants, ..}) => {
+        Data::Struct(_) => { unimplemented!("Structs currently not supported") }
+        Data::Union(_) => { unimplemented!("Unions currently not supported") }
+        Data::Enum(DataEnum { variants, .. }) => {
             let match_arms: Vec<TokenStream2> = variants.iter().map(|variant| {
+                let field_idents = get_field_identifiers(&variant.fields, root_ident);
+                let field_clones = get_field_clones(&variant.fields, root_ident);
                 let variant_ident = &variant.ident;
 
-                let field_names: Vec<Ident> = match &variant.fields {
-                    Fields::Unit => {todo!()}
-                    Fields::Named(_) => {todo!()}
-                    Fields::Unnamed(fields) => {
-                        fields.unnamed.iter().enumerate().map(|(idx, field)| {
-                            let field_name = &format!("field_{}", idx);
-                            Ident::new(field_name, enum_ident.span())
-                        }).collect::<Vec<Ident>>()
+                let match_pattern = if field_idents.is_empty() {
+                    quote! {
+                        #root_ident::#variant_ident
+                    }
+                } else {
+                    quote! {
+                        #root_ident::#variant_ident(#(#field_idents,)*)
                     }
                 };
 
-                quote! {
-                    #enum_ident::#variant_ident(#(#field_names)*) => {
-
+                let mach_arm = quote! {
+                     #match_pattern => {
+                        vec![#(#field_clones,)*]
                     }
-                }
+                };
+
+                println!("Generated match arm: {}", mach_arm.to_string());
+
+                mach_arm
             }).collect::<Vec<_>>();
 
-            quote! {
+            let match_statement = quote! {
                 match self {
                     #(#match_arms)*
                 }
-            }
+            };
+
+            println!("Generated match statement for {}: \n{}", root_ident.to_string(), match_statement.to_string());
+
+            match_statement
         }
     };
 
     let output = quote! {
-        impl Uniplate for #enum_ident {
-            fn uniplate(&self) -> (Vec<#enum_ident>, Box<dyn Fn(Vec<#enum_ident>) -> #enum_ident +'_>) {
-                let context: Box<dyn Fn(Vec<#enum_ident>) -> #enum_ident> = match self {
-                    _ => Box::new(|Vec<#enum_ident>| #enum_ident::A(0))
+        impl Uniplate for #root_ident {
+            fn uniplate(&self) -> (Vec<#root_ident>, Box<dyn Fn(Vec<#root_ident>) -> #root_ident +'_>) {
+                let context: Box<dyn Fn(Vec<#root_ident>) -> #root_ident> = match self {
+                    _ => Box::new(|children| #root_ident::A(0))
                 };
 
-                let children: Vec<#enum_ident> = #children_impl;
+                let children: Vec<#root_ident> = #children_impl;
 
                 (children, context)
             }
         }
     };
+
+    println!("Final macro output:\n{}", output.to_string());
+
     output.into()
 }
 

--- a/crates/uniplate_derive/src/lib.rs
+++ b/crates/uniplate_derive/src/lib.rs
@@ -1,0 +1,77 @@
+use proc_macro::{self, TokenStream};
+use proc_macro2::{TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, DeriveInput, Data, DataEnum, Fields, Ident};
+
+#[proc_macro_derive(Uniplate)]
+pub fn derive(macro_input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(macro_input as DeriveInput);
+    let enum_ident = &input.ident;
+    let data = &input.data;
+
+    let children_impl: TokenStream2 = match data {
+        Data::Struct(_) => {unimplemented!("Structs currently not supported")}
+        Data::Union(_) => {unimplemented!("Unions currently not supported")}
+        Data::Enum(DataEnum {variants, ..}) => {
+            let match_arms: Vec<TokenStream2> = variants.iter().map(|variant| {
+                let variant_ident = &variant.ident;
+
+                let field_names: Vec<Ident> = match &variant.fields {
+                    Fields::Unit => {todo!()}
+                    Fields::Named(_) => {todo!()}
+                    Fields::Unnamed(fields) => {
+                        fields.unnamed.iter().enumerate().map(|(idx, field)| {
+                            let field_name = &format!("field_{}", idx);
+                            Ident::new(field_name, enum_ident.span())
+                        }).collect::<Vec<Ident>>()
+                    }
+                };
+
+                quote! {
+                    #enum_ident::#variant_ident(#(#field_names)*) => {
+
+                    }
+                }
+            }).collect::<Vec<_>>();
+
+            quote! {
+                match self {
+                    #(#match_arms)*
+                }
+            }
+        }
+    };
+
+    let output = quote! {
+        impl Uniplate for #enum_ident {
+            fn uniplate(&self) -> (Vec<#enum_ident>, Box<dyn Fn(Vec<#enum_ident>) -> #enum_ident +'_>) {
+                let context: Box<dyn Fn(Vec<#enum_ident>) -> #enum_ident> = match self {
+                    _ => Box::new(|Vec<#enum_ident>| #enum_ident::A(0))
+                };
+
+                let children: Vec<#enum_ident> = #children_impl;
+
+                (children, context)
+            }
+        }
+    };
+    output.into()
+}
+
+/*
+let context: Box<dyn Fn(Vec<AST>) -> AST> = match self {
+//!             AST::Int(i) =>    Box::new(|_| AST::Int(*i)),
+//!             AST::Add(_, _) => Box::new(|exprs: Vec<AST>| AST::Add(Box::new(exprs[0].clone()),Box::new(exprs[1].clone()))),
+//!             AST::Sub(_, _) => Box::new(|exprs: Vec<AST>| AST::Sub(Box::new(exprs[0].clone()),Box::new(exprs[1].clone()))),
+//!             AST::Div(_, _) => Box::new(|exprs: Vec<AST>| AST::Div(Box::new(exprs[0].clone()),Box::new(exprs[1].clone()))),
+//!             AST::Mul(_, _) => Box::new(|exprs: Vec<AST>| AST::Mul(Box::new(exprs[0].clone()),Box::new(exprs[1].clone())))
+//!         };
+//!
+//!         let children: Vec<AST> = match self {
+//!             AST::Add(a,b) => vec![*a.clone(),*b.clone()],
+//!             AST::Sub(a,b) => vec![*a.clone(),*b.clone()],
+//!             AST::Div(a,b) => vec![*a.clone(),*b.clone()],
+//!             AST::Mul(a,b) => vec![*a.clone(),*b.clone()],
+//!             _ => vec![]
+//!         };
+ */


### PR DESCRIPTION
This PR implements a derive macro for the Uniplate trait for arbitrary enums.

What is supported:
- Types other than the original enum (these will be ignored by children() and put back by context())
- Boxes
- Vec's
- Any tuples of the above, including nested tuples
- Nested Vec's, although more testing needed

This is not ready - I want to clean up code and test properly first