### PR TITLE
[Biplate Macro #1] conjure_core: use new Uniplate types for AST traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,8 +343,8 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
- "uniplate",
- "uniplate_derive",
+ "uniplate 0.1.0 (git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170)",
+ "uniplate_derive 0.1.0 (git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170)",
  "walkdir",
 ]
 
@@ -377,8 +377,8 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
- "uniplate",
- "uniplate_derive",
+ "uniplate 0.1.0 (git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170)",
+ "uniplate_derive 0.1.0 (git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170)",
  "versions",
  "walkdir",
 ]
@@ -1555,6 +1555,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniplate"
+version = "0.1.0"
+source = "git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170#0dc7090f0388d9a4fc0460d7d5fbf79da7854170"
+dependencies = [
+ "im",
+ "proptest",
+ "proptest-derive",
+ "thiserror",
+]
+
+[[package]]
 name = "uniplate_derive"
 version = "0.1.0"
 dependencies = [
@@ -1562,7 +1573,19 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.36",
  "syn 2.0.60",
- "uniplate",
+ "uniplate 0.1.0",
+]
+
+[[package]]
+name = "uniplate_derive"
+version = "0.1.0"
+source = "git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170#0dc7090f0388d9a4fc0460d7d5fbf79da7854170"
+dependencies = [
+ "log",
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.60",
+ "uniplate 0.1.0 (git+https://github.com/conjure-cp/conjure-oxide.git?rev=0dc7090f0388d9a4fc0460d7d5fbf79da7854170)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "derivative",
  "derive_is_enum_variant",
  "enum_compatability_macro",
+ "im",
  "itertools",
  "linkme",
  "log",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -10,8 +10,8 @@ walkdir = "2.5.0"
 
 [dependencies]
 conjure_core = { path = "../crates/conjure_core" }
-uniplate = { path = "../crates/uniplate" }
-uniplate_derive = { path = "../crates/uniplate_derive" }
+uniplate = { git = "https://github.com/conjure-cp/conjure-oxide.git", rev = "0dc7090f0388d9a4fc0460d7d5fbf79da7854170" }
+uniplate_derive = { git = "https://github.com/conjure-cp/conjure-oxide.git", rev = "0dc7090f0388d9a4fc0460d7d5fbf79da7854170" }
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 serde_with = "3.8.1"

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -13,7 +13,7 @@ use conjure_oxide::{
     utils::testing::save_stats_json,
     Metadata, Model, Rule,
 };
-use uniplate::uniplate::Uniplate;
+use uniplate::biplate::Uniplate;
 
 #[test]
 fn rules_present() {
@@ -1098,9 +1098,7 @@ fn is_simple_iteration<'a>(
         for i in 0..sub.len() {
             if let Some(new) = is_simple_iteration(&sub[i], rules) {
                 sub[i] = new;
-                if let Ok(res) = expression.with_children(sub.clone()) {
-                    return Some(res);
-                }
+                return Some(expression.with_children(sub.clone()));
             }
         }
     }

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 conjure_macros = { path = "../conjure_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }
-uniplate = { path = "../uniplate" }
-uniplate_derive = { path = "../uniplate_derive" }
+uniplate = { git = "https://github.com/conjure-cp/conjure-oxide.git", rev = "0dc7090f0388d9a4fc0460d7d5fbf79da7854170" }
+uniplate_derive = { git = "https://github.com/conjure-cp/conjure-oxide.git", rev = "0dc7090f0388d9a4fc0460d7d5fbf79da7854170" }
 minion_rs = { path = "../../solvers/minion" }
 project-root = "0.2.2"
 linkme = "0.3.25"

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -26,6 +26,7 @@ derivative = "2.2.0"
 schemars = "0.8.17"
 clap = { version = "4.5.4", features = ["derive"] }
 itertools = "0.12.1"
+im = "15.1.0"
 
 [lints]
 workspace = true

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -4,8 +4,6 @@ use derive_is_enum_variant::is_enum_variant;
 use serde::{Deserialize, Serialize};
 
 use enum_compatability_macro::document_compatibility;
-use uniplate::uniplate::Uniplate;
-use uniplate_derive::Uniplate;
 
 use crate::ast::constants::Constant;
 use crate::ast::symbol_table::{Name, SymbolTable};
@@ -15,7 +13,7 @@ use crate::metadata::Metadata;
 use super::{Domain, Range};
 
 #[document_compatibility]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, is_enum_variant, Uniplate)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, is_enum_variant)]
 #[non_exhaustive]
 pub enum Expression {
     /**

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -3,6 +3,7 @@ mod domains;
 mod expressions;
 mod symbol_table;
 pub mod types;
+mod uniplate;
 mod variables;
 
 pub use constants::Constant;

--- a/crates/conjure_core/src/ast/uniplate.rs
+++ b/crates/conjure_core/src/ast/uniplate.rs
@@ -1,0 +1,347 @@
+//! Uniplate and Traversal utilities for the AST.
+
+use super::Expression;
+use im::vector;
+use uniplate::biplate::Uniplate;
+
+use crate::ast::constants::Constant;
+
+//NOTE (niklasdewally): Temporary manual implementation until the macro is sorted out
+impl Uniplate for Expression {
+    fn uniplate(
+        &self,
+    ) -> (
+        uniplate::Tree<Self>,
+        Box<dyn Fn(uniplate::Tree<Self>) -> Self>,
+    ) {
+        use uniplate::Tree::*;
+        use Expression::*;
+        match self {
+            Nothing => (Zero, Box::new(|_| Nothing)),
+            Constant(m, c) => {
+                let m = m.clone(); // allows us to move m into the closure.
+                let c = c.clone();
+                (Zero, Box::new(move |_| (Constant(m.clone(), c.clone()))))
+            }
+            Reference(m, n) => {
+                let m = m.clone();
+                let n = n.clone();
+                (Zero, Box::new(move |_| (Reference(m.clone(), n.clone()))))
+            }
+            Sum(m, es) => {
+                let m = m.clone();
+                (
+                    Many(es.iter().map(|e| One(e.clone())).collect()),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let es: Vec<Expression> = es
+                            .into_iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e
+                            })
+                            .collect();
+                        Sum(m.clone(), es)
+                    }),
+                )
+            }
+            Min(m, es) => {
+                let m = m.clone();
+                (
+                    Many(es.iter().map(|e| One(e.clone())).collect()),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let es: Vec<Expression> = es
+                            .into_iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e
+                            })
+                            .collect();
+                        Min(m.clone(), es)
+                    }),
+                )
+            }
+            And(m, es) => {
+                let m = m.clone();
+                (
+                    Many(es.iter().map(|e| One(e.clone())).collect()),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let es: Vec<Expression> = es
+                            .into_iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e
+                            })
+                            .collect();
+                        And(m.clone(), es)
+                    }),
+                )
+            }
+            Or(m, es) => {
+                let m = m.clone();
+                (
+                    Many(es.iter().map(|e| One(e.clone())).collect()),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let es: Vec<Expression> = es
+                            .into_iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e
+                            })
+                            .collect();
+                        Or(m.clone(), es)
+                    }),
+                )
+            }
+            AllDiff(m, es) => {
+                let m = m.clone();
+                (
+                    Many(es.iter().map(|e| One(e.clone())).collect()),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let es: Vec<Expression> = es
+                            .into_iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e
+                            })
+                            .collect();
+                        AllDiff(m.clone(), es)
+                    }),
+                )
+            }
+
+            Not(m, e) => {
+                let m = m.clone();
+                (
+                    One(*e.clone()),
+                    Box::new(move |x| {
+                        let One(e) = x else { panic!() };
+                        Not(m.clone(), Box::new(e))
+                    }),
+                )
+            }
+            Bubble(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Bubble(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Eq(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Eq(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Neq(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Neq(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Geq(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Geq(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Leq(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Leq(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Gt(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Gt(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            Lt(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        Lt(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            SafeDiv(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        SafeDiv(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            UnsafeDiv(m, e1, e2) => {
+                let m = m.clone();
+                (
+                    Many(vector![One(*e1.clone()), One(*e2.clone())]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        UnsafeDiv(m.clone(), Box::new(e1.clone()), Box::new(e2.clone()))
+                    }),
+                )
+            }
+            DivEq(m, e1, e2, e3) => {
+                let m = m.clone();
+                (
+                    Many(vector![
+                        One(*e1.clone()),
+                        One(*e2.clone()),
+                        One(*e3.clone())
+                    ]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        let One(e3) = &es[2] else { panic!() };
+                        DivEq(
+                            m.clone(),
+                            Box::new(e1.clone()),
+                            Box::new(e2.clone()),
+                            Box::new(e3.clone()),
+                        )
+                    }),
+                )
+            }
+            Ineq(m, e1, e2, e3) => {
+                let m = m.clone();
+                (
+                    Many(vector![
+                        One(*e1.clone()),
+                        One(*e2.clone()),
+                        One(*e3.clone())
+                    ]),
+                    Box::new(move |x| {
+                        let Many(es) = x else { panic!() };
+                        let One(e1) = &es[0] else { panic!() };
+                        let One(e2) = &es[1] else { panic!() };
+                        let One(e3) = &es[2] else { panic!() };
+                        Ineq(
+                            m.clone(),
+                            Box::new(e1.clone()),
+                            Box::new(e2.clone()),
+                            Box::new(e3.clone()),
+                        )
+                    }),
+                )
+            }
+            SumEq(m, es, e) => {
+                let m = m.clone();
+                let field_1 = Many(es.iter().map(|e| One(e.clone())).collect());
+                let field_2 = One(*e.clone());
+                let children = Many(vector![field_1, field_2]);
+                (
+                    children,
+                    Box::new(move |x| {
+                        let Many(x) = x else { panic!() };
+                        let Many(es) = &x[0] else { panic!() };
+                        let One(e) = &x[1] else { panic!() };
+                        let es: Vec<Expression> = es
+                            .iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e.clone()
+                            })
+                            .collect();
+                        SumEq(m.clone(), es, Box::new(e.clone()))
+                    }),
+                )
+            }
+            SumGeq(m, es, e) => {
+                let m = m.clone();
+                let field_1 = Many(es.iter().map(|e| One(e.clone())).collect());
+                let field_2 = One(*e.clone());
+                let children = Many(vector![field_1, field_2]);
+                (
+                    children,
+                    Box::new(move |x| {
+                        let Many(x) = x else { panic!() };
+                        let Many(es) = &x[0] else { panic!() };
+                        let One(e) = &x[1] else { panic!() };
+                        let es: Vec<Expression> = es
+                            .iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e.clone()
+                            })
+                            .collect();
+                        SumGeq(m.clone(), es, Box::new(e.clone()))
+                    }),
+                )
+            }
+            SumLeq(m, es, e) => {
+                let m = m.clone();
+                let field_1 = Many(es.iter().map(|e| One(e.clone())).collect());
+                let field_2 = One(*e.clone());
+                let children = Many(vector![field_1, field_2]);
+                (
+                    children,
+                    Box::new(move |x| {
+                        let Many(x) = x else { panic!() };
+                        let Many(es) = &x[0] else { panic!() };
+                        let One(e) = &x[1] else { panic!() };
+                        let es: Vec<Expression> = es
+                            .iter()
+                            .map(|e| {
+                                let One(e) = e else { panic!() };
+                                e.clone()
+                            })
+                            .collect();
+                        SumLeq(m.clone(), es, Box::new(e.clone()))
+                    }),
+                )
+            }
+        }
+    }
+}

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use thiserror::Error;
 
 use crate::stats::RewriterStats;
-use uniplate::uniplate::Uniplate;
+use uniplate::biplate::Uniplate;
 
 use crate::rule_engine::{Reduction, Rule, RuleSet};
 use crate::{
@@ -119,9 +119,8 @@ fn rewrite_iteration<'a>(
     for i in 0..sub.len() {
         if let Some(red) = rewrite_iteration(&sub[i], model, rules, apply_optimizations, stats) {
             sub[i] = red.new_expression;
-            if let Ok(res) = expression.with_children(sub.clone()) {
-                return Some(Reduction::new(res, red.new_top, red.symbols));
-            }
+            let res = expression.with_children(sub.clone());
+            return Some(Reduction::new(res, red.new_top, red.symbols));
         }
     }
     // If all children are clean, mark this expression as clean

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -6,7 +6,7 @@ use conjure_core::rule_engine::{
     register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
 };
 use conjure_core::Model;
-use uniplate::uniplate::Uniplate;
+use uniplate::biplate::Uniplate;
 
 /*****************************************************************************/
 /*        This file contains basic rules for simplifying expressions         */
@@ -55,7 +55,9 @@ fn remove_nothings(expr: &Expr, _: &Model) -> ApplicationResult {
         (lhs, rhs)
     }
 
-    let new_sub = remove_nothings(expr.children())?;
+    // FIXME (niklasdewally): temporary conversion until I get the Uniplate APIs figured out
+    // Uniplate *should* support Vec<> not im::Vector
+    let new_sub = remove_nothings(expr.children().into_iter().collect())?;
 
     match expr {
         Expr::And(md, _) => Ok(Reduction::pure(Expr::And(md.clone(), new_sub))),

--- a/crates/conjure_core/src/rules/bubble.rs
+++ b/crates/conjure_core/src/rules/bubble.rs
@@ -4,7 +4,7 @@ use conjure_core::rule_engine::{
     register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
 };
 use conjure_core::Model;
-use uniplate::uniplate::Uniplate;
+use uniplate::biplate::Uniplate;
 
 register_rule_set!("Bubble", 254, ("Base"));
 
@@ -50,10 +50,7 @@ fn bubble_up(expr: &Expression, _: &Model) -> ApplicationResult {
     }
     return Ok(Reduction::pure(Expression::Bubble(
         Metadata::new(),
-        Box::new(
-            expr.with_children(sub)
-                .or(Err(ApplicationError::RuleNotApplicable))?,
-        ),
+        Box::new(expr.with_children(sub)),
         Box::new(Expression::And(Metadata::new(), bubbled_conditions)),
     )));
 }

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -2,8 +2,6 @@
 /*        Rules for translating to Minion-supported constraints         */
 /************************************************************************/
 
-use uniplate::uniplate::Uniplate;
-
 use crate::ast::{
     Constant as Const, DecisionVariable, Domain, Expression as Expr, Range, SymbolTable,
 };
@@ -13,6 +11,7 @@ use crate::rule_engine::{
 };
 use crate::solver::SolverFamily;
 use crate::Model;
+use uniplate::biplate::Uniplate;
 
 register_rule_set!("Minion", 100, ("Base"), (SolverFamily::Minion));
 
@@ -290,8 +289,7 @@ fn flatten_safediv(expr: &Expr, mdl: &Model) -> ApplicationResult {
         }
         if !new_top.is_empty() {
             return Ok(Reduction::new(
-                expr.with_children(sub)
-                    .or(Err(ApplicationError::RuleNotApplicable))?,
+                expr.with_children(sub),
                 Expr::And(Metadata::new(), new_top),
                 new_vars,
             ));


### PR DESCRIPTION
~~Based on #308~~

* Use a manual implementation of Uniplate on Expression instead of the
  derive macro.

* Use the new uniplate::biplate::Uniplate type instead of uniplate::uniplate::Uniplate. This will be the only Uniplate type in the future.

* Make conjure_core and conjure_oxide use a specific version of Uniplate (the latest commit on main at time of writing), instead of the latest "path" version of Uniplate.

These changes are to help development of the new Uniplate derive macro. 

In particular, pinning conjure_oxide to a specific version of uniplate will allow me to make breaking changes in Uniplate without having to keep fixing conjure_oxide -- instead, refactoring conjure_oxide to the new Uniplate can be done later in one go once Uniplate is more done.

In https://github.com/conjure-cp/conjure-oxide/pull/290, I am in the process of removing the old uniplate type (uniplate::uniplate::Uniplate) and rewriting the macro - the changes made in this commit ensure that during development of this PR Conjure Oxide still compiles and passes the tests.