### PR TITLE
Fix nightly build 

### DIFF
--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Install rust ${{ env.rust_release }}
         run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}
       
+      - name: Disable rust-lld (to fix linkme)
+        run: | 
+          echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+          echo RUSTDOCFLAGS=${RUSTDOCFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+        if: matrix.rust_release == 'nightly'
+
       - uses: ./.github/actions/install-conjure
         with: 
           os_arch: linux

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -40,6 +40,12 @@ jobs:
 
       - name: Install rust ${{ env.rust_release }}
         run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}
+
+      - name: Disable rust-lld (to fix linkme)
+        run: | 
+          echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+          echo RUSTDOCFLAGS=${RUSTDOCFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+        if: matrix.rust_release == 'nightly'
       
       - uses: ./.github/actions/install-conjure
         with: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ on:
 env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 2
+  SCCACHE_GHA_VERSION: 4
 
 jobs:
   build-and-test:
@@ -53,6 +53,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
+
+      - name: Disable rust-lld (to fix linkme)
+        run: | 
+          echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+          echo RUSTDOCFLAGS=${RUSTDOCFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
+        if: matrix.rust_release == 'nightly'
 
       - run: rustup update ${{ matrix.rust_release }} && rustup default ${{ matrix.rust_release }}
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,21 @@ This repository hosts the following projects:
 This project is being produced by staff and students of University of St
 Andrews, and is licenced under the [MPL 2.0](./LICENCE).
 
+## Rust Nightly Support
+
+The following compiler flags are required for Conjure-Oxide to work with
+Nightly Rust:
+
+```sh
+export RUSTFLAGS="-Zlinker-features=-lld" 
+export RUSTDOCFLAGS="-Zlinker-features=-lld" 
+cargo build <...>
+```
+
+This is because of current incompatibilities with linkme and the new default
+linker ([link](https://github.com/dtolnay/linkme/issues/94)).
+
+
 ## Documentation
 
 API documentation can be found [here](https://conjure-cp.github.io/conjure-oxide/docs/).


### PR DESCRIPTION
In recent versions of the nightly / beta compilers, the use of linkme causes linker errors. (https://github.com/dtolnay/linkme/issues/94) This is due to the new linker set as default in these versions.

Add linker flags to nightly builds to revert to the old linker behaviour.

See:
  - https://github.com/dtolnay/linkme/pull/88
  - https://blog.rust-lang.org/2024/05/17/enabling-rust-lld-on-linux.html