### PR TITLE
Rewriter Optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ conjure_oxide/tests/**/*.generated.*
 conjure_oxide/tests/**/*.generated-parse.*
 conjure_oxide/tests/**/*.generated-rewrite.*
 conjure_oxide/tests/**/*.generated-minion.*
+conjure_oxide/tests/*.png
 
 *-stats.json
 

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -139,8 +139,6 @@ pub fn main() -> AnyhowResult<()> {
     model = rewrite_model(&model, &rule_sets)?;
 
     log::info!("Rewritten model: {}", to_string_pretty(&json!(model))?);
-    println!("\nRewritten model:");
-    println!("{:#?}", model); 
 
     let solutions = get_minion_solutions(model)?;
     log::info!("Solutions: {}", minion_solutions_to_json(&solutions));

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -139,6 +139,8 @@ pub fn main() -> AnyhowResult<()> {
     model = rewrite_model(&model, &rule_sets)?;
 
     log::info!("Rewritten model: {}", to_string_pretty(&json!(model))?);
+    println!("\nRewritten model:");
+    println!("{:#?}", model); 
 
     let solutions = get_minion_solutions(model)?;
     log::info!("Solutions: {}", minion_solutions_to_json(&solutions));

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
@@ -2,12 +2,12 @@
   "constraints": {
     "Neq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Reference": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "UserName": "x"
@@ -17,7 +17,7 @@
       {
         "Reference": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "UserName": "y"

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
@@ -2,13 +2,13 @@
   "constraints": {
     "AllDiff": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Reference": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "UserName": "x"
@@ -18,7 +18,7 @@
         {
           "Reference": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "UserName": "y"

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "Geq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Min": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           [
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -36,7 +36,7 @@
       {
         "Constant": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "Int": 3

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 3
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -33,7 +33,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -45,12 +45,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -60,7 +60,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -70,7 +70,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -82,12 +82,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -97,7 +97,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -107,7 +107,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -119,18 +119,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -140,7 +140,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -150,7 +150,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -162,12 +162,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -177,7 +177,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -187,7 +187,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -202,18 +202,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -223,7 +223,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -233,7 +233,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -245,12 +245,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -260,7 +260,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -270,7 +270,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -285,18 +285,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -306,7 +306,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -316,7 +316,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -328,12 +328,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -343,7 +343,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -353,7 +353,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -368,18 +368,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -389,7 +389,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -399,7 +399,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -411,12 +411,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -426,7 +426,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -436,7 +436,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "Leq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Min": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           [
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -36,7 +36,7 @@
       {
         "Constant": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "Int": 2

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -23,7 +23,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 2
@@ -33,7 +33,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -45,12 +45,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -60,7 +60,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -70,7 +70,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -82,12 +82,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -97,7 +97,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -107,7 +107,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -119,18 +119,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -140,7 +140,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -150,7 +150,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -162,12 +162,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -177,7 +177,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -187,7 +187,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -202,18 +202,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -223,7 +223,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -233,7 +233,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -245,12 +245,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -260,7 +260,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -270,7 +270,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -285,18 +285,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -306,7 +306,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -316,7 +316,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -328,12 +328,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -343,7 +343,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -353,7 +353,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -368,18 +368,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -389,7 +389,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -399,7 +399,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -411,12 +411,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -426,7 +426,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -436,7 +436,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "Leq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Min": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           [
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -36,7 +36,7 @@
       {
         "Constant": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "Int": 2

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -23,7 +23,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 2
@@ -33,7 +33,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -45,12 +45,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -60,7 +60,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -70,7 +70,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -82,12 +82,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -97,7 +97,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -107,7 +107,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -119,18 +119,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -140,7 +140,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -150,7 +150,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -162,12 +162,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -177,7 +177,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -187,7 +187,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -202,18 +202,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -223,7 +223,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -233,7 +233,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -245,12 +245,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -260,7 +260,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -270,7 +270,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -285,18 +285,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -306,7 +306,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -316,7 +316,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -328,12 +328,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -343,7 +343,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -353,7 +353,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -368,18 +368,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -389,7 +389,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -399,7 +399,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -411,12 +411,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -426,7 +426,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -436,7 +436,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "Geq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Min": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           [
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -36,7 +36,7 @@
       {
         "Constant": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "Int": 3

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 3
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -33,7 +33,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -45,12 +45,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -60,7 +60,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -70,7 +70,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -82,12 +82,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -97,7 +97,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -107,7 +107,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -119,18 +119,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -140,7 +140,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -150,7 +150,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -162,12 +162,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -177,7 +177,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -187,7 +187,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -202,18 +202,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -223,7 +223,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -233,7 +233,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -245,12 +245,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -260,7 +260,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -270,7 +270,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -285,18 +285,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -306,7 +306,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -316,7 +316,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -328,12 +328,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -343,7 +343,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -353,7 +353,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -368,18 +368,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -389,7 +389,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -399,7 +399,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -411,12 +411,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -426,7 +426,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -436,7 +436,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "Leq": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       {
         "Min": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           [
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -23,7 +23,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -36,7 +36,7 @@
       {
         "Constant": [
           {
-            "dirtyclean": false
+            "clean": false
           },
           {
             "Int": 2

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
@@ -2,18 +2,18 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -23,7 +23,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 2
@@ -33,7 +33,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -45,12 +45,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -60,7 +60,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -70,7 +70,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -82,12 +82,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "MachineName": 0
@@ -97,7 +97,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -107,7 +107,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0
@@ -119,18 +119,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -140,7 +140,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -150,7 +150,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -162,12 +162,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -177,7 +177,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -187,7 +187,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -202,18 +202,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -223,7 +223,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -233,7 +233,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -245,12 +245,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -260,7 +260,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -270,7 +270,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -285,18 +285,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -306,7 +306,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -316,7 +316,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -328,12 +328,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -343,7 +343,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -353,7 +353,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -368,18 +368,18 @@
         {
           "Or": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             [
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "a"
@@ -389,7 +389,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -399,7 +399,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0
@@ -411,12 +411,12 @@
               {
                 "Ineq": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "b"
@@ -426,7 +426,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "MachineName": 0
@@ -436,7 +436,7 @@
                   {
                     "Constant": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "Int": 0

--- a/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
@@ -2,30 +2,30 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "Eq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Sum": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 [
                   {
                     "Sum": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       [
                         {
                           "Reference": [
                             {
-                              "dirtyclean": false
+                              "clean": false
                             },
                             {
                               "UserName": "a"
@@ -35,7 +35,7 @@
                         {
                           "Reference": [
                             {
-                              "dirtyclean": false
+                              "clean": false
                             },
                             {
                               "UserName": "b"
@@ -48,7 +48,7 @@
                   {
                     "Reference": [
                       {
-                        "dirtyclean": false
+                        "clean": false
                       },
                       {
                         "UserName": "c"
@@ -61,7 +61,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 4
@@ -73,12 +73,12 @@
         {
           "Geq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -88,7 +88,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"

--- a/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
@@ -2,19 +2,19 @@
   "constraints": {
     "And": [
       {
-        "dirtyclean": false
+        "clean": false
       },
       [
         {
           "SumGeq": [
             {
-              "dirtyclean": false
+              "clean": true
             },
             [
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "a"
@@ -24,7 +24,7 @@
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "b"
@@ -34,7 +34,7 @@
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "c"
@@ -45,7 +45,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": true
                 },
                 {
                   "Int": 4
@@ -57,13 +57,13 @@
         {
           "SumLeq": [
             {
-              "dirtyclean": false
+              "clean": true
             },
             [
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "a"
@@ -73,7 +73,7 @@
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "b"
@@ -83,7 +83,7 @@
               {
                 "Reference": [
                   {
-                    "dirtyclean": false
+                    "clean": false
                   },
                   {
                     "UserName": "c"
@@ -94,7 +94,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": true
                 },
                 {
                   "Int": 4
@@ -106,12 +106,12 @@
         {
           "Ineq": [
             {
-              "dirtyclean": false
+              "clean": false
             },
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "b"
@@ -121,7 +121,7 @@
             {
               "Reference": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "UserName": "a"
@@ -131,7 +131,7 @@
             {
               "Constant": [
                 {
-                  "dirtyclean": false
+                  "clean": false
                 },
                 {
                   "Int": 0

--- a/conjure_oxide/tests/plot_rewriter_optimization_performance.py
+++ b/conjure_oxide/tests/plot_rewriter_optimization_performance.py
@@ -1,0 +1,97 @@
+import json
+import matplotlib.pyplot as plt
+
+
+def load_data_from_file(file_path):
+    with open(file_path, "r") as file:
+        return json.load(file)
+
+
+def plot_performance_gain(data):
+    x = [key for key in sorted(data.keys())]
+    y = [data[key]["performance_gain"] for key in sorted(data.keys())]
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(x, y, marker="o")
+    plt.xlabel("Number of OR Clauses")
+    plt.ylabel("Performance Gain (%)")
+    plt.title("Performance Gain between Optimized and Unoptimized Versions")
+    plt.grid(True)
+    plt.savefig("performance_gain.png")
+    plt.close()
+
+
+def plot_rule_application_savings(data):
+    x = [key for key in sorted(data.keys())]
+    y = [data[key]["rule_application_savings"] for key in sorted(data.keys())]
+
+    plt.figure(figsize=(8, 6))
+    plt.plot(x, y, marker="o", color="g")
+    plt.xlabel("Number of OR Clauses")
+    plt.ylabel("Rule Application Savings (%)")
+    plt.title("Rule Application Savings between Optimized and Unoptimized Versions")
+    plt.grid(True)
+    plt.savefig("rule_application_savings.png")
+    plt.close()
+
+
+def main():
+    output_files = [
+        "rewrite_solve_xyz_optimized_1-stats.json",
+        "rewrite_solve_xyz_optimized_2-stats.json",
+        "rewrite_solve_xyz_optimized_3-stats.json",
+        "rewrite_solve_xyz_optimized_4-stats.json",
+        "rewrite_solve_xyz_unoptimized_1-stats.json",
+        "rewrite_solve_xyz_unoptimized_2-stats.json",
+        "rewrite_solve_xyz_unoptimized_3-stats.json",
+        "rewrite_solve_xyz_unoptimized_4-stats.json",
+    ]
+
+    results = {}
+    optimized_performance = []
+    unoptimized_performance = []
+    optimized_rule_applications = []
+    unoptimized_rule_applications = []
+
+    for file_name in output_files:
+        with open(file_name, "r") as file:
+            data = json.load(file)
+            if "unoptimized" in file_name:
+                unoptimized_performance.append(
+                    data["stats"]["rewriterRuns"][0]["rewriterRunTime"]["nanos"]
+                    + data["stats"]["rewriterRuns"][0]["rewriterRunTime"]["secs"] * 1e9
+                )
+                unoptimized_rule_applications.append(
+                    data["stats"]["rewriterRuns"][0]["rewriterRuleApplicationAttempts"]
+                )
+            else:
+                optimized_performance.append(
+                    data["stats"]["rewriterRuns"][0]["rewriterRunTime"]["nanos"]
+                    + data["stats"]["rewriterRuns"][0]["rewriterRunTime"]["secs"] * 1e9
+                )
+                optimized_rule_applications.append(
+                    data["stats"]["rewriterRuns"][0]["rewriterRuleApplicationAttempts"]
+                )
+
+    for i in range(4):
+        performance_gain = (
+            (unoptimized_performance[i] - optimized_performance[i])
+            / optimized_performance[i]
+            * 100
+        )
+        rule_application_savings = (
+            (unoptimized_rule_applications[i] - optimized_rule_applications[i])
+            / unoptimized_rule_applications[i]
+            * 100
+        )
+        results[i + 1] = {
+            "performance_gain": performance_gain,
+            "rule_application_savings": rule_application_savings,
+        }
+
+    plot_performance_gain(results)
+    plot_rule_application_savings(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -969,34 +969,30 @@ fn rewrite_solve_xyz_parameterized() {
         let nested_expr = Expression::Or(Metadata::new(), or_exprs);
 
         let model_for_rewrite = Model::new(HashMap::new(), nested_expr.clone(), Default::default());
-        let model_for_rewrite_unoptimized = Model::new(HashMap::new(), nested_expr.clone(), Default::default());
+        let model_for_rewrite_unoptimized =
+            Model::new(HashMap::new(), nested_expr.clone(), Default::default());
 
         // Apply rewrite function to the nested expression
-        let rewritten_expr = rewrite_model(
-            &model_for_rewrite,
-            &rule_sets,
-        )
-        .unwrap()
-        .constraints;
+        let rewritten_expr = rewrite_model(&model_for_rewrite, &rule_sets)
+            .unwrap()
+            .constraints;
 
         env::set_var("OPTIMIZATIONS", "0");
 
-        let rewritten_expr_unoptimized = rewrite_model(
-            &model_for_rewrite_unoptimized, 
-            &rule_sets,
-        )
-        .unwrap()
-        .constraints;
+        let rewritten_expr_unoptimized = rewrite_model(&model_for_rewrite_unoptimized, &rule_sets)
+            .unwrap()
+            .constraints;
 
         env::remove_var("OPTIMIZATIONS");
 
-        let info_file_name_optimized = format!("rewrite_solve_xyz_optimized_{}", num_or_clauses); 
-        let info_file_name_unoptimized = format!("rewrite_solve_xyz_unoptimized_{}", num_or_clauses);
-         
+        let info_file_name_optimized = format!("rewrite_solve_xyz_optimized_{}", num_or_clauses);
+        let info_file_name_unoptimized =
+            format!("rewrite_solve_xyz_unoptimized_{}", num_or_clauses);
+
         save_stats_json(
             model_for_rewrite.context,
             "tests",
-            &info_file_name_optimized, 
+            &info_file_name_optimized,
         );
         save_stats_json(
             model_for_rewrite_unoptimized.context,
@@ -1057,8 +1053,6 @@ fn rewrite_solve_xyz_parameterized() {
                 domain: domain.clone(),
             },
         );
-
-        
 
         let solver: Solver<adaptors::Minion> = Solver::new(adaptors::Minion::new());
         let solver = solver.load_model(model).unwrap();

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -140,9 +140,7 @@ impl Expression {
                 metadata.clean && exprs.iter().all(|e| e.is_clean())
             }
             Expression::Not(metadata, expr) => metadata.clean && expr.is_clean(),
-            Expression::Or(metadata, exprs) => {
-                metadata.clean && exprs.iter().all(|e| e.is_clean())
-            }
+            Expression::Or(metadata, exprs) => metadata.clean && exprs.iter().all(|e| e.is_clean()),
             Expression::And(metadata, exprs) => {
                 metadata.clean && exprs.iter().all(|e| e.is_clean())
             }
@@ -188,96 +186,55 @@ impl Expression {
             Expression::Nothing => {}
             Expression::Constant(metadata, _) => metadata.clean = bool_value,
             Expression::Reference(metadata, _) => metadata.clean = bool_value,
-            Expression::Sum(metadata, exprs) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
+            Expression::Sum(metadata, _) => {
+                metadata.clean = bool_value;
             }
-            Expression::Min(metadata, exprs) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
+            Expression::Min(metadata, _) => {
+                metadata.clean = bool_value;
             }
-            Expression::Not(metadata, expr) => {
-                metadata.clean =bool_value;
-                expr.set_clean(bool_value);
+            Expression::Not(metadata, _) => {
+                metadata.clean = bool_value;
             }
-            Expression::Or(metadata, exprs) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
+            Expression::Or(metadata, _) => {
+                metadata.clean = bool_value;
             }
-            Expression::And(metadata, exprs) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
+            Expression::And(metadata, _) => {
+                metadata.clean = bool_value;
             }
             Expression::Eq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
+                metadata.clean = bool_value;
                 box1.set_clean(bool_value);
                 box2.set_clean(bool_value);
             }
             Expression::Neq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::Geq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::Leq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::Gt(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::Lt(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::SumGeq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                for e in box1 {
-                    e.set_clean(bool_value);
-                }
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::SumLeq(metadata, box1, box2) => {
-                metadata.clean =bool_value;
-                for e in box1 {
-                    e.set_clean(bool_value);
-                }
-                box2.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::Ineq(metadata, box1, box2, box3) => {
-                metadata.clean =bool_value;
-                box1.set_clean(bool_value);
-                box2.set_clean(bool_value);
-                box3.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
             Expression::AllDiff(metadata, exprs) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
+                metadata.clean = bool_value;
             }
             Expression::SumEq(metadata, exprs, expr) => {
-                metadata.clean =bool_value;
-                for e in exprs {
-                    e.set_clean(bool_value);
-                }
-                expr.set_clean(bool_value);
+                metadata.clean = bool_value;
             }
         }
     }

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -127,6 +127,160 @@ impl Expression {
             _ => todo!(),
         }
     }
+
+    pub fn is_clean(&self) -> bool {
+        match self {
+            Expression::Nothing => true,
+            Expression::Constant(metadata, _) => metadata.clean,
+            Expression::Reference(metadata, _) => metadata.clean,
+            Expression::Sum(metadata, exprs) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean())
+            }
+            Expression::Min(metadata, exprs) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean())
+            }
+            Expression::Not(metadata, expr) => metadata.clean && expr.is_clean(),
+            Expression::Or(metadata, exprs) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean())
+            }
+            Expression::And(metadata, exprs) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean())
+            }
+            Expression::Eq(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::Neq(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::Geq(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::Leq(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::Gt(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::Lt(metadata, box1, box2) => {
+                metadata.clean && box1.is_clean() && box2.is_clean()
+            }
+            Expression::SumGeq(metadata, box1, box2) => {
+                metadata.clean && box1.iter().all(|e| e.is_clean()) && box2.is_clean()
+            }
+            Expression::SumLeq(metadata, box1, box2) => {
+                metadata.clean && box1.iter().all(|e| e.is_clean()) && box2.is_clean()
+            }
+            Expression::Ineq(metadata, box1, box2, box3) => {
+                metadata.clean && box1.is_clean() && box2.is_clean() && box3.is_clean()
+            }
+            Expression::AllDiff(metadata, exprs) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean())
+            }
+            Expression::SumEq(metadata, exprs, expr) => {
+                metadata.clean && exprs.iter().all(|e| e.is_clean()) && expr.is_clean()
+            }
+            _ => false,
+        }
+    }
+
+    pub fn set_clean(&mut self, bool_value: bool) {
+        match self {
+            Expression::Nothing => {}
+            Expression::Constant(metadata, _) => metadata.clean = bool_value,
+            Expression::Reference(metadata, _) => metadata.clean = bool_value,
+            Expression::Sum(metadata, exprs) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+            }
+            Expression::Min(metadata, exprs) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+            }
+            Expression::Not(metadata, expr) => {
+                metadata.clean =bool_value;
+                expr.set_clean(bool_value);
+            }
+            Expression::Or(metadata, exprs) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+            }
+            Expression::And(metadata, exprs) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+            }
+            Expression::Eq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::Neq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::Geq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::Leq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::Gt(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::Lt(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+            }
+            Expression::SumGeq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                for e in box1 {
+                    e.set_clean(bool_value);
+                }
+                box2.set_clean(bool_value);
+            }
+            Expression::SumLeq(metadata, box1, box2) => {
+                metadata.clean =bool_value;
+                for e in box1 {
+                    e.set_clean(bool_value);
+                }
+                box2.set_clean(bool_value);
+            }
+            Expression::Ineq(metadata, box1, box2, box3) => {
+                metadata.clean =bool_value;
+                box1.set_clean(bool_value);
+                box2.set_clean(bool_value);
+                box3.set_clean(bool_value);
+            }
+            Expression::AllDiff(metadata, exprs) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+            }
+            Expression::SumEq(metadata, exprs, expr) => {
+                metadata.clean =bool_value;
+                for e in exprs {
+                    e.set_clean(bool_value);
+                }
+                expr.set_clean(bool_value);
+            }
+        }
+    }
 }
 
 fn display_expressions(expressions: &[Expression]) -> String {

--- a/crates/conjure_core/src/metadata.rs
+++ b/crates/conjure_core/src/metadata.rs
@@ -2,20 +2,14 @@ use std::fmt::{Debug, Display};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct Metadata {
-    pub dirtyclean: bool,
-}
-
-impl Default for Metadata {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub clean: bool,
 }
 
 impl Metadata {
     pub fn new() -> Metadata {
-        Metadata { dirtyclean: false }
+        Metadata { clean: false }
     }
 }
 

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -1,7 +1,9 @@
+use std::env;
 use std::fmt::Display;
 
 use thiserror::Error;
 
+use crate::stats::RewriterStats;
 use uniplate::uniplate::Uniplate;
 
 use crate::rule_engine::{Reduction, Rule, RuleSet};
@@ -38,6 +40,18 @@ impl From<ResolveError> for RewriteError {
     }
 }
 
+/// Checks if the OPTIMIZATIONS environment variable is set to "0".
+///
+/// # Returns
+/// - true if the environment variable is set to "0".
+/// - false if the environment variable is not set or set to any other value.
+fn optimizations_disabled() -> bool {
+    match env::var("OPTIMIZATIONS") {
+        Ok(val) => val == "0",
+        Err(_) => false, // Assume optimizations are enabled if the variable is not set
+    }
+}
+
 /// Rewrites the model by applying the rules to all constraints.
 ///
 /// Any side-effects such as symbol table updates and top-level constraints are applied to the returned model.
@@ -48,16 +62,32 @@ pub fn rewrite_model<'a>(
     model: &Model,
     rule_sets: &Vec<&'a RuleSet<'a>>,
 ) -> Result<Model, RewriteError> {
-    let start = std::time::Instant::now();
     let rule_priorities = get_rule_priorities(rule_sets)?;
     let rules = get_rules_vec(&rule_priorities);
     let mut new_model = model.clone();
+    let mut stats = RewriterStats {
+        is_optimization_enabled: Some(!optimizations_disabled()),
+        rewriter_run_time: None,
+        rewriter_rule_application_attempts: Some(0),
+        rewriter_rule_applications: Some(0),
+    };
 
-    while let Some(step) = rewrite_iteration(&new_model.constraints, &new_model, &rules) {
+    // Check if optimizations are disabled
+    let apply_optimizations = !optimizations_disabled();
+
+    let start = std::time::Instant::now();
+
+    while let Some(step) = rewrite_iteration(
+        &new_model.constraints,
+        &new_model,
+        &rules,
+        apply_optimizations,
+        &mut stats,
+    ) {
         step.apply(&mut new_model); // Apply side-effects (e.g. symbol table updates)
     }
-    // Now - start time
-    model.context.write().unwrap().stats.rewriter_run_time = Some(start.elapsed());
+    stats.rewriter_run_time = Some(start.elapsed());
+    model.context.write().unwrap().stats.add_rewriter_run(stats);
     Ok(new_model)
 }
 
@@ -68,36 +98,43 @@ fn rewrite_iteration<'a>(
     expression: &'a Expression,
     model: &'a Model,
     rules: &'a Vec<&'a Rule<'a>>,
+    apply_optimizations: bool,
+    stats: &mut RewriterStats,
 ) -> Option<Reduction> {
-    if expression.is_clean() {
+    if apply_optimizations && expression.is_clean() {
         // Skip processing this expression if it's clean
         return None;
     }
 
     // Mark the expression as clean - will be marked dirty if any rule is applied
     let mut expression = expression.clone();
-    expression.set_clean(true);
+    if apply_optimizations {
+        expression.set_clean(true);
+    }
 
-    let rule_results = apply_all_rules(&expression, model, rules);
+    let rule_results = apply_all_rules(&expression, model, rules, stats);
     if let Some(mut new) = choose_rewrite(&rule_results) {
         // If a rule is applied, mark the expression as dirty
-        new.new_expression.set_clean(false);
+        if apply_optimizations {
+            new.new_expression.set_clean(false);
+        }
         return Some(new);
     }
-    
+
     let mut sub = expression.children();
     for i in 0..sub.len() {
-            if let Some(red) = rewrite_iteration(&sub[i], model, rules) {
-                sub[i] = red.new_expression;
-                // If child is dirty, make this expression dirty
-                if !sub[i].is_clean() {
-                    expression.set_clean(false);
-                }
-                if let Ok(res) = expression.with_children(sub.clone()) {
-                    return Some(Reduction::new(res, red.new_top, red.symbols));
-                }
+        if let Some(red) = rewrite_iteration(&sub[i], model, rules, apply_optimizations, stats) {
+            sub[i] = red.new_expression;
+            // If child is dirty, make this expression dirty
+
+            if apply_optimizations && !sub[i].is_clean() {
+                expression.set_clean(false);
+            }
+            if let Ok(res) = expression.with_children(sub.clone()) {
+                return Some(Reduction::new(res, red.new_top, red.symbols));
             }
         }
+    }
     None // No rules applicable to this branch of the expression
 }
 
@@ -108,19 +145,26 @@ fn apply_all_rules<'a>(
     expression: &'a Expression,
     model: &'a Model,
     rules: &'a Vec<&'a Rule<'a>>,
+    stats: &mut RewriterStats,
 ) -> Vec<RuleResult<'a>> {
     let mut results = Vec::new();
     for rule in rules {
         match rule.apply(expression, model) {
             Ok(red) => {
+                log::trace!(target: "file", "Rule applied: {:?}, to Expression: {:?}, resulting in: {:?}", rule, expression, red.new_expression);
+                stats.rewriter_rule_application_attempts =
+                    Some(stats.rewriter_rule_application_attempts.unwrap() + 1);
+                stats.rewriter_rule_applications =
+                    Some(stats.rewriter_rule_applications.unwrap() + 1);
                 results.push(RuleResult {
                     rule,
                     reduction: red,
                 });
-                log::trace!(target: "file", "Rule applied: {:?}", rule);
             }
             Err(_) => {
-                log::trace!(target: "file", "Rule attempted but not applied: {:?}", rule);
+                log::trace!(target: "file", "Rule attempted but not applied: {:?}, to Expression: {:?}", rule, expression);
+                stats.rewriter_rule_application_attempts =
+                    Some(stats.rewriter_rule_application_attempts.unwrap() + 1);
                 continue;
             }
         }

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -11,6 +11,7 @@ pub use solver_stats::SolverStats;
 #[serde(rename_all = "camelCase")]
 pub struct Stats {
     pub solver_runs: Vec<SolverStats>,
+    pub rewriter_run_time : Option<std::time::Duration>, 
 }
 
 impl Stats {

--- a/crates/conjure_core/src/stats/mod.rs
+++ b/crates/conjure_core/src/stats/mod.rs
@@ -1,5 +1,7 @@
+mod rewriter_stats;
 mod solver_stats;
 
+pub use rewriter_stats::RewriterStats;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
@@ -11,7 +13,7 @@ pub use solver_stats::SolverStats;
 #[serde(rename_all = "camelCase")]
 pub struct Stats {
     pub solver_runs: Vec<SolverStats>,
-    pub rewriter_run_time : Option<std::time::Duration>, 
+    pub rewriter_runs: Vec<RewriterStats>,
 }
 
 impl Stats {
@@ -21,5 +23,9 @@ impl Stats {
 
     pub fn add_solver_run(&mut self, solver_stats: SolverStats) {
         self.solver_runs.push(solver_stats);
+    }
+
+    pub fn add_rewriter_run(&mut self, rewriter_stats: RewriterStats) {
+        self.rewriter_runs.push(rewriter_stats);
     }
 }

--- a/crates/conjure_core/src/stats/rewriter_stats.rs
+++ b/crates/conjure_core/src/stats/rewriter_stats.rs
@@ -1,0 +1,15 @@
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde_with::skip_serializing_none;
+
+#[skip_serializing_none]
+#[derive(Default, Serialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+
+pub struct RewriterStats {
+    pub is_optimization_enabled: Option<bool>,
+    pub rewriter_run_time: Option<std::time::Duration>,
+    pub rewriter_rule_application_attempts: Option<usize>,
+    pub rewriter_rule_applications: Option<usize>,
+}


### PR DESCRIPTION
This PR adds the "clean/dirty" optimisation. The rewriter algorithm and this optimisation are explained in [this issue](https://github.com/conjure-cp/conjure-oxide/issues/149). Clean nodes are skipped as there is no work to be done with them and dirty nodes are rewritten normally. Whenever a node is turned dirty then it's parent will make itself dirty. 

I have written a new test in `rewriter_tests` called `rewrite_solve_xyz_parameterized` which runs the rewriter over increasing "complex" XYZ models. Complex in this instance refers to the number of branches of execution so each version of the test will have an extra XYZ problem in the OR clause. Currently, this test runs from 1 to 4 number of XYZ problems mainly because 5 and above is quite slow - 5 XYZ problems in the OR runs for around 15 seconds for example.  

Additionally, this tests each number of XYZ problems with and without the new optimisation so that we can compare the speed and number of rule application attempts. An info json is output inside the `conjure_oxide/tests` directory for each configuration of the test (so 8 in total for now). 

Here are some graphs that show the performance gains over the unoptimized version and the amount of rule applications saved over the unoptimized version as the number of XYZ problems increases. I have removed the data where there is only one XYZ problem as the results are very very inconsistent probably due to its very low run time. 

![performance_gain_1](https://github.com/conjure-cp/conjure-oxide/assets/27870413/8c8d7ee5-b8d3-4c23-a2b4-346815bb9a2b)
![rule_application_savings_1](https://github.com/conjure-cp/conjure-oxide/assets/27870413/6ba71463-ccb2-4ca0-8e12-d6aa63a634a9)

It is important to note that the performance increase seems to vary from run to run but is always positive. It seems that on most runs one number of XYZ problems gets quite a large increase in performance but this shifts from run to run - could this be from some sort of caching? Any insight would be appreciated!

I plan to add an option to the tests to increase the number of XYZ problems to a set amount but keep the default at 4 so I can collect some more results without affecting the test runtime. I will also do a few runs and average out the data for some better graphs but I think this shows the general idea :)