### PR TITLE
Save context to info.json, and print json schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ conjure_oxide/tests/**/*.generated-parse.*
 conjure_oxide/tests/**/*.generated-rewrite.*
 conjure_oxide/tests/**/*.generated-minion.*
 
+*-stats.json
+
 
 *.profraw
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 coverage
+info.json
 
 conjure_oxide/tests/**/*.generated.*
 conjure_oxide/tests/**/*.generated-parse.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "minion_rs",
  "project-root",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -356,6 +357,7 @@ dependencies = [
  "log",
  "minion_rs",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -462,6 +464,12 @@ dependencies = [
  "quote 0.3.15",
  "syn 0.11.11",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -1132,6 +1140,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1187,17 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.35",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "conjure_rules_proc_macro",
+ "derivative",
  "derive_is_enum_variant",
  "enum_compatability_macro",
  "linkme",
@@ -427,6 +428,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -29,6 +29,7 @@ itertools = "0.12.1"
 regex = "1.10.3"
 log = "0.4.21"
 structured-logger = "1.0.3"
+schemars = "0.8.16"
 
 [features]
 

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::io::stdout;
 use std::path::PathBuf;
 use std::process::exit;
-use std::sync::{Arc, RwLock};
 
 use anyhow::Result as AnyhowResult;
 use anyhow::{anyhow, bail};

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::stdout;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result as AnyhowResult;
 use anyhow::{anyhow, bail};
@@ -99,15 +100,15 @@ pub fn main() -> AnyhowResult<()> {
     }
 
     let astjson = String::from_utf8(output.stdout)?;
-    let mut model = model_from_json(&astjson)?;
 
-    let context = Context::new(
+    let context = Context::new_ptr(
         target_family,
         extra_rule_sets.clone(),
         rules_vec.clone(),
         rule_sets.clone(),
     );
-    model.set_context(context);
+
+    let mut model = model_from_json(&astjson, context.clone())?;
 
     log::info!("Initial model: {}", to_string_pretty(&json!(model))?);
 

--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -74,14 +74,19 @@ pub fn get_minion_solutions(model: Model) -> Result<Vec<HashMap<Name, Constant>>
     let all_solutions_ref = Arc::new(Mutex::<Vec<HashMap<Name, Constant>>>::new(vec![]));
     let all_solutions_ref_2 = all_solutions_ref.clone();
     #[allow(clippy::unwrap_used)]
-    solver.solve(Box::new(move |sols| {
-        let mut all_solutions = (*all_solutions_ref_2).lock().unwrap();
-        (*all_solutions).push(sols);
-        true
-    }))?;
+    let solver = solver
+        .solve(Box::new(move |sols| {
+            let mut all_solutions = (*all_solutions_ref_2).lock().unwrap();
+            (*all_solutions).push(sols);
+            true
+        }))
+        .unwrap();
+
+    solver.save_stats_to_context();
 
     #[allow(clippy::unwrap_used)]
     let sols = (*all_solutions_ref).lock().unwrap();
+
     Ok((*sols).clone())
 }
 

--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
+use conjure_core::context::Context;
 use serde_json::{Map, Value as JsonValue};
 use thiserror::Error as ThisError;
 
@@ -26,7 +27,11 @@ impl From<ParseErr> for EssenceParseError {
     }
 }
 
-pub fn parse_essence_file(path: &str, filename: &str) -> Result<Model, EssenceParseError> {
+pub fn parse_essence_file(
+    path: &str,
+    filename: &str,
+    context: Arc<RwLock<Context<'static>>>,
+) -> Result<Model, EssenceParseError> {
     let mut cmd = std::process::Command::new("conjure");
     let output = match cmd
         .arg("pretty")
@@ -54,7 +59,7 @@ pub fn parse_essence_file(path: &str, filename: &str) -> Result<Model, EssencePa
         }
     };
 
-    let parsed_model = model_from_json(&astjson)?;
+    let parsed_model = model_from_json(&astjson, context)?;
     Ok(parsed_model)
 }
 

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -80,7 +80,7 @@ pub fn save_stats_json(
     test_name: &str,
 ) -> Result<(), std::io::Error> {
     #[allow(clippy::unwrap_used)]
-    let stats = context.read().unwrap().stats.clone();
+    let stats = context.read().unwrap().clone();
     let generated_json = sort_json_object(&serde_json::to_value(stats)?, false);
 
     // serialise to string

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -24,6 +24,7 @@ fn main() {
     }
 }
 
+#[allow(clippy::unwrap_used)]
 fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>> {
     let context: Arc<RwLock<Context<'static>>> = Default::default();
     let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
@@ -41,6 +42,8 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     if verbose {
         println!("Parsed model: {:#?}", model)
     }
+
+    context.as_ref().write().unwrap().file_name = Some(format!("{path}/{essence_base}.essence"));
 
     save_model_json(&model, path, essence_base, "parse", accept)?;
     let expected_model = read_model_json(path, essence_base, "expected", "parse")?;

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -8,6 +8,7 @@ use conjure_core::context::Context;
 use conjure_oxide::rule_engine::resolve_rule_sets;
 use conjure_oxide::rule_engine::rewrite_model;
 use conjure_oxide::utils::conjure::{get_minion_solutions, parse_essence_file};
+use conjure_oxide::utils::testing::save_stats_json;
 use conjure_oxide::utils::testing::{
     read_minion_solutions_json, read_model_json, save_minion_solutions_json, save_model_json,
 };
@@ -36,7 +37,7 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     }
 
     // Stage 1: Read the essence file and check that the model is parsed correctly
-    let model = parse_essence_file(path, essence_base, context)?;
+    let model = parse_essence_file(path, essence_base, context.clone())?;
     if verbose {
         println!("Parsed model: {:#?}", model)
     }
@@ -77,6 +78,8 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     }
 
     assert_eq!(solutions_json, expected_solutions_json);
+
+    save_stats_json(context, path, essence_base)?;
 
     Ok(())
 }

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -1,7 +1,10 @@
 use std::env;
 use std::error::Error;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::RwLock;
 
+use conjure_core::context::Context;
 use conjure_oxide::rule_engine::resolve_rule_sets;
 use conjure_oxide::rule_engine::rewrite_model;
 use conjure_oxide::utils::conjure::{get_minion_solutions, parse_essence_file};
@@ -21,6 +24,7 @@ fn main() {
 }
 
 fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>> {
+    let context: Arc<RwLock<Context<'static>>> = Default::default();
     let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
     let verbose = env::var("VERBOSE").unwrap_or("false".to_string()) == "true";
 
@@ -32,7 +36,7 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     }
 
     // Stage 1: Read the essence file and check that the model is parsed correctly
-    let model = parse_essence_file(path, essence_base)?;
+    let model = parse_essence_file(path, essence_base, context)?;
     if verbose {
         println!("Parsed model: {:#?}", model)
     }

--- a/conjure_oxide/tests/model_tests.rs
+++ b/conjure_oxide/tests/model_tests.rs
@@ -20,7 +20,7 @@ fn modify_domain() {
     let mut m = Model::new(
         variables,
         Expression::And(Metadata::new(), Vec::new()),
-        Context::default(),
+        Default::default(),
     );
 
     assert_eq!(m.variables.get(&a).unwrap().domain, d1);

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -149,11 +149,11 @@ fn rule_sum_constants() {
     );
 
     expr = sum_constants
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     expr = unwrap_sum
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -177,7 +177,7 @@ fn rule_sum_mixed() {
     );
 
     expr = sum_constants
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -210,7 +210,7 @@ fn rule_sum_geq() {
     );
 
     expr = flatten_sum_geq
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -253,11 +253,11 @@ fn reduce_solve_xyz() {
     );
 
     expr1 = sum_constants
-        .apply(&expr1, &Model::default())
+        .apply(&expr1, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     expr1 = unwrap_sum
-        .apply(&expr1, &Model::default())
+        .apply(&expr1, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     assert_eq!(
@@ -279,7 +279,7 @@ fn reduce_solve_xyz() {
         Box::new(expr1),
     );
     expr1 = sum_leq_to_sumleq
-        .apply(&expr1, &Model::default())
+        .apply(&expr1, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     assert_eq!(
@@ -308,7 +308,7 @@ fn reduce_solve_xyz() {
         )),
     );
     expr2 = lt_to_ineq
-        .apply(&expr2, &Model::default())
+        .apply(&expr2, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     assert_eq!(
@@ -330,7 +330,7 @@ fn reduce_solve_xyz() {
     let mut model = Model::new(
         HashMap::new(),
         Expression::And(Metadata::new(), vec![expr1, expr2]),
-        Context::default(),
+        Default::default(),
     );
     model.variables.insert(
         Name::UserName(String::from("a")),
@@ -369,7 +369,7 @@ fn rule_remove_double_negation() {
     );
 
     expr = remove_double_negation
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -398,7 +398,7 @@ fn rule_unwrap_nested_or() {
     );
 
     expr = unwrap_nested_or
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -434,7 +434,7 @@ fn rule_unwrap_nested_and() {
     );
 
     expr = unwrap_nested_and
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -463,7 +463,7 @@ fn unwrap_nested_or_not_changed() {
         ],
     );
 
-    let result = unwrap_nested_or.apply(&expr, &Model::default());
+    let result = unwrap_nested_or.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -480,7 +480,7 @@ fn unwrap_nested_and_not_changed() {
         ],
     );
 
-    let result = unwrap_nested_and.apply(&expr, &Model::default());
+    let result = unwrap_nested_and.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -500,11 +500,11 @@ fn remove_trivial_and_or() {
     );
 
     expr_and = remove_trivial_and
-        .apply(&expr_and, &Model::default())
+        .apply(&expr_and, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
     expr_or = remove_trivial_or
-        .apply(&expr_or, &Model::default())
+        .apply(&expr_or, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -532,7 +532,7 @@ fn rule_remove_constants_from_or() {
     );
 
     expr = remove_constants_from_or
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -556,7 +556,7 @@ fn rule_remove_constants_from_and() {
     );
 
     expr = remove_constants_from_and
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -578,7 +578,7 @@ fn remove_constants_from_or_not_changed() {
         ],
     );
 
-    let result = remove_constants_from_or.apply(&expr, &Model::default());
+    let result = remove_constants_from_or.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -595,7 +595,7 @@ fn remove_constants_from_and_not_changed() {
         ],
     );
 
-    let result = remove_constants_from_and.apply(&expr, &Model::default());
+    let result = remove_constants_from_and.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -616,7 +616,7 @@ fn rule_distribute_not_over_and() {
     );
 
     expr = distribute_not_over_and
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -660,7 +660,7 @@ fn rule_distribute_not_over_or() {
     );
 
     expr = distribute_not_over_or
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap()
         .new_expression;
 
@@ -700,7 +700,7 @@ fn rule_distribute_not_over_and_not_changed() {
         )),
     );
 
-    let result = distribute_not_over_and.apply(&expr, &Model::default());
+    let result = distribute_not_over_and.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -717,7 +717,7 @@ fn rule_distribute_not_over_or_not_changed() {
         )),
     );
 
-    let result = distribute_not_over_or.apply(&expr, &Model::default());
+    let result = distribute_not_over_or.apply(&expr, &Model::new_empty(Default::default()));
 
     assert!(result.is_err());
 }
@@ -741,7 +741,7 @@ fn rule_distribute_or_over_and() {
     );
 
     let red = distribute_or_over_and
-        .apply(&expr, &Model::default())
+        .apply(&expr, &Model::new_empty(Default::default()))
         .unwrap();
 
     assert_eq!(
@@ -784,7 +784,7 @@ fn rule_distribute_or_over_and() {
 //         )),
 //     );
 
-//     let red = ensure_div.apply(&expr, &Model::default()).unwrap();
+//     let red = ensure_div.apply(&expr, &Model::new_empty(Default::default())).unwrap();
 
 //     assert_eq!(
 //         red.new_expression,
@@ -876,7 +876,7 @@ fn rewrite_solve_xyz() {
 
     // Apply rewrite function to the nested expression
     let rewritten_expr = rewrite_model(
-        &Model::new(HashMap::new(), nested_expr, Context::default()),
+        &Model::new(HashMap::new(), nested_expr, Default::default()),
         &rule_sets,
     )
     .unwrap()
@@ -887,7 +887,7 @@ fn rewrite_solve_xyz() {
     assert!(is_simple(&expr));
 
     // Create model with variables and constraints
-    let mut model = Model::new(HashMap::new(), rewritten_expr, Context::default());
+    let mut model = Model::new(HashMap::new(), rewritten_expr, Default::default());
 
     // Insert variables and domains
     model.variables.insert(
@@ -965,7 +965,7 @@ fn apply_all_rules<'a>(
 ) -> Vec<RuleResult<'a>> {
     let mut results = Vec::new();
     for rule in rules {
-        match rule.apply(expression, &Model::default()) {
+        match rule.apply(expression, &Model::new_empty(Default::default())) {
             Ok(red) => {
                 results.push(RuleResult {
                     rule,

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.21"
 anyhow = "1.0.81"
 regex = "1.10.4"
 walkdir = "2.5.0"
+derivative = "2.2.0"
 
 [lints]
 workspace = true

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1.0.81"
 regex = "1.10.4"
 walkdir = "2.5.0"
 derivative = "2.2.0"
+schemars = "0.8.16"
 
 [lints]
 workspace = true

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -1,17 +1,30 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
+use derivative::Derivative;
+use serde::Serialize;
+
 use crate::rule_engine::{Rule, RuleSet};
 use crate::solver::SolverFamily;
 use crate::stats::Stats;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Default, Derivative)]
+#[derivative(Eq, PartialEq)]
 #[non_exhaustive]
 pub struct Context<'a> {
-    pub target_solver_family: Arc<RwLock<Option<SolverFamily>>>,
-    pub extra_rule_set_names: Arc<RwLock<Vec<&'a str>>>,
-    pub rules: Arc<RwLock<Vec<&'a Rule<'a>>>>,
-    pub rule_sets: Arc<RwLock<Vec<&'a RuleSet<'a>>>>,
+    pub target_solver_family: Option<SolverFamily>,
+
+    pub file_name: Option<String>,
+
+    pub extra_rule_set_names: Vec<&'a str>,
+
+    #[serde(skip)]
+    pub rules: Vec<&'a Rule<'a>>,
+
+    #[serde(skip)]
+    pub rule_sets: Vec<&'a RuleSet<'a>>,
+
+    #[derivative(PartialEq = "ignore")]
     pub stats: Stats,
 }
 
@@ -23,11 +36,12 @@ impl<'a> Context<'a> {
         rule_sets: Vec<&'a RuleSet<'a>>,
     ) -> Self {
         Context {
-            target_solver_family: Arc::new(RwLock::new(Some(target_solver_family))),
-            extra_rule_set_names: Arc::new(RwLock::new(extra_rule_set_names)),
-            rules: Arc::new(RwLock::new(rules)),
-            rule_sets: Arc::new(RwLock::new(rule_sets)),
+            target_solver_family: Some(target_solver_family),
+            extra_rule_set_names,
+            rules,
+            rule_sets,
             stats: Default::default(),
+            ..Default::default()
         }
     }
 }
@@ -50,16 +64,10 @@ impl Context<'static> {
 
 impl<'a> Debug for Context<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let target_solver_family: Option<SolverFamily> = *self.target_solver_family.read().unwrap();
-        let extra_rule_set_names: Vec<&str> = self.extra_rule_set_names.read().unwrap().clone();
-        let rules: Vec<&str> = self.rules.read().unwrap().iter().map(|r| r.name).collect();
-        let rule_sets: Vec<&str> = self
-            .rule_sets
-            .read()
-            .unwrap()
-            .iter()
-            .map(|r| r.name)
-            .collect();
+        let target_solver_family: Option<SolverFamily> = self.target_solver_family;
+        let extra_rule_set_names: Vec<&str> = self.extra_rule_set_names.clone();
+        let rules: Vec<&str> = self.rules.iter().map(|r| r.name).collect();
+        let rule_sets: Vec<&str> = self.rule_sets.iter().map(|r| r.name).collect();
 
         write!(
             f,
@@ -71,38 +79,5 @@ impl<'a> Debug for Context<'a> {
         }}",
             target_solver_family, extra_rule_set_names, rules, rule_sets
         )
-    }
-}
-
-impl<'a> Default for Context<'a> {
-    fn default() -> Self {
-        Context {
-            target_solver_family: Arc::new(RwLock::new(None)),
-            extra_rule_set_names: Arc::new(RwLock::new(Vec::new())),
-            rules: Arc::new(RwLock::new(Vec::new())),
-            rule_sets: Arc::new(RwLock::new(Vec::new())),
-            stats: Default::default(),
-        }
-    }
-}
-
-impl PartialEq for Context<'_> {
-    #[allow(clippy::unwrap_used)] // A poisoned RWLock is probably panic worthy
-    fn eq(&self, other: &Self) -> bool {
-        self.target_solver_family
-            .read()
-            .unwrap()
-            .eq(&*other.target_solver_family.read().unwrap())
-            && self
-                .extra_rule_set_names
-                .read()
-                .unwrap()
-                .eq(&*other.extra_rule_set_names.read().unwrap())
-            && self.rules.read().unwrap().eq(&*other.rules.read().unwrap())
-            && self
-                .rule_sets
-                .read()
-                .unwrap()
-                .eq(&*other.rule_sets.read().unwrap())
     }
 }

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -11,6 +11,7 @@ use crate::stats::Stats;
 
 #[skip_serializing_none]
 #[derive(Clone, Serialize, Default, Derivative)]
+#[serde(rename_all = "camelCase")]
 #[derivative(Eq, PartialEq)]
 #[non_exhaustive]
 pub struct Context<'a> {

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 
 use crate::rule_engine::{Rule, RuleSet};
 use crate::solver::SolverFamily;
+use crate::stats::Stats;
 
 #[derive(Clone)]
 #[non_exhaustive]
@@ -11,6 +12,7 @@ pub struct Context<'a> {
     pub extra_rule_set_names: Arc<RwLock<Vec<&'a str>>>,
     pub rules: Arc<RwLock<Vec<&'a Rule<'a>>>>,
     pub rule_sets: Arc<RwLock<Vec<&'a RuleSet<'a>>>>,
+    pub stats: Stats,
 }
 
 impl<'a> Context<'a> {
@@ -25,7 +27,24 @@ impl<'a> Context<'a> {
             extra_rule_set_names: Arc::new(RwLock::new(extra_rule_set_names)),
             rules: Arc::new(RwLock::new(rules)),
             rule_sets: Arc::new(RwLock::new(rule_sets)),
+            stats: Default::default(),
         }
+    }
+}
+
+impl Context<'static> {
+    pub fn new_ptr(
+        target_solver_family: SolverFamily,
+        extra_rule_set_names: Vec<&'static str>,
+        rules: Vec<&'static Rule<'static>>,
+        rule_sets: Vec<&'static RuleSet<'static>>,
+    ) -> Arc<RwLock<Context<'static>>> {
+        Arc::new(RwLock::new(Context::new(
+            target_solver_family,
+            extra_rule_set_names,
+            rules,
+            rule_sets,
+        )))
     }
 }
 
@@ -62,6 +81,7 @@ impl<'a> Default for Context<'a> {
             extra_rule_set_names: Arc::new(RwLock::new(Vec::new())),
             rules: Arc::new(RwLock::new(Vec::new())),
             rule_sets: Arc::new(RwLock::new(Vec::new())),
+            stats: Default::default(),
         }
     }
 }
@@ -86,5 +106,3 @@ impl PartialEq for Context<'_> {
                 .eq(&*other.rule_sets.read().unwrap())
     }
 }
-
-impl Eq for Context<'_> {}

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -2,6 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
 use derivative::Derivative;
+use schemars::{schema_for, JsonSchema};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
@@ -10,7 +11,7 @@ use crate::solver::SolverFamily;
 use crate::stats::Stats;
 
 #[skip_serializing_none]
-#[derive(Clone, Serialize, Default, Derivative)]
+#[derive(Clone, Serialize, Default, Derivative, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[derivative(Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -3,11 +3,13 @@ use std::sync::{Arc, RwLock};
 
 use derivative::Derivative;
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 
 use crate::rule_engine::{Rule, RuleSet};
 use crate::solver::SolverFamily;
 use crate::stats::Stats;
 
+#[skip_serializing_none]
 #[derive(Clone, Serialize, Default, Derivative)]
 #[derivative(Eq, PartialEq)]
 #[non_exhaustive]

--- a/crates/conjure_core/src/lib.rs
+++ b/crates/conjure_core/src/lib.rs
@@ -11,3 +11,4 @@ pub mod parse;
 pub mod rule_engine;
 pub mod rules;
 pub mod solver;
+pub mod stats;

--- a/crates/conjure_core/src/parse/example_models.rs
+++ b/crates/conjure_core/src/parse/example_models.rs
@@ -1,5 +1,6 @@
 // example_models with get_example_model function
 
+use std::default;
 use std::path::PathBuf;
 
 use project_root::get_project_root;
@@ -59,7 +60,7 @@ pub fn get_example_model(filename: &str) -> Result<Model, anyhow::Error> {
     //println!("ASTJSON: {}", astjson);
 
     // parse AST JSON from desired Model format
-    let generated_mdl = model_from_json(&astjson)?;
+    let generated_mdl = model_from_json(&astjson, Default::default())?;
 
     Ok(generated_mdl)
 }
@@ -101,7 +102,7 @@ pub fn get_example_model_by_path(filepath: &str) -> Result<Model, anyhow::Error>
     // println!("ASTJSON: {}", astjson);
 
     // parse AST JSON into the desired Model format
-    let generated_model = model_from_json(&astjson)?;
+    let generated_model = model_from_json(&astjson, Default::default())?;
 
     Ok(generated_model)
 }

--- a/crates/conjure_core/src/parse/parse_model.rs
+++ b/crates/conjure_core/src/parse/parse_model.rs
@@ -1,15 +1,17 @@
 use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
 use serde_json::Value as JsonValue;
 
 use crate::ast::{Constant, DecisionVariable, Domain, Expression, Name, Range};
+use crate::context::Context;
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
 use crate::Model;
 
-pub fn model_from_json(str: &str) -> Result<Model> {
-    let mut m = Model::default();
+pub fn model_from_json(str: &str, context: Arc<RwLock<Context<'static>>>) -> Result<Model> {
+    let mut m = Model::new_empty(context);
     let v: JsonValue = serde_json::from_str(str)?;
     let statements = v["mStatements"]
         .as_array()

--- a/crates/conjure_core/src/solver/adaptors/kissat.rs
+++ b/crates/conjure_core/src/solver/adaptors/kissat.rs
@@ -15,6 +15,7 @@ use super::sat_common::CNFModel;
 /// A [SolverAdaptor] for interacting with the Kissat SAT solver.
 pub struct Kissat {
     __non_constructable: private::Internal,
+    model: Option<CNFModel>,
 }
 
 impl private::Sealed for Kissat {}
@@ -23,6 +24,7 @@ impl Kissat {
     pub fn new() -> Self {
         Kissat {
             __non_constructable: private::Internal,
+            model: None,
         }
     }
 }
@@ -34,15 +36,8 @@ impl Default for Kissat {
 }
 
 impl SolverAdaptor for Kissat {
-    type Model = CNFModel;
-
-    type Solution = ();
-
-    type Modifier = NotModifiable;
-
     fn solve(
         &mut self,
-        model: Self::Model,
         callback: SolverCallback,
         _: private::Internal,
     ) -> Result<SolveSuccess, SolverError> {
@@ -51,19 +46,15 @@ impl SolverAdaptor for Kissat {
 
     fn solve_mut(
         &mut self,
-        model: Self::Model,
-        callback: SolverMutCallback<Self>,
+        callback: SolverMutCallback,
         _: private::Internal,
     ) -> Result<SolveSuccess, SolverError> {
         Err(OpNotSupported("solve_mut".to_owned()))
     }
 
-    fn load_model(
-        &mut self,
-        model: ConjureModel,
-        _: private::Internal,
-    ) -> Result<Self::Model, SolverError> {
-        CNFModel::from_conjure(model)
+    fn load_model(&mut self, model: ConjureModel, _: private::Internal) -> Result<(), SolverError> {
+        self.model = Some(CNFModel::from_conjure(model)?);
+        Ok(())
     }
 
     fn get_family(&self) -> SolverFamily {

--- a/crates/conjure_core/src/solver/adaptors/minion.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion.rs
@@ -127,7 +127,7 @@ impl SolverAdaptor for Minion {
             status = Complete(NoSolutions);
         }
         Ok(SolveSuccess {
-            stats: None,
+            stats: Default::default(),
             status,
         })
     }

--- a/crates/conjure_core/src/solver/adaptors/minion.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion.rs
@@ -151,6 +151,10 @@ impl SolverAdaptor for Minion {
     fn get_family(&self) -> SolverFamily {
         SolverFamily::Minion
     }
+
+    fn get_name(&self) -> Option<String> {
+        Some("adaptors::Minion".to_owned())
+    }
 }
 
 fn parse_vars(

--- a/crates/conjure_core/src/solver/mod.rs
+++ b/crates/conjure_core/src/solver/mod.rs
@@ -93,6 +93,7 @@ use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString};
 use thiserror::Error;
@@ -114,8 +115,20 @@ mod private;
 pub mod states;
 
 #[derive(
-    Debug, EnumString, EnumIter, Display, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize,
+    Debug,
+    EnumString,
+    EnumIter,
+    Display,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    JsonSchema,
 )]
+
 pub enum SolverFamily {
     SAT,
     Minion,

--- a/crates/conjure_core/src/solver/mod.rs
+++ b/crates/conjure_core/src/solver/mod.rs
@@ -84,9 +84,12 @@
 #![allow(unused)]
 #![allow(clippy::manual_non_exhaustive)]
 
+use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Debug, Display};
+use std::rc::Rc;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
@@ -94,15 +97,15 @@ use strum_macros::{Display, EnumIter, EnumString};
 use thiserror::Error;
 
 use crate::ast::{Constant, Name};
+use crate::context::Context;
+use crate::stats::SolverStats;
 use crate::Model;
 
-use self::model_modifier::*;
+use self::model_modifier::ModelModifier;
 use self::states::*;
-use self::stats::SolverStats;
 
 pub mod adaptors;
 pub mod model_modifier;
-pub mod stats;
 
 #[doc(hidden)]
 mod private;
@@ -219,6 +222,7 @@ pub trait SolverAdaptor: private::Sealed {
 pub struct Solver<A: SolverAdaptor, State: SolverState = Init> {
     state: State,
     adaptor: A,
+    context: Option<Arc<RwLock<Context<'static>>>>,
 }
 
 impl<Adaptor: SolverAdaptor> Solver<Adaptor> {
@@ -226,6 +230,7 @@ impl<Adaptor: SolverAdaptor> Solver<Adaptor> {
         let mut solver = Solver {
             state: Init,
             adaptor: solver_adaptor,
+            context: None,
         };
 
         solver.adaptor.init_solver(private::Internal);
@@ -239,10 +244,11 @@ impl<Adaptor: SolverAdaptor> Solver<Adaptor> {
 
 impl<A: SolverAdaptor> Solver<A, Init> {
     pub fn load_model(mut self, model: Model) -> Result<Solver<A, ModelLoaded>, SolverError> {
-        let solver_model = &mut self.adaptor.load_model(model, private::Internal)?;
+        let solver_model = &mut self.adaptor.load_model(model.clone(), private::Internal)?;
         Ok(Solver {
             state: ModelLoaded,
             adaptor: self.adaptor,
+            context: Some(model.context.clone()),
         })
     }
 }
@@ -264,11 +270,11 @@ impl<A: SolverAdaptor> Solver<A, ModelLoaded> {
             Ok(x) => Ok(Solver {
                 adaptor: self.adaptor,
                 state: ExecutionSuccess {
-                    stats: x.stats,
+                    stats: x.stats.with_timings(duration.as_secs_f64()),
                     status: x.status,
                     _sealed: private::Internal,
-                    wall_time_s: duration.as_secs_f64(),
                 },
+                context: self.context,
             }),
             Err(x) => Err(x),
         }
@@ -290,11 +296,11 @@ impl<A: SolverAdaptor> Solver<A, ModelLoaded> {
             Ok(x) => Ok(Solver {
                 adaptor: self.adaptor,
                 state: ExecutionSuccess {
-                    stats: x.stats,
+                    stats: x.stats.with_timings(duration.as_secs_f64()),
                     status: x.status,
                     _sealed: private::Internal,
-                    wall_time_s: duration.as_secs_f64(),
                 },
+                context: self.context,
             }),
             Err(x) => Err(x),
         }
@@ -302,12 +308,25 @@ impl<A: SolverAdaptor> Solver<A, ModelLoaded> {
 }
 
 impl<A: SolverAdaptor> Solver<A, ExecutionSuccess> {
-    pub fn stats(self) -> Option<Box<dyn SolverStats>> {
-        self.state.stats
+    pub fn stats(&self) -> SolverStats {
+        self.state.stats.clone()
+    }
+
+    // Saves this solvers stats to the global context as a "solver run"
+    pub fn save_stats_to_context(&self) {
+        #[allow(clippy::unwrap_used)]
+        #[allow(clippy::expect_used)]
+        self.context
+            .as_ref()
+            .expect("")
+            .write()
+            .unwrap()
+            .stats
+            .add_solver_run(self.stats());
     }
 
     pub fn wall_time_s(&self) -> f64 {
-        self.state.wall_time_s
+        self.stats().conjure_solver_wall_time_s
     }
 }
 
@@ -340,7 +359,7 @@ pub enum SolverError {
 
 /// Returned from [SolverAdaptor] when solving is successful.
 pub struct SolveSuccess {
-    stats: Option<Box<dyn SolverStats>>,
+    stats: SolverStats,
     status: SearchStatus,
 }
 

--- a/crates/conjure_core/src/solver/states.rs
+++ b/crates/conjure_core/src/solver/states.rs
@@ -1,9 +1,10 @@
 //! States of a [`Solver`].
 use std::fmt::Display;
 
+use crate::stats::SolverStats;
+
 use super::private::Internal;
 use super::private::Sealed;
-use super::stats::*;
 use super::SearchStatus;
 use super::Solver;
 use super::SolverError;
@@ -26,13 +27,10 @@ pub struct ModelLoaded;
 /// The state returned by [`Solver`] if solving has been successful.
 pub struct ExecutionSuccess {
     /// Execution statistics.
-    pub stats: Option<Box<dyn SolverStats>>,
+    pub stats: SolverStats,
 
     /// The status of the search
     pub status: SearchStatus,
-
-    // Wall time elapsed in seconds.
-    pub wall_time_s: f64,
 
     /// Cannot construct this from outside this module.
     pub _sealed: Internal,

--- a/crates/conjure_core/src/solver/stats.rs
+++ b/crates/conjure_core/src/solver/stats.rs
@@ -1,4 +1,0 @@
-pub trait SolverStats {}
-
-pub struct NoStats;
-impl SolverStats for NoStats {}

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -1,12 +1,13 @@
 mod solver_stats;
 
+use schemars::JsonSchema;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 pub use solver_stats::SolverStats;
 
 #[allow(dead_code)]
 #[skip_serializing_none]
-#[derive(Default, Serialize, Clone)]
+#[derive(Default, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Stats {
     pub solver_runs: Vec<SolverStats>,

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -1,0 +1,21 @@
+mod solver_stats;
+
+use serde::Serialize;
+pub use solver_stats::SolverStats;
+
+#[allow(dead_code)]
+#[derive(Default, Serialize, Clone)]
+pub struct Stats {
+    pub solve_wall_time_s: Option<f64>,
+    pub solver_runs: Vec<SolverStats>,
+}
+
+impl Stats {
+    pub fn new() -> Stats {
+        Default::default()
+    }
+
+    pub fn add_solver_run(&mut self, solver_stats: SolverStats) {
+        self.solver_runs.push(solver_stats);
+    }
+}

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -1,9 +1,11 @@
 mod solver_stats;
 
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 pub use solver_stats::SolverStats;
 
 #[allow(dead_code)]
+#[skip_serializing_none]
 #[derive(Default, Serialize, Clone)]
 pub struct Stats {
     pub solve_wall_time_s: Option<f64>,

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -7,8 +7,8 @@ pub use solver_stats::SolverStats;
 #[allow(dead_code)]
 #[skip_serializing_none]
 #[derive(Default, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Stats {
-    pub solve_wall_time_s: Option<f64>,
     pub solver_runs: Vec<SolverStats>,
 }
 

--- a/crates/conjure_core/src/stats/solver_stats.rs
+++ b/crates/conjure_core/src/stats/solver_stats.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+use crate::solver::SolverFamily;
+
+#[derive(Default, Serialize, Clone)]
+#[allow(dead_code)]
+pub struct SolverStats {
+    // Wall time as measured by Conjure Oxide.
+    // This is set by Solver, not SolverAdaptor
+    pub conjure_solver_wall_time_s: f64,
+
+    pub solver_family: Option<SolverFamily>,
+
+    // NOTE (niklasdewally): these fields are copied from the list in Savile Row
+    pub nodes: Option<u64>,
+    pub satisfiable: Option<bool>,
+    pub sat_vars: Option<u64>,
+    pub sat_clauses: Option<u64>,
+}
+
+impl SolverStats {
+    // If the given stats object exists, add the wall time value.
+    // Otherwise create a new stats object containing the wall time value.
+    pub fn with_timings(self, wall_time_s: f64) -> SolverStats {
+        SolverStats {
+            conjure_solver_wall_time_s: wall_time_s,
+            ..self.clone()
+        }
+    }
+}

--- a/crates/conjure_core/src/stats/solver_stats.rs
+++ b/crates/conjure_core/src/stats/solver_stats.rs
@@ -1,7 +1,9 @@
 use serde::Serialize;
+use serde_with::skip_serializing_none;
 
 use crate::solver::SolverFamily;
 
+#[skip_serializing_none]
 #[derive(Default, Serialize, Clone)]
 #[allow(dead_code)]
 pub struct SolverStats {

--- a/crates/conjure_core/src/stats/solver_stats.rs
+++ b/crates/conjure_core/src/stats/solver_stats.rs
@@ -1,17 +1,23 @@
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
-use crate::solver::SolverFamily;
+use crate::solver::{SolverAdaptor, SolverFamily};
 
 #[skip_serializing_none]
 #[derive(Default, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
 pub struct SolverStats {
-    // Wall time as measured by Conjure Oxide.
-    // This is set by Solver, not SolverAdaptor
+    /// Wall time as measured by Conjure-oxide (not the solver).
+    #[serde(rename = "conjureSolverWallTime_s")]
     pub conjure_solver_wall_time_s: f64,
 
+    // This is set by Solver, not SolverAdaptor
+    /// The solver family used for this run.
     pub solver_family: Option<SolverFamily>,
+
+    /// The solver adaptor used for this run.
+    pub solver_adaptor: Option<String>,
 
     // NOTE (niklasdewally): these fields are copied from the list in Savile Row
     pub nodes: Option<u64>,
@@ -21,8 +27,7 @@ pub struct SolverStats {
 }
 
 impl SolverStats {
-    // If the given stats object exists, add the wall time value.
-    // Otherwise create a new stats object containing the wall time value.
+    // Adds the conjure_solver_wall_time_s to the stats.
     pub fn with_timings(self, wall_time_s: f64) -> SolverStats {
         SolverStats {
             conjure_solver_wall_time_s: wall_time_s,

--- a/crates/conjure_core/src/stats/solver_stats.rs
+++ b/crates/conjure_core/src/stats/solver_stats.rs
@@ -1,15 +1,17 @@
+use schemars::JsonSchema;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
-use crate::solver::{SolverAdaptor, SolverFamily};
+use crate::solver::SolverFamily;
 
 #[skip_serializing_none]
-#[derive(Default, Serialize, Clone)]
+#[derive(Default, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
+// Statistics for a run of a solver.
 pub struct SolverStats {
-    /// Wall time as measured by Conjure-oxide (not the solver).
     #[serde(rename = "conjureSolverWallTime_s")]
+    /// Wall time as measured by Conjure-Oxide (not the solver).
     pub conjure_solver_wall_time_s: f64,
 
     // This is set by Solver, not SolverAdaptor


### PR DESCRIPTION
Based on #279 

This PR adds two convenience flags to the CLI:

```
--print-info-schema                Prints the schema for the info JSON then exits
--info-json-path <INFO_JSON_PATH>  Saves execution info as JSON to the given file-path
```

The former in particular may be helpful for @PedroGGBM  / those doing stuff with the stats JSON.

(to run with cargo run, do cargo run -- --print-info-schema )