### PR TITLE
Improve docs

### DIFF
--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -13,6 +13,10 @@ use crate::metadata::Metadata;
 
 use super::{Domain, Range};
 
+/// Represents different types of expressions used to define rules and constraints in the model.
+///
+/// The `Expression` enum includes operations, constants, and variable references
+/// used to build rules and conditions for the model.
 #[document_compatibility]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Uniplate)]
 #[uniplate(walk_into=[])]

--- a/crates/conjure_core/src/ast/variables.rs
+++ b/crates/conjure_core/src/ast/variables.rs
@@ -4,6 +4,28 @@ use serde::{Deserialize, Serialize};
 
 use crate::ast::domains::{Domain, Range};
 
+/// Represents a decision variable within a computational model.
+///
+/// A `DecisionVariable` has a domain that defines the set of values it can take. The domain could be:
+/// - A boolean domain, meaning the variable can only be `true` or `false`.
+/// - An integer domain, meaning the variable can only take specific integer values or a range of integers.
+///
+/// # Fields
+/// - `domain`:
+///   - Type: `Domain`
+///   - Represents the set of possible values that this decision variable can assume. The domain can be a range of integers
+///     (`IntDomain`) or a boolean domain (`BoolDomain`).
+///
+/// # Example
+/// ```
+/// use crate::ast::domains::{DecisionVariable, Domain, Range};
+///
+/// let bool_var = DecisionVariable::new(Domain::BoolDomain);
+/// let int_var = DecisionVariable::new(Domain::IntDomain(vec![Range::Bounded(1, 10)]));
+///
+/// println!("Boolean Variable: {}", bool_var);
+/// println!("Integer Variable: {}", int_var);
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecisionVariable {
     pub domain: Domain,

--- a/crates/conjure_core/src/ast/variables.rs
+++ b/crates/conjure_core/src/ast/variables.rs
@@ -14,10 +14,10 @@ use crate::ast::domains::{Domain, Range};
 /// - `domain`:
 ///   - Type: `Domain`
 ///   - Represents the set of possible values that this decision variable can assume. The domain can be a range of integers
-///     (`IntDomain`) or a boolean domain (`BoolDomain`).
+///   (IntDomain) or a boolean domain (BoolDomain).
 ///
 /// # Example
-/// ```
+/// 
 /// use crate::ast::domains::{DecisionVariable, Domain, Range};
 ///
 /// let bool_var = DecisionVariable::new(Domain::BoolDomain);
@@ -25,10 +25,10 @@ use crate::ast::domains::{Domain, Range};
 ///
 /// println!("Boolean Variable: {}", bool_var);
 /// println!("Integer Variable: {}", int_var);
-/// ```
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+<<<<<<< HEAD
+///
+=======
 pub struct DecisionVariable {
-    pub domain: Domain,
 }
 
 impl DecisionVariable {

--- a/crates/conjure_core/src/ast/variables.rs
+++ b/crates/conjure_core/src/ast/variables.rs
@@ -26,8 +26,10 @@ use crate::ast::domains::{Domain, Range};
 /// println!("Boolean Variable: {}", bool_var);
 /// println!("Integer Variable: {}", int_var);
 
-pub struct DecisionVariable {}
-
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionVariable {
+    pub domain: Domain,
+}
 impl DecisionVariable {
     pub fn new(domain: Domain) -> DecisionVariable {
         DecisionVariable { domain }

--- a/crates/conjure_core/src/ast/variables.rs
+++ b/crates/conjure_core/src/ast/variables.rs
@@ -17,7 +17,7 @@ use crate::ast::domains::{Domain, Range};
 ///   (IntDomain) or a boolean domain (BoolDomain).
 ///
 /// # Example
-/// 
+///
 /// use crate::ast::domains::{DecisionVariable, Domain, Range};
 ///
 /// let bool_var = DecisionVariable::new(Domain::BoolDomain);
@@ -25,11 +25,8 @@ use crate::ast::domains::{Domain, Range};
 ///
 /// println!("Boolean Variable: {}", bool_var);
 /// println!("Integer Variable: {}", int_var);
-<<<<<<< HEAD
-///
-=======
-pub struct DecisionVariable {
-}
+
+pub struct DecisionVariable {}
 
 impl DecisionVariable {
     pub fn new(domain: Domain) -> DecisionVariable {

--- a/crates/conjure_core/src/model.rs
+++ b/crates/conjure_core/src/model.rs
@@ -10,6 +10,36 @@ use crate::ast::{DecisionVariable, Domain, Expression, Name, SymbolTable};
 use crate::context::Context;
 use crate::metadata::Metadata;
 
+/// Represents a computational model containing variables, constraints, and a shared context.
+///
+/// The `Model` struct holds a set of variables and constraints for manipulating and evaluating symbolic expressions.
+///
+/// # Fields
+/// - `variables`:
+///   - Type: `SymbolTable`
+///   - A table that links each variable's name to its corresponding `DecisionVariable`.
+///   - For example, the name `x` might be linked to a `DecisionVariable` that says `x` can only take values between 1 and 10.
+///
+/// - `constraints`:
+///   - Type: `Expression`
+///   - Represents the logical constraints applied to the model's variables.
+///   - Can be a single constraint or a combination of various expressions, such as logical operations (e.g., `AND`, `OR`),
+///     arithmetic operations (e.g., `SafeDiv`, `UnsafeDiv`), or specialized constraints like `SumEq`.
+///
+/// - `context`:
+///   - Type: `Arc<RwLock<Context<'static>>>`
+///   - A shared object that stores global settings and state for the model.
+///   - Can be safely read or changed by multiple parts of the program at the same time, making it good for multi-threaded use.
+///
+/// - `next_var`:
+///   - Type: `RefCell<i32>`
+///   - A counter used to create new, unique variable names.
+///   - Allows updating the counter inside the model without making the whole model mutable.
+///
+/// # Usage
+/// This struct is typically used to:
+/// - Define a set of variables and constraints for rule-based evaluation.
+/// - Have transformations, optimizations, and simplifications applied to it using a set of rules.
 #[serde_as]
 #[derive(Derivative, Clone, Debug, Serialize, Deserialize)]
 #[derivative(PartialEq, Eq)]

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -318,7 +318,7 @@ fn apply_all_rules<'a>(
 ) -> Vec<RuleResult<'a>> {
     let mut results = Vec::new();
     for rule in rules {
-        match rule.apply(expression, modchooseel) {
+        match rule.apply(expression, model) {
             Ok(red) => {
                 log::trace!(target: "file", "Rule applicable: {:?}, to Expression: {:?}, resulting in: {:?}", rule, expression, red.new_expression);
                 stats.rewriter_rule_application_attempts =

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -21,6 +21,9 @@ struct RuleResult<'a> {
     reduction: Reduction,
 }
 
+/// Represents errors that can occur during the model rewriting process.
+///
+/// This enum captures errors that occur when trying to resolve or apply rules in the model.
 #[derive(Debug, Error)]
 pub enum RewriteError {
     ResolveRulesError(ResolveError),

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -87,34 +87,16 @@ fn optimizations_enabled() -> bool {
 /// - Using `rewrite_model` with the Expression `a + min(x, y)`
 ///
 ///     Initial expression: a + min(x, y)
-///     let initial_constraints = Expression::new(Sum(Metadata, Vec<Expression(a + min(x, y)))),
-///     let variables = SymbolTable::new  //a hashamp that will hold variables a,x,y
-///    
-///     // Create a model containing the expression
-///     let model = Model::new(variables, initial_constraints, some_context, next_var);
-///
-///     // Define rule sets with simplification rules for the benefit of the example
-///     let rule_set_1 = RuleSet::new(vec![
-///         Rule::new("min(x, y) => d if d <= x and d<=y "),
-///         Rule::new("a + 0 => a"),
-///     ]);
-///
-///     let rule_set_2 = RuleSet::new(vec![
-///         Rule::new("x * 1 => x"),
-///     ]);
-///
-///     Apply the rewriting model
-///     let optimized_model = rewrite_model(&model, &vec![&rule_set_1, &rule_set_2])?;
-///
-/// //Inside rewrite_model
-///     //After getting the rules by their priorities and getting additional statistics the while loop of single interations
-///     //is executed
-///     while let Some(step) = None // the loop is exited only when no more rules can be applied, when rewrite_iteration returns None
+///     A model containing the expression is created. The variables of the model are represented by a SymbolTable and contain a,x,y.
+///     The contraints of the initail model is the expression itself.
 ///     
-///     //will result is side effects ((d<=x ^ d<=y) being the new_top and the model will now be a conjuction of that and (a+d)
-///     step.(&mut new_model)
+///     After getting the rules by their priorities and getting additional statistics the while loop of single interations is executed.
+///     Function
+///     The loop is exited only when no more rules can be applied, when rewrite_iteration returns None and [`while let Some(step) = None`] occurs
+///     
+///     Will result in side effects ((d<=x ^ d<=y) being the [`new_top`] and the model will now be a conjuction of that and (a+d)
 ///      
-///     //Rewritten expression: ((a + d) ^ (d<=x ^ d<=y))/
+///     Rewritten expression: ((a + d) ^ (d<=x ^ d<=y))
 ///
 /// # Performance Considerations
 /// - The function checks if optimizations are enabled before applying rules, which may affect the performance
@@ -193,29 +175,29 @@ pub fn rewrite_model<'a>(
 ///
 /// # Example of rewtire iteration for the expression `a + min(x, y)`
 ///
-///  //Initially
+///  Initially
 ///  if apply_optimizations && expression.is_clean() //is not true yet since intially our expression is dirty
 ///
 ///  rule_results = null //apply_results returns a null vector since no rules can be applied at the top level
 ///  let mut sub = expression.children();  // sub = [a, min(x, y)] - vector of subexpressions
 ///
-/// //the function iterates through the vector of the children of the top expression and calls itself
+///  the function iterates through the vector of the children of the top expression and calls itself
 ///
-/// //rewrite_iteration on a returns None, but on min(x, y) returns a Reduction object red. In this case, Rule 1 (min simplification) might apply:
-/// //d is added to the SymbolTable and the variables field is updated in the model. new_top is the side effects: (d<=x ^ d<=y)
+///  rewrite_iteration on a returns None, but on min(x, y) returns a Reduction object red. In this case, Rule 1 (min simplification) might apply:
+///  d is added to the SymbolTable and the variables field is updated in the model. new_top is the side effects: (d<=x ^ d<=y)
 ///  let red = Reduction::new(new_expression = d, new_top, symbols);
-///  sub[1] = red.new_expression;  // Update `min(x, y)` to `d`
+///  sub[1] = red.new_expression - Updates `min(x, y)` to `d`
 ///
-/// //Since a child expression (min(x, y)) was rewritten to x, the parent expression (a + min(x, y)) is updated with the new child:
+///  Since a child expression (min(x, y)) was rewritten to x, the parent expression (a + min(x, y)) is updated with the new child:
 ///  let res = expression.with_children(sub.clone());  // res = `a + d`
 ///  return Some(Reduction::new(res, red.new_top, red.symbols));  // `a + d`,
 ///
-///  //the condition in the while loop in rewrite_model is met -> side effects are applied
+///  the condition in the while loop in rewrite_model is met -> side effects are applied
 ///
-///  //no more rules in our example can apply to the modified model -> mark all the children as clean and return a pure reduction
+///  no more rules in our example can apply to the modified model -> mark all the children as clean and return a pure reduction
 ///  return Some(Reduction::pure(expression));
 ///    
-/// //on the last execution of rewrite_iteration
+///  on the last execution of rewrite_iteration
 ///  if apply_optimizations && expression.is_clean() {
 ///      return None; //the while loop is rewrite_model is exited
 ///

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -86,8 +86,7 @@ fn optimizations_enabled() -> bool {
 /// # Example
 /// - Using `rewrite_model` with the Expression `a + min(x, y)`
 ///
-/// ```rust
-///     // Initial expression: a + min(x, y)
+///     Initial expression: a + min(x, y)
 ///     let initial_constraints = Expression::new(Sum(Metadata, Vec<Expression(a + min(x, y)))),
 ///     let variables = SymbolTable::new  //a hashamp that will hold variables a,x,y
 ///    
@@ -104,7 +103,7 @@ fn optimizations_enabled() -> bool {
 ///         Rule::new("x * 1 => x"),
 ///     ]);
 ///
-///     // Apply the rewriting model
+///     Apply the rewriting model
 ///     let optimized_model = rewrite_model(&model, &vec![&rule_set_1, &rule_set_2])?;
 ///
 /// //Inside rewrite_model
@@ -116,7 +115,6 @@ fn optimizations_enabled() -> bool {
 ///     step.(&mut new_model)
 ///      
 ///     //Rewritten expression: ((a + d) ^ (d<=x ^ d<=y))/
-/// ```
 ///
 /// # Performance Considerations
 /// - The function checks if optimizations are enabled before applying rules, which may affect the performance
@@ -194,7 +192,7 @@ pub fn rewrite_model<'a>(
 ///   optimized or processed.
 ///
 /// # Example of rewtire iteration for the expression `a + min(x, y)`
-/// ```rust
+///
 ///  //Initially
 ///  if apply_optimizations && expression.is_clean() //is not true yet since intially our expression is dirty
 ///
@@ -220,9 +218,8 @@ pub fn rewrite_model<'a>(
 /// //on the last execution of rewrite_iteration
 ///  if apply_optimizations && expression.is_clean() {
 ///      return None; //the while loop is rewrite_model is exited
-/// }
 ///
-/// ```
+///
 ///
 /// # Notes
 /// - This function works recursively, meaning it traverses all sub-expressions within the given `expression` to find the
@@ -296,14 +293,14 @@ fn rewrite_iteration<'a>(
 /// - Debug or trace logging may be performed to track which rules were applicable or not for a given expression.
 ///
 /// # Example
-/// ```rust
+///
 /// let applicable_rules = apply_all_rules(&expr, &model, &rules, &mut stats);
 /// if !applicable_rules.is_empty() {
 ///     for result in applicable_rules {
 ///         println!("Rule applied: {:?}", result.rule);
 ///     }
 /// }
-/// ```
+///
 ///
 /// # Notes
 /// - This function does not modify the input `expression` or `model` directly. The returned `RuleResult` vector
@@ -363,12 +360,12 @@ fn apply_all_rules<'a>(
 /// - `None`: If no rule applications are available in the `results` slice (i.e., it is empty), it returns `None`.
 ///
 /// # Example
-/// ```rust
+///
 /// let rule_results = vec![rule1_result, rule2_result];
 /// if let Some(reduction) = choose_rewrite(&rule_results) {
-///     // Process the chosen reduction
+/// Process the chosen reduction
 /// }
-/// ```
+///
 fn choose_rewrite(results: &[RuleResult]) -> Option<Reduction> {
     if results.is_empty() {
         return None;

--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -16,9 +16,40 @@ pub enum ApplicationError {
     DomainError,
 }
 
-/// The result of applying a rule to an expression.
+/// Represents the result of applying a rule to an expression within a model.
 ///
-/// Contains an expression to replace the original, a top-level constraint to add to the top of the constraint AST, and an expansion to the model symbol table.
+/// A `Reduction` encapsulates the changes made to a model during a rule application.
+/// It includes a new expression to replace the original one, an optional top-level constraint
+/// to be added to the model, and any updates to the model's symbol table.
+///
+/// This struct allows for representing side-effects of rule applications, ensuring that
+/// all modifications, including symbol table expansions and additional constraints, are
+/// accounted for and can be applied to the model consistently.
+///
+/// # Fields
+/// - `new_expression`: The updated [`Expression`] that replaces the original one after applying the rule.
+/// - `new_top`: An additional top-level [`Expression`] constraint that should be added to the model. If no top-level
+///   constraint is needed, this field can be set to `Expression::Nothing`.
+/// - `symbols`: A [`SymbolTable`] containing any new symbol definitions or modifications to be added to the model's
+///   symbol table. If no symbols are modified, this field can be set to an empty symbol table.
+///
+/// # Usage
+/// A `Reduction` can be created using one of the provided constructors:
+/// - [`Reduction::new`]: Creates a reduction with a new expression, top-level constraint, and symbol modifications.
+/// - [`Reduction::pure`]: Creates a reduction with only a new expression and no side-effects on the symbol table or constraints.
+/// - [`Reduction::with_symbols`]: Creates a reduction with a new expression and symbol table modifications, but no top-level constraint.
+/// - [`Reduction::with_top`]: Creates a reduction with a new expression and a top-level constraint, but no symbol table modifications.
+///
+/// The `apply` method allows for applying the changes represented by the `Reduction` to a [`Model`].
+///
+/// # Example
+/// ```
+/// // Need to add an example
+/// ```
+///
+/// # See Also
+/// - [`ApplicationResult`]: Represents the result of applying a rule, which may either be a `Reduction` or an `ApplicationError`.
+/// - [`Model`]: The structure to which the `Reduction` changes are applied.
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct Reduction {

--- a/crates/conjure_core/src/rule_engine/rule_set.rs
+++ b/crates/conjure_core/src/rule_engine/rule_set.rs
@@ -8,7 +8,25 @@ use log::warn;
 use crate::rule_engine::{get_rule_set_by_name, get_rules, Rule};
 use crate::solver::SolverFamily;
 
-/// A set of rules with a name, priority, and dependencies.
+/// A structure representing a set of rules with a name, priority, and dependencies.
+///
+/// `RuleSet` is a way to group related rules together under a single name.
+/// You can think of it like a list of rules that belong to the same category.
+/// Each `RuleSet` can also have a number that tells it what order it should run in compared to other `RuleSet` instances.
+/// Additionally, a `RuleSet` can depend on other `RuleSet` instances, meaning it needs them to run first.
+///
+/// To make things efficient, `RuleSet` only figures out its rules and dependencies the first time they're needed,
+/// and then it remembers them so it doesn't have to do the work again.
+///
+/// # Fields
+/// - `name`: The name of the rule set.
+/// - `order`: A number that decides the order in which this `RuleSet` should be applied.
+/// If two `RuleSet` instances have the same rule but with different priorities,
+/// the one with the higher `order` number will be the one that is used.
+/// - `rules`: A lazily initialized map of rules to their priorities.
+/// - `dependency_rs_names`: The names of the rule sets that this rule set depends on.
+/// - `dependencies`: A lazily initialized set of `RuleSet` dependencies.
+/// - `solver_families`: The solver families that this rule set applies to.
 #[derive(Clone, Debug)]
 pub struct RuleSet<'a> {
     /// The name of the rule set.

--- a/crates/conjure_core/src/stats/rewriter_stats.rs
+++ b/crates/conjure_core/src/stats/rewriter_stats.rs
@@ -2,11 +2,69 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 
+/// Represents the statistical data collected during the model rewriting process.
+///
+/// The `RewriterStats` struct is used to track various metrics and statistics related to the rewriting
+/// of a model using a set of rules. These statistics can be used for performance monitoring, debugging,
+/// and optimization purposes. The structure supports optional fields, allowing selective tracking of data
+/// without requiring all fields to be set.
+///
+/// The struct uses the following features:
+/// - `#[skip_serializing_none]`: Skips serializing fields that have a value of `None`, resulting in cleaner JSON output.
+/// - `#[serde(rename_all = "camelCase")]`: Uses camelCase for all serialized field names, adhering to common JSON naming conventions.
+///
+/// # Fields
+/// - `is_optimization_enabled`:
+///   - Type: `Option<bool>`
+///   - Indicates whether optimizations were enabled during the rewriting process.
+///   - If `Some(true)`, it means optimizations were enabled.
+///   - If `Some(false)`, optimizations were explicitly disabled.
+///   - If `None`, the status of optimizations is unknown or not tracked.
+///
+/// - `rewriter_run_time`:
+///   - Type: `Option<std::time::Duration>`
+///   - The total runtime duration of the rewriter in the current session.
+///   - If set, it indicates the amount of time spent on rewriting, measured as a `Duration`.
+///   - If `None`, the runtime is either unknown or not tracked.
+///
+/// - `rewriter_rule_application_attempts`:
+///   - Type: `Option<usize>`
+///   - The number of rule application attempts made during the rewriting process.
+///   - An attempt is counted each time a rule is evaluated, regardless of whether it was successfully applied.
+///   - If `None`, this metric is not tracked or not applicable for the current session.
+///
+/// - `rewriter_rule_applications`:
+///   - Type: `Option<usize>`
+///   - The number of successful rule applications during the rewriting process.
+///   - A successful application means the rule was successfully applied to transform the expression or constraint.
+///   - If `None`, this metric is not tracked or not applicable for the current session.
+///
+/// # Example
+/// ```
+/// let stats = RewriterStats {
+///     is_optimization_enabled: Some(true),
+///     rewriter_run_time: Some(std::time::Duration::new(2, 0)),
+///     rewriter_rule_application_attempts: Some(15),
+///     rewriter_rule_applications: Some(10),
+/// };
+///
+/// // Serialize the stats to JSON
+/// let serialized_stats = serde_json::to_string(&stats).unwrap();
+/// println!("Serialized Stats: {}", serialized_stats);
+/// ```
+///
+/// # Usage Notes
+/// - This struct is intended to be used in contexts where tracking the performance and behavior of rule-based
+///   rewriting systems is necessary. It is designed to be easily serialized and deserialized to/from JSON, making it
+///   suitable for logging, analytics, and reporting purposes.
+///
+/// # See Also
+/// - [`serde_with::skip_serializing_none`]: For skipping `None` values during serialization.
+/// - [`std::time::Duration`]: For measuring and representing time intervals.
 #[skip_serializing_none]
 #[derive(Default, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
-
 pub struct RewriterStats {
     pub is_optimization_enabled: Option<bool>,
     pub rewriter_run_time: Option<std::time::Duration>,

--- a/crates/conjure_core/src/stats/rewriter_stats.rs
+++ b/crates/conjure_core/src/stats/rewriter_stats.rs
@@ -40,7 +40,7 @@ use serde_with::skip_serializing_none;
 ///   - If `None`, this metric is not tracked or not applicable for the current session.
 ///
 /// # Example
-/// ```
+///
 /// let stats = RewriterStats {
 ///     is_optimization_enabled: Some(true),
 ///     rewriter_run_time: Some(std::time::Duration::new(2, 0)),
@@ -51,7 +51,7 @@ use serde_with::skip_serializing_none;
 /// // Serialize the stats to JSON
 /// let serialized_stats = serde_json::to_string(&stats).unwrap();
 /// println!("Serialized Stats: {}", serialized_stats);
-/// ```
+///
 ///
 /// # Usage Notes
 /// - This struct is intended to be used in contexts where tracking the performance and behavior of rule-based


### PR DESCRIPTION
Improving documentation. Ideally, I would like to see all methods and methods` parametres in rule_engine documented.

TODO for rewrite.rs:
- [x] Add examples in documentation (note: where examples haven't been found - we have "// add an example" comment for better navigation)
- [x] Add docstring for choose_rewrite
- [x] Add docstring for apply_all_rules
- [x] Imrpove docstring for Expression
- [x] Add docstrings for Model struct 
- [x] Add docstrings for RewriterStats
- [x] Improve docstring for RuleSet
- [x] Add docstrings for RewriteError
- [x] Make tests pass