### PR TITLE
fix(ci): checkout repository before generating code coverage comment (2)

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -101,6 +101,7 @@ jobs:
     needs: deploy-coverage
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Checkout repository at the start of the comment job of
code-coverage-deploy.yml. This job relies on files in the repo; however,
no copy of the repo was present, causing missing file errors.

This was mistakenly left out of 781ca09a (fix(ci): checkout repository
before generating code coverage comment, 2024-10-06).
