### PR TITLE
ci(code-coverage-deploy): only load historical lcov if it exists

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -234,6 +234,7 @@ jobs:
             })
       
       - name: Download the previous lcov.info (historical) file
+        if: steps.find_artifacts.outputs.result != '[]'
         uses: actions/download-artifact@v4
         with: |
           name: code-coverage-${{ env.num }}-${{ env.previous_artifact_id }}


### PR DESCRIPTION
The code-coverage-deploy workflow was failing, as it was trying to use historical lcov when it did not exist. This patch makes this step conditional on whether historical lcov exists or not.

https://github.com/conjure-cp/conjure-oxide/actions/runs/11146109623/job/30977305993