### PR TITLE
tests: add .eprime file extension support to the test runner

### DIFF
--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -30,13 +30,14 @@ impl From<ParseErr> for EssenceParseError {
 pub fn parse_essence_file(
     path: &str,
     filename: &str,
+    extension: &str,
     context: Arc<RwLock<Context<'static>>>,
 ) -> Result<Model, EssenceParseError> {
     let mut cmd = std::process::Command::new("conjure");
     let output = match cmd
         .arg("pretty")
         .arg("--output-format=astjson")
-        .arg(format!("{path}/{filename}.essence"))
+        .arg(format!("{path}/{filename}.{extension}"))
         .output()
     {
         Ok(output) => output,

--- a/conjure_oxide/tests/gen_test_template
+++ b/conjure_oxide/tests/gen_test_template
@@ -1,4 +1,4 @@
 #[test]
 fn {test_name}() -> Result<(), Box<dyn Error>> {{
-    integration_test("{test_dir}", "{essence_file}")
+    integration_test("{test_dir}", "{essence_file}","{ext}")
 }}

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -25,7 +25,7 @@ fn main() {
 }
 
 #[allow(clippy::unwrap_used)]
-fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>> {
+fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(), Box<dyn Error>> {
     let context: Arc<RwLock<Context<'static>>> = Default::default();
     let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
     let verbose = env::var("VERBOSE").unwrap_or("false".to_string()) == "true";
@@ -38,12 +38,13 @@ fn integration_test(path: &str, essence_base: &str) -> Result<(), Box<dyn Error>
     }
 
     // Stage 1: Read the essence file and check that the model is parsed correctly
-    let model = parse_essence_file(path, essence_base, context.clone())?;
+    let model = parse_essence_file(path, essence_base, extension, context.clone())?;
     if verbose {
         println!("Parsed model: {:#?}", model)
     }
 
-    context.as_ref().write().unwrap().file_name = Some(format!("{path}/{essence_base}.essence"));
+    context.as_ref().write().unwrap().file_name =
+        Some(format!("{path}/{essence_base}.{extension}"));
 
     save_model_json(&model, path, essence_base, "parse", accept)?;
     let expected_model = read_model_json(path, essence_base, "expected", "parse")?;

--- a/conjure_oxide/tests/integration/eprime-minion/README
+++ b/conjure_oxide/tests/integration/eprime-minion/README
@@ -1,0 +1,6 @@
+These tests cover Essence Prime language support targeting the Minion solver.
+They test the use of Conjure Oxide as a replacement for Savile Row.
+
+
+~niklasdewally: these tests are part of my dissertation deliverable, so ask me
+  before changing anything in here.

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/README
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/README
@@ -1,0 +1,3 @@
+The xyz problem, as in tests/integration/xyz.
+
+Copied here to check that the tester supports the .eprime file extension correctly.

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.eprime
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.eprime
@@ -1,0 +1,4 @@
+language ESSENCE' 1.0
+find a,b,c : int(1..3)
+such that a + b + c = 4
+such that a >= b

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-minion.solutions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "UserName(a)": 1,
+    "UserName(b)": 1,
+    "UserName(c)": 2
+  },
+  {
+    "UserName(a)": 2,
+    "UserName(b)": 1,
+    "UserName(c)": 1
+  }
+]

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-parse.serialised.json
@@ -1,0 +1,168 @@
+{
+  "constraints": {
+    "And": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Reference": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "UserName": "a"
+                            }
+                          ]
+                        },
+                        {
+                          "Reference": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "UserName": "b"
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "Reference": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UserName": "c"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Constant": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Int": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Geq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "UserName": "a"
+                }
+              ]
+            },
+            {
+              "Reference": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "UserName": "b"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "next_var": 0,
+  "variables": [
+    [
+      {
+        "UserName": "a"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    [
+      {
+        "UserName": "b"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    [
+      {
+        "UserName": "c"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  ]
+}

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
@@ -1,0 +1,215 @@
+{
+  "constraints": {
+    "And": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "SumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "a"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "b"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "c"
+                  }
+                ]
+              }
+            ],
+            {
+              "Constant": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Int": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "SumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "a"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "b"
+                  }
+                ]
+              },
+              {
+                "Reference": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "UserName": "c"
+                  }
+                ]
+              }
+            ],
+            {
+              "Constant": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Int": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Ineq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "UserName": "b"
+                }
+              ]
+            },
+            {
+              "Reference": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "UserName": "a"
+                }
+              ]
+            },
+            {
+              "Constant": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "next_var": 0,
+  "variables": [
+    [
+      {
+        "UserName": "a"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    [
+      {
+        "UserName": "b"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    [
+      {
+        "UserName": "c"
+      },
+      {
+        "domain": {
+          "IntDomain": [
+            {
+              "Bounded": [
+                1,
+                3
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Add support for Essence Prime files (.eprime) to the test runner. This
change will help test Conjure Oxide as a replacement for Savile Row (the
current Essence Prime toolchain).

As Essence Prime is a subset of Essence, no extra work will be needed in
Conjure Oxide to support Essence Prime.
