### PR TITLE
tester: add config.toml and extra assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,10 @@ fabric.properties
 .idea/inspectionProfiles
 .idea/.gitignore
 .idea/conjure-oxide.iml
+
+# savile row files
+*.eprime.solution
+*.eprime.infor
+*.eprime.minion
+*.eprime.solution
+*.eprime.info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "toml",
  "uniplate",
  "versions",
  "walkdir",
@@ -1164,6 +1165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1437,40 @@ dependencies = [
  "bytes",
  "parking_lot",
  "pin-project-lite",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.5.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1717,6 +1761,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -28,6 +28,7 @@ regex = "1.11.0"
 log = "0.4.22"
 structured-logger = "1.0.3"
 schemars = "0.8.21"
+toml = "0.8.19"
 
 [features]
 

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -1,10 +1,12 @@
 use std::env;
 use std::error::Error;
+use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
 
+use conjure_core::ast::Expression;
 use conjure_core::context::Context;
 use conjure_oxide::rule_engine::resolve_rule_sets;
 use conjure_oxide::rule_engine::rewrite_model;
@@ -14,6 +16,15 @@ use conjure_oxide::utils::testing::{
     read_minion_solutions_json, read_model_json, save_minion_solutions_json, save_model_json,
 };
 use conjure_oxide::SolverFamily;
+
+use uniplate::Uniplate;
+
+use serde::Deserialize;
+
+#[derive(Deserialize, Default)]
+struct TestConfig {
+    extra_rewriter_asserts: Vec<String>,
+}
 
 fn main() {
     let file_path = Path::new("/path/to/your/file.txt");
@@ -62,6 +73,13 @@ fn integration_test_inner(
         );
     }
 
+    let config: TestConfig =
+        if let Ok(config_contents) = fs::read_to_string(format!("{}/config.toml", path)) {
+            toml::from_str(&config_contents).unwrap()
+        } else {
+            Default::default()
+        };
+
     // Stage 1: Read the essence file and check that the model is parsed correctly
     let model = parse_essence_file(path, essence_base, extension, context.clone())?;
     if verbose {
@@ -90,6 +108,16 @@ fn integration_test_inner(
     }
 
     save_model_json(&model, path, essence_base, "rewrite", accept)?;
+
+    for extra_assert in config.extra_rewriter_asserts {
+        match extra_assert.as_str() {
+            "vector_operators_have_partially_evaluated" => {
+                assert_vector_operators_have_partially_evaluated(&model)
+            }
+            x => println!("Unrecognised extra assert: {}", x),
+        };
+    }
+
     let expected_model = read_model_json(path, essence_base, "expected", "rewrite")?;
     if verbose {
         println!("Expected model: {:#?}", expected_model)
@@ -114,6 +142,47 @@ fn integration_test_inner(
     save_stats_json(context, path, essence_base)?;
 
     Ok(())
+}
+
+fn assert_vector_operators_have_partially_evaluated(model: &conjure_core::Model) {
+    model.constraints.descend(Arc::new(|x| {
+        use conjure_core::ast::Expression::*;
+        match &x {
+            Nothing => (),
+            Bubble(_, _, _) => (),
+            Constant(_, _) => (),
+            Reference(_, _) => (),
+            Sum(_, vec) => assert_constants_leq_one(&x, vec),
+            Min(_, vec) => assert_constants_leq_one(&x, vec),
+            Not(_, _) => (),
+            Or(_, vec) => assert_constants_leq_one(&x, vec),
+            And(_, vec) => assert_constants_leq_one(&x, vec),
+            Eq(_, _, _) => (),
+            Neq(_, _, _) => (),
+            Geq(_, _, _) => (),
+            Leq(_, _, _) => (),
+            Gt(_, _, _) => (),
+            Lt(_, _, _) => (),
+            SafeDiv(_, _, _) => (),
+            UnsafeDiv(_, _, _) => (),
+            SumEq(_, vec, _) => assert_constants_leq_one(&x, vec),
+            SumGeq(_, vec, _) => assert_constants_leq_one(&x, vec),
+            SumLeq(_, vec, _) => assert_constants_leq_one(&x, vec),
+            DivEq(_, _, _, _) => (),
+            Ineq(_, _, _, _) => (),
+            AllDiff(_, vec) => assert_constants_leq_one(&x, vec),
+        };
+        x.clone()
+    }));
+}
+
+fn assert_constants_leq_one(parent_expr: &Expression, exprs: &[Expression]) {
+    let count = exprs.iter().fold(0, |i, x| match x {
+        Expression::Constant(_, _) => i + 1,
+        _ => i,
+    });
+
+    assert!(count <= 1, "assert_vector_operators_have_partially_evaluated: expression {} is not partially evaluated",parent_expr)
 }
 
 #[test]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/config.toml
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/config.toml
@@ -1,0 +1,1 @@
+extra_rewriter_asserts=["vector_operators_have_partially_evaluated"]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.eprime.disabled
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.eprime.disabled
@@ -1,0 +1,3 @@
+language ESSENCE' 1.0
+given x,y :int(1..50) such that
+  x + 10 + 20 + y + 5 = 100

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -21,7 +21,6 @@ use super::{Domain, Range};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Uniplate)]
 #[uniplate(walk_into=[])]
 #[biplate(to=Constant)]
-#[non_exhaustive]
 pub enum Expression {
     /**
      * Represents an empty expression

--- a/tools/test-summary.sh
+++ b/tools/test-summary.sh
@@ -55,6 +55,6 @@ echo ""
     echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
   done
   for test in $DISABLED_EPRIME_TESTS; do
-    echo -e "$ test, \033[0;33m$test , disabled \033[0m\n"
+    echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
   done
 } | sort -k1 -t, | cut -d, -f 2,3 | column -t -s,


### PR DESCRIPTION
Add a  configuration file, config.toml, to test cases, allowing
optional extra assertions to be enabled. These assertions are run on the
rewritten model.

Add the "vector_operators_have_partially_evaluated" assertion, allowing
testing of partial evaluation.


## Changelog

- **tools/test-summary: fix typo**
- **gitignore: add savile row solution files**

- **tester: when verbose is enabled, do not run tests in parallel**

    When verbose printing is enabled in the tester, run tests in sequence
    not parallel. When run in parallel, log messages from tests would appear
    out of order and interspersed with logs from other test cases.

- **tester: allow enabling of extra assertions in config.toml**

    Add an optional configuration file, config.toml, to test cases, allowing
    optional extra assertions to be enabled. These assertions are run on the
    rewritten model.

    Add the "vector_operators_have_partially_evaluated" assertion, allowing
    testing of partial evaluation.
