### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,13 +57,21 @@ jobs:
       - run: rustup update ${{ matrix.rust_release }} && rustup default ${{ matrix.rust_release }}
 
       - run: cargo build -vv --workspace
+        if: ${{ matrix.rust_release == 'stable' }}
+
+      - run: cargo build -vv --workspace --features nightly
+        if: ${{ matrix.rust_release == 'nightly' }}
 
       - uses: ./.github/actions/install-conjure
         with: 
           os_arch: ${{ matrix.release_suffix }}
           version: ${{ matrix.conjure_version }}
           
+      - run: cargo test --workspace --features nightly
+        if: ${{ matrix.rust_release == 'nightly' }}
+
       - run: cargo test --workspace
+        if: ${{ matrix.rust_release == 'stable' }}
 
   audit:
     name: "Dependency Audit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
  "minion_rs",
  "project-root",
  "regex",
+ "rustc_version",
  "schemars",
  "serde",
  "serde_json",
@@ -1096,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1180,21 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -29,3 +29,9 @@ itertools = "0.12.1"
 
 [lints]
 workspace = true
+
+[build-dependencies]
+rustc_version = "0.2"
+
+[features]
+nightly = ["linkme/used_linker"]

--- a/crates/conjure_core/build.rs
+++ b/crates/conjure_core/build.rs
@@ -1,0 +1,12 @@
+use rustc_version::{version, version_meta, Channel, Version};
+
+fn main() {
+    // Set cfg flags depending on release channel
+    match version_meta().unwrap().channel {
+        Channel::Nightly => {
+            // required for the linkme feature use_linker enabled by --features nightly
+            println!("cargo:rustc-flags=-Zused_with_args");
+        }
+        _ => {}
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ This repository hosts the following projects:
 This project is being produced by staff and students of University of St
 Andrews, and is licenced under the [MPL 2.0](./LICENCE).
 
+
 ## Documentation
 
 API documentation can be found [here](https://conjure-cp.github.io/conjure-oxide/docs/).
@@ -20,6 +21,16 @@ API documentation can be found [here](https://conjure-cp.github.io/conjure-oxide
 ## Contributing
 
 See the [Contributors Guide](https://github.com/conjure-cp/conjure-oxide/wiki/Contributing).
+
+## Rust Nightly
+
+The `nightly` feature must be used when using the nightly Rust compiler:
+
+E.g.
+
+```
+cargo build --features nightly
+```
 
 <!-- vim: cc=80
 -->


### PR DESCRIPTION
Recently, linkme stopped linking correctly on nightly Ubuntu CI builds,
causing the build to fail. (https://github.com/conjure-cp/conjure-oxide/actions/runs/9155720150/job/25168652913?pr=306)

Enabling the used_linker feature of linkme fixes this. However, this
feature is nightly only, so enabling it always would break the stable
build.

A nightly feature flag has been added to enable nightly-only features
and fixes in Conjure Oxide.

