### PR TITLE
Get Stats out of Minion

### DIFF
--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -10,6 +10,7 @@ env:
   rust_release: nightly
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_VERSION: 2
 
 jobs:
   coverage:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,6 +13,7 @@ env:
   rust_release: nightly
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_VERSION: 2
 
 jobs:
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ on:
 env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_VERSION: 2
 
 jobs:
   build-and-test:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "solvers/minion/vendor"]
 	path = solvers/minion/vendor
 	url = https://github.com/niklasdewally/minion
-  branch = dev 
+  branch = libminion/get-tableout
   ignore = dirty
 
 [submodule "solvers/chuffed/vendor"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "anyhow",
  "bindgen 0.69.4",
  "glob",
+ "libc",
  "thiserror",
 ]
 

--- a/crates/conjure_core/src/solver/adaptors/minion.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion.rs
@@ -6,12 +6,13 @@ use regex::Regex;
 use minion_ast::Model as MinionModel;
 use minion_rs::ast as minion_ast;
 use minion_rs::error::MinionError;
-use minion_rs::run_minion;
+use minion_rs::{get_from_table, run_minion};
 
 use crate::ast as conjure_ast;
 use crate::solver::SolverCallback;
 use crate::solver::SolverFamily;
 use crate::solver::SolverMutCallback;
+use crate::stats::SolverStats;
 use crate::Model as ConjureModel;
 
 use super::super::model_modifier::NotModifiable;
@@ -127,7 +128,7 @@ impl SolverAdaptor for Minion {
             status = Complete(NoSolutions);
         }
         Ok(SolveSuccess {
-            stats: Default::default(),
+            stats: get_solver_stats(),
             status,
         })
     }
@@ -345,5 +346,13 @@ fn _name_to_string(name: conjure_ast::Name) -> String {
     match name {
         conjure_ast::Name::UserName(x) => x,
         conjure_ast::Name::MachineName(x) => format!("__conjure_machine_name_{}", x),
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn get_solver_stats() -> SolverStats {
+    SolverStats {
+        nodes: get_from_table("Nodes".into()).map(|x| x.parse::<u64>().unwrap()),
+        ..Default::default()
     }
 }

--- a/crates/conjure_core/src/solver/adaptors/minion.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion.rs
@@ -154,7 +154,7 @@ impl SolverAdaptor for Minion {
     }
 
     fn get_name(&self) -> Option<String> {
-        Some("adaptors::Minion".to_owned())
+        Some("Minion".to_owned())
     }
 }
 

--- a/solvers/minion/Cargo.toml
+++ b/solvers/minion/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.81"
+libc = "0.2.153"
 thiserror = "1.0.58"
 
 [build-dependencies]

--- a/solvers/minion/build.rs
+++ b/solvers/minion/build.rs
@@ -110,6 +110,7 @@ fn bind() {
         .allowlist_function("vec_vec_int_new")
         .allowlist_function("vec_vec_int_push_back")
         .allowlist_function("vec_vec_int_free")
+        .allowlist_function("TableOut_get")
         .clang_arg(format!("-I{}/build/src/", out_dir)) // generated from configure.py
         .clang_arg("-Ivendor/minion/")
         .clang_arg("-DLIBMINION")

--- a/solvers/minion/src/lib.rs
+++ b/solvers/minion/src/lib.rs
@@ -114,3 +114,6 @@ pub mod ast;
 mod run;
 
 mod scoped_ptr;
+
+mod wrappers;
+pub use wrappers::*;

--- a/solvers/minion/src/wrappers.rs
+++ b/solvers/minion/src/wrappers.rs
@@ -1,0 +1,30 @@
+//! Small wrapper functions over FFI things.
+
+use std::ffi::{c_char, CStr, CString};
+
+use crate::ffi;
+use libc::free;
+
+/// Gets a given value from Minion's TableOut (where it stores run statistics).
+pub fn get_from_table(key: String) -> Option<String> {
+    unsafe {
+        #[allow(clippy::expect_used)]
+        let c_string = CString::new(key).expect("");
+        let key_ptr = c_string.into_raw();
+        let val_ptr: *mut c_char = ffi::TableOut_get(key_ptr);
+
+        drop(CString::from_raw(key_ptr));
+
+        if val_ptr.is_null() {
+            free(val_ptr as _);
+            None
+        } else {
+            #[allow(clippy::unwrap_used)]
+            // CStr borrows the string in the ptr.
+            // We convert it to &str then clone into a String.
+            let res = CStr::from_ptr(val_ptr).to_str().unwrap().to_owned();
+            free(val_ptr as _);
+            Some(res)
+        }
+    }
+}

--- a/solvers/minion/tests/test_watchedor_reifyimply_1.rs
+++ b/solvers/minion/tests/test_watchedor_reifyimply_1.rs
@@ -23,7 +23,7 @@ use std::sync::Mutex;
 
 use minion_rs::ast::{Constant, Constraint, Model, Var, VarDomain, VarName};
 use minion_rs::error::MinionError;
-
+use minion_rs::get_from_table;
 #[test]
 #[allow(clippy::panic_in_result_fn)]
 fn test_watchedor_reifyimply_1() -> Result<(), MinionError> {
@@ -50,6 +50,7 @@ fn test_watchedor_reifyimply_1() -> Result<(), MinionError> {
 
     let guard = SOLS_COUNTER.lock().unwrap();
     assert_eq!(*guard, 7);
+    assert_ne!(get_from_table("Nodes".into()), None);
     Ok(())
 }
 


### PR DESCRIPTION
This PR provides a safe way  to get stats out of Minion's "TableOut" object, and uses this to put node count in the SolverStats. This is useful for performance benchmarking.
