### PR TITLE
ci: update actions/download-artifact steps to v4

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -234,7 +234,7 @@ jobs:
             })
       
       - name: Download the previous lcov.info (historical) file
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with: |
           name: code-coverage-${{ env.num }}-${{ env.previous_artifact_id }}
           path: ./tools/code-coverage-diff/deploy-prev

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -73,7 +73,7 @@ jobs:
           echo "${{github.event.pull_request.number}}" > deploy/prnumber
 
       - name: Archive code coverage results for deployment
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-${{ steps.sha.outputs.sha }}
           path: deploy/**


### PR DESCRIPTION
Update actions/download-artifact steps in code-coverage-deploy to v4. This requires uploaded artifacts to use actions/upload-artifact v4; therefore, this has also been updated. This fixes CI failures for code-coverage-deploy.

Github deprecated actions/download-artifact@v2 [1], making it cause automatic failures on workflows that use it. This causes our code coverage deploy jobs to fail [2].

1: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
2: https://github.com/conjure-cp/conjure-oxide/actions/runs/11134871648/job/30943894187
