### PR TITLE
solver: make SolverAdaptor object safe

### DIFF
--- a/crates/conjure_core/src/solver/adaptors/kissat.rs
+++ b/crates/conjure_core/src/solver/adaptors/kissat.rs
@@ -15,6 +15,7 @@ use super::sat_common::CNFModel;
 /// A [SolverAdaptor] for interacting with the Kissat SAT solver.
 pub struct Kissat {
     __non_constructable: private::Internal,
+    model: Option<CNFModel>,
 }
 
 impl private::Sealed for Kissat {}
@@ -23,6 +24,7 @@ impl Kissat {
     pub fn new() -> Self {
         Kissat {
             __non_constructable: private::Internal,
+            model: None,
         }
     }
 }
@@ -34,15 +36,8 @@ impl Default for Kissat {
 }
 
 impl SolverAdaptor for Kissat {
-    type Model = CNFModel;
-
-    type Solution = ();
-
-    type Modifier = NotModifiable;
-
     fn solve(
         &mut self,
-        model: Self::Model,
         callback: SolverCallback,
         _: private::Internal,
     ) -> Result<SolveSuccess, SolverError> {
@@ -51,19 +46,15 @@ impl SolverAdaptor for Kissat {
 
     fn solve_mut(
         &mut self,
-        model: Self::Model,
-        callback: SolverMutCallback<Self>,
+        callback: SolverMutCallback,
         _: private::Internal,
     ) -> Result<SolveSuccess, SolverError> {
         Err(OpNotSupported("solve_mut".to_owned()))
     }
 
-    fn load_model(
-        &mut self,
-        model: ConjureModel,
-        _: private::Internal,
-    ) -> Result<Self::Model, SolverError> {
-        CNFModel::from_conjure(model)
+    fn load_model(&mut self, model: ConjureModel, _: private::Internal) -> Result<(), SolverError> {
+        self.model = Some(CNFModel::from_conjure(model)?);
+        Ok(())
     }
 
     fn get_family(&self) -> SolverFamily {


### PR DESCRIPTION
In Rust, a trait T is "object safe" if it can be stored and used as a type. Non object safe traits do not allow type erasure or the storing any implementer of the trait as a Box<dyn Foo>.

See: https://doc.rust-lang.org/reference/items/traits.html#object-safety

The point of the solver adaptor in the first place was to be solver independent and generic - therefore, object safety is necessary. In particular, @gskorokhod wanted to put this into the global context so that we can define what SolverAdaptor to use depending on CLI arguments.

The idea is that we should "be a Java interface". The associated types of the trait are not needed, and the encapsulation should be strengthened such that the adaptor implementation does not even need to announce what types it uses internally in the first place.

On testing, context compiles with a SolverAdaptor inside it. Actually adding this properly is work for a future PR.

Credit for this goes entirely to @gskorokhod (I just code monkeyed!).