### PR TITLE
(minor) Add CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ name = "conjure_core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "clap",
  "conjure_macros",
  "derivative",
  "derive_is_enum_variant",

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -91,12 +91,6 @@ pub fn main() -> AnyhowResult<()> {
                 .open(pth)?,
         ),
     };
-
-    if target_family != SolverFamily::Minion {
-        log::error!("Only the Minion solver is currently supported!");
-        exit(1);
-    }
-
     #[allow(clippy::unwrap_used)]
     let log_file = File::options()
         .create(true)
@@ -107,6 +101,11 @@ pub fn main() -> AnyhowResult<()> {
         .with_target_writer("info", new_writer(stdout()))
         .with_target_writer("file", new_writer(log_file))
         .init();
+
+    if target_family != SolverFamily::Minion {
+        log::error!("Only the Minion solver is currently supported!");
+        exit(1);
+    }
 
     let rule_sets = match resolve_rule_sets(target_family, &extra_rule_sets) {
         Ok(rs) => rs,

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -28,26 +28,43 @@ use conjure_oxide::SolverFamily;
 struct Cli {
     #[arg(
         value_name = "INPUT_ESSENCE",
-        default_value = "./conjure_oxide/tests/integration/xyz/input.essence"
+        default_value = "./conjure_oxide/tests/integration/xyz/input.essence",
+        help = "The input Essence file"
     )]
     input_file: PathBuf,
 
-    #[arg(long, value_name = "EXTRA_RULE_SETS")]
+    #[arg(
+        long,
+        value_name = "EXTRA_RULE_SETS",
+        help = "Names of extra rule sets to enable"
+    )]
     extra_rule_sets: Vec<String>,
 
-    #[arg(long, value_enum, value_name = "SOLVER", short = 's')]
-    solver: Option<SolverFamily>,
+    #[arg(
+        long,
+        value_enum,
+        value_name = "SOLVER",
+        short = 's',
+        help = "Solver family use (Minion by default)"
+    )]
+    solver: Option<SolverFamily>, // ToDo this should probably set the solver adapter
 
     // TODO: subcommands instead of these being a flag.
-    #[arg(long, default_value_t = false)]
-    /// Prints the schema for the info JSON then exits.
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Print the schema for the info JSON and exit"
+    )]
     print_info_schema: bool,
 
-    #[arg(long)]
-    /// Saves execution info as JSON to the given file-path.
+    #[arg(long, help = "Save execution info as JSON to the given file-path.")]
     info_json_path: Option<PathBuf>,
 
-    #[arg(long, short = 'o')]
+    #[arg(
+        long,
+        short = 'o',
+        help = "Save solutions to a JSON file (prints to stdin by default)"
+    )]
     output: Option<PathBuf>,
 }
 
@@ -74,6 +91,11 @@ pub fn main() -> AnyhowResult<()> {
                 .open(pth)?,
         ),
     };
+
+    if target_family != SolverFamily::Minion {
+        log::error!("Only the Minion solver is currently supported!");
+        exit(1);
+    }
 
     #[allow(clippy::unwrap_used)]
     let log_file = File::options()
@@ -161,7 +183,7 @@ pub fn main() -> AnyhowResult<()> {
 
     log::info!(target: "file", "Rewritten model: {}", json!(model));
 
-    let solutions = get_minion_solutions(model)?;
+    let solutions = get_minion_solutions(model)?; // ToDo we need to properly set the solver adaptor here, not hard code minion
     log::info!(target: "file", "Solutions: {}", minion_solutions_to_json(&solutions));
 
     let solutions_json = minion_solutions_to_json(&solutions);

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -54,7 +54,7 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     assert_eq!(model, expected_model);
 
     // Stage 2: Rewrite the model using the rule engine and check that the result is as expected
-    let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"])?;
+    let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()])?;
     let model = rewrite_model(&model, &rule_sets)?;
     if verbose {
         println!("Rewritten model: {:#?}", model)

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -2,7 +2,6 @@ use core::panic;
 use std::collections::HashMap;
 use std::process::exit;
 
-use conjure_core::context::Context;
 use conjure_core::rules::eval_constant;
 use conjure_core::solver::SolverFamily;
 use conjure_oxide::{
@@ -827,7 +826,7 @@ fn rule_distribute_or_over_and() {
 fn rewrite_solve_xyz() {
     println!("Rules: {:?}", get_rules());
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);
@@ -866,7 +865,7 @@ fn rewrite_solve_xyz() {
         ],
     );
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -24,6 +24,7 @@ regex = "1.10.4"
 walkdir = "2.5.0"
 derivative = "2.2.0"
 schemars = "0.8.16"
+clap = { version = "4.5.4", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
 use derivative::Derivative;
-use schemars::{schema_for, JsonSchema};
+use schemars::JsonSchema;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
@@ -20,7 +20,7 @@ pub struct Context<'a> {
 
     pub file_name: Option<String>,
 
-    pub extra_rule_set_names: Vec<&'a str>,
+    pub extra_rule_set_names: Vec<String>,
 
     #[serde(skip)]
     pub rules: Vec<&'a Rule<'a>>,
@@ -35,7 +35,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     pub fn new(
         target_solver_family: SolverFamily,
-        extra_rule_set_names: Vec<&'a str>,
+        extra_rule_set_names: Vec<String>,
         rules: Vec<&'a Rule<'a>>,
         rule_sets: Vec<&'a RuleSet<'a>>,
     ) -> Self {
@@ -53,7 +53,7 @@ impl<'a> Context<'a> {
 impl Context<'static> {
     pub fn new_ptr(
         target_solver_family: SolverFamily,
-        extra_rule_set_names: Vec<&'static str>,
+        extra_rule_set_names: Vec<String>,
         rules: Vec<&'static Rule<'static>>,
         rule_sets: Vec<&'static RuleSet<'static>>,
     ) -> Arc<RwLock<Context<'static>>> {
@@ -69,7 +69,7 @@ impl Context<'static> {
 impl<'a> Debug for Context<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let target_solver_family: Option<SolverFamily> = self.target_solver_family;
-        let extra_rule_set_names: Vec<&str> = self.extra_rule_set_names.clone();
+        let extra_rule_set_names: Vec<String> = self.extra_rule_set_names.clone();
         let rules: Vec<&str> = self.rules.iter().map(|r| r.name).collect();
         let rule_sets: Vec<&str> = self.rule_sets.iter().map(|r| r.name).collect();
 

--- a/crates/conjure_core/src/parse/example_models.rs
+++ b/crates/conjure_core/src/parse/example_models.rs
@@ -1,6 +1,5 @@
 // example_models with get_example_model function
 
-use std::default;
 use std::path::PathBuf;
 
 use project_root::get_project_root;

--- a/crates/conjure_core/src/rule_engine/resolve_rules.rs
+++ b/crates/conjure_core/src/rule_engine/resolve_rules.rs
@@ -43,7 +43,7 @@ fn get_rule_set(rule_set_name: &str) -> Result<&'static RuleSet<'static>, Resolv
 ///
 #[allow(clippy::mutable_key_type)] // RuleSet is 'static so it's fine
 pub fn rule_sets_by_names<'a>(
-    rule_set_names: &Vec<&str>,
+    rule_set_names: &Vec<String>,
 ) -> Result<HashSet<&'a RuleSet<'static>>, ResolveRulesError> {
     let mut rs_set: HashSet<&'static RuleSet<'static>> = HashSet::new();
 
@@ -69,7 +69,7 @@ pub fn rule_sets_by_names<'a>(
 #[allow(clippy::mutable_key_type)] // RuleSet is 'static so it's fine
 pub fn resolve_rule_sets<'a>(
     target_solver: SolverFamily,
-    extra_rs_names: &Vec<&str>,
+    extra_rs_names: &Vec<String>,
 ) -> Result<Vec<&'a RuleSet<'static>>, ResolveRulesError> {
     let mut ans = HashSet::new();
 

--- a/crates/conjure_core/src/solver/mod.rs
+++ b/crates/conjure_core/src/solver/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! // Define and rewrite a model for minion.
 //! let model = get_example_model("bool-03").unwrap();
-//! let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]).unwrap();
+//! let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]).unwrap();
 //! let model = rewrite_model(&model,&rule_sets).unwrap();
 //!
 //!
@@ -128,7 +128,6 @@ pub mod states;
     Deserialize,
     JsonSchema,
 )]
-
 pub enum SolverFamily {
     SAT,
     Minion,


### PR DESCRIPTION
This PR makes most things in main log to a file (instead of stdin), and adds a basic CLI to choose the target solver, enable extra rule sets, and choose whether to solve solutions to a file or print them to stdin

```
Usage: conjure_oxide [OPTIONS] [INPUT_ESSENCE]

Arguments:
  [INPUT_ESSENCE]  The input Essence file [default: ./conjure_oxide/tests/integration/xyz/input.essence]

Options:
      --extra-rule-sets <EXTRA_RULE_SETS>
          Names of extra rule sets to enable
  -s, --solver <SOLVER>
          Solver family use (Minion by default)
      --print-info-schema
          Print the schema for the info JSON and exit
      --info-json-path <INFO_JSON_PATH>
          Save execution info as JSON to the given file-path.
  -o, --output <OUTPUT>
          Save solutions to a JSON file (prints to stdin by default)
  -h, --help
          Print help
  -V, --version
          Print version
```