### PR TITLE
To fix issue #354 (allowing disabled integration tests to be run)

### DIFF
--- a/conjure_oxide/build.rs
+++ b/conjure_oxide/build.rs
@@ -1,3 +1,4 @@
+
 use std::env::var;
 use std::fs::{read_dir, File};
 use std::io::{self, Write};
@@ -18,46 +19,88 @@ fn main() -> io::Result<()> {
     for subdir in WalkDir::new(test_dir) {
         let subdir = subdir?;
         if subdir.file_type().is_dir() {
-            let stems: Vec<String> = read_dir(subdir.path())?
-                .filter_map(Result::ok)
-                .filter(|entry| {
-                    entry
-                        .path()
-                        .extension()
-                        .map_or(false, |ext| ext == "essence" || ext == "eprime")
-                })
-                .filter_map(|entry| {
-                    entry
-                        .path()
-                        .file_stem()
-                        .and_then(|stem| stem.to_str())
-                        .map(|s| s.to_owned())
-                })
-                .collect();
+            if std::env::var("ALLTEST").is_ok(){
+                let stems: Vec<String> = read_dir(subdir.path())?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .map_or(false, |ext| ext == "essence" || ext == "eprime" || ext == "disabled")
+                    })
+                    .filter_map(|entry| {
+                        entry
+                            .path()
+                            .file_stem()
+                            .and_then(|stem| stem.to_str())
+                            .map(|s| s.to_owned())
+                    })
+                    .collect();
 
-            let exts: Vec<String> = read_dir(subdir.path())?
-                .filter_map(Result::ok)
-                .filter(|entry| {
-                    entry
-                        .path()
-                        .extension()
-                        .map_or(false, |ext| ext == "essence" || ext == "eprime")
-                })
-                .filter_map(|entry| {
-                    entry
-                        .path()
-                        .extension()
-                        .and_then(|ext| ext.to_str())
-                        .map(|s| s.to_owned())
-                })
-                .collect();
+                let exts: Vec<String> = read_dir(subdir.path())?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .map_or(false, |ext| ext == "essence" || ext == "eprime" || ext == "disabled")
+                    })
+                    .filter_map(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .and_then(|ext| ext.to_str())
+                            .map(|s| s.to_owned())
+                    })
+                    .collect();
 
-            let essence_files = std::iter::zip(stems, exts).collect();
+                let essence_files = std::iter::zip(stems, exts).collect();
 
-            write_test(&mut f, subdir.path().display().to_string(), essence_files)?;
+                write_test(&mut f, subdir.path().display().to_string(), essence_files)?;
+            } 
+
+            else {
+                let stems: Vec<String> = read_dir(subdir.path())?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .map_or(false, |ext| ext == "essence" || ext == "eprime")
+                    })
+                    .filter_map(|entry| {
+                        entry
+                            .path()
+                            .file_stem()
+                            .and_then(|stem| stem.to_str())
+                            .map(|s| s.to_owned())
+                    })
+                    .collect();
+
+                let exts: Vec<String> = read_dir(subdir.path())?
+                    .filter_map(Result::ok)
+                    .filter(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .map_or(false, |ext| ext == "essence" || ext == "eprime")
+                    })
+                    .filter_map(|entry| {
+                        entry
+                            .path()
+                            .extension()
+                            .and_then(|ext| ext.to_str())
+                            .map(|s| s.to_owned())
+                    })
+                    .collect();
+
+                let essence_files = std::iter::zip(stems, exts).collect();
+
+                write_test(&mut f, subdir.path().display().to_string(), essence_files)?;
+            }
         }
     }
-
+    
     Ok(())
 }
 


### PR DESCRIPTION
Added an environment variable (called ALLTEST) to build.rs and an if-else statement to allow for disabled integration testing to be run when tests are run using 'ALLTEST=1 cargo test --no-fail-fast'. When environment variable is not set, these disabled integration tests are not run. This is to complete issue #354 .