### PR TITLE
Define behaviour for empty expressions

### DIFF
--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -232,7 +232,6 @@ fn assert_vector_operators_have_partially_evaluated(model: &conjure_core::Model)
     model.constraints.transform(Arc::new(|x| {
         use conjure_core::ast::Expression::*;
         match &x {
-            Nothing => (),
             Bubble(_, _, _) => (),
             FactorE(_, _) => (),
             Sum(_, vec) => assert_constants_leq_one(&x, vec),

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-parse.serialised.json
@@ -1,5 +1,13 @@
 {
-  "constraints": "Nothing",
+  "constraints": {
+    "And": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      []
+    ]
+  },
   "next_var": 0,
   "variables": [
     [

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-rewrite.serialised.json
@@ -1,5 +1,17 @@
 {
-  "constraints": "Nothing",
+  "constraints": {
+    "FactorE": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      {
+        "Literal": {
+          "Bool": true
+        }
+      }
+    ]
+  },
   "next_var": 0,
   "variables": [
     [

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-parse.serialised.json
@@ -1,5 +1,13 @@
 {
-  "constraints": "Nothing",
+  "constraints": {
+    "And": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      []
+    ]
+  },
   "next_var": 0,
   "variables": [
     [

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-rewrite.serialised.json
@@ -1,5 +1,17 @@
 {
-  "constraints": "Nothing",
+  "constraints": {
+    "FactorE": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      {
+        "Literal": {
+          "Bool": true
+        }
+      }
+    ]
+  },
   "next_var": 0,
   "variables": [
     [

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -27,12 +27,6 @@ use super::{Domain, Range};
 #[biplate(to=Factor)]
 #[biplate(to=Name)]
 pub enum Expression {
-    /**
-     * Represents an empty expression
-     * NB: we only expect this at the top level of a model (if there is no constraints)
-     */
-    Nothing,
-
     /// An expression representing "A is valid as long as B is true"
     /// Turns into a conjunction when it reaches a boolean context
     Bubble(Metadata, Box<Expression>, Box<Expression>),
@@ -245,7 +239,6 @@ impl Expression {
             Expression::Ineq(_, _, _, _) => Some(ReturnType::Bool),
             Expression::AllDiff(_, _) => Some(ReturnType::Bool),
             Expression::Bubble(_, _, _) => None, // TODO: (flm8) should this be a bool?
-            Expression::Nothing => None,
             Expression::WatchedLiteral(_, _, _) => Some(ReturnType::Bool),
             Expression::Reify(_, _, _) => Some(ReturnType::Bool),
         }
@@ -306,7 +299,6 @@ impl Display for Expression {
                 Name::MachineName(n) => write!(f, "_{}", n),
                 Name::UserName(s) => write!(f, "{}", s),
             },
-            Expression::Nothing => write!(f, "Nothing"),
             Expression::Sum(_, expressions) => {
                 write!(f, "Sum({})", display_expressions(expressions))
             }

--- a/crates/conjure_core/src/model.rs
+++ b/crates/conjure_core/src/model.rs
@@ -68,7 +68,11 @@ impl Model {
     }
 
     pub fn new_empty(context: Arc<RwLock<Context<'static>>>) -> Model {
-        Model::new(Default::default(), Expression::Nothing, context)
+        Model::new(
+            Default::default(),
+            Expression::And(Metadata::new(), Vec::new()),
+            context,
+        )
     }
     // Function to update a DecisionVariable based on its Name
     pub fn update_domain(&mut self, name: &Name, new_domain: Domain) {
@@ -89,14 +93,13 @@ impl Model {
     pub fn get_constraints_vec(&self) -> Vec<Expression> {
         match &self.constraints {
             Expression::And(_, constraints) => constraints.clone(),
-            Expression::Nothing => vec![],
             _ => vec![self.constraints.clone()],
         }
     }
 
     pub fn set_constraints(&mut self, constraints: Vec<Expression>) {
         if constraints.is_empty() {
-            self.constraints = Expression::Nothing;
+            self.constraints = Expression::And(Metadata::new(), Vec::new());
         } else if constraints.len() == 1 {
             self.constraints = constraints[0].clone();
         } else {

--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -75,7 +75,7 @@ impl Reduction {
     pub fn pure(new_expression: Expression) -> Self {
         Self {
             new_expression,
-            new_top: Expression::Nothing,
+            new_top: Expression::And(Metadata::new(), Vec::new()),
             symbols: SymbolTable::new(),
         }
     }
@@ -84,7 +84,7 @@ impl Reduction {
     pub fn with_symbols(new_expression: Expression, symbols: SymbolTable) -> Self {
         Self {
             new_expression,
-            new_top: Expression::Nothing,
+            new_top: Expression::And(Metadata::new(), Vec::new()),
             symbols,
         }
     }
@@ -101,21 +101,25 @@ impl Reduction {
     // Apply side-effects (e.g. symbol table updates
     pub fn apply(self, model: &mut Model) {
         model.variables.extend(self.symbols); // Add new assignments to the symbol table
-        if let Expression::Nothing = self.new_top {
-            model.constraints = self.new_expression.clone();
-        } else {
-            model.constraints = match self.new_expression {
-                Expression::And(metadata, mut exprs) => {
-                    // Avoid creating a nested conjunction
-                    exprs.push(self.new_top.clone());
-                    Expression::And(metadata.clone_dirty(), exprs)
-                }
-                _ => Expression::And(
-                    Metadata::new(),
-                    vec![self.new_expression.clone(), self.new_top],
-                ),
-            };
+                                              // TODO: (yb33) Remove it when we change constraints to a vector
+        if let Expression::And(_, exprs) = &self.new_top {
+            if exprs.is_empty() {
+                model.constraints = self.new_expression.clone();
+                return;
+            }
         }
+
+        model.constraints = match self.new_expression {
+            Expression::And(metadata, mut exprs) => {
+                // Avoid creating a nested conjunction
+                exprs.push(self.new_top.clone());
+                Expression::And(metadata.clone_dirty(), exprs)
+            }
+            _ => Expression::And(
+                Metadata::new(),
+                vec![self.new_expression.clone(), self.new_top],
+            ),
+        };
     }
 }
 

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -83,11 +83,16 @@ fn remove_nothings(expr: &Expr, _: &Model) -> ApplicationResult {
     }
 }
 
-/// Remove empty expressions:
-///  ```text
-///   or([]) ~> false
-///   X([])  ~> Nothing
-///  ```
+/// This rule simplifies expressions where the operator is applied to an empty set of sub-expressions.
+///
+/// For example:
+/// - `or([])` simplifies to `false` since no disjunction exists.
+///
+/// **Applicable examples:**
+/// ```text
+/// or([])  ~> false
+/// X([]) ~> Nothing
+/// ```
 #[register_rule(("Base", 8800))]
 fn remove_empty_expression(expr: &Expr, _: &Model) -> ApplicationResult {
     // excluded expressions

--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -15,7 +15,6 @@ fn partial_evaluator(expr: &Expr, _: &Model) -> ApplicationResult {
     // rule infinitely!
     // This is why we always check whether we found a constant or not.
     match expr.clone() {
-        Nothing => Err(RuleNotApplicable),
         Bubble(_, _, _) => Err(RuleNotApplicable),
         FactorE(_, _) => Err(RuleNotApplicable),
         Sum(m, vec) => {


### PR DESCRIPTION
This PR is based on the Chris's and Oz's comment on Teams:

"
Chris:
I'd get existing PRs merged in first, but then it might be worth making a pass over empty constraints, I think (please check essence semantics  , and I'm not sure which are implemented yet):
 
and([]) = true
or([]) = false
sum([]) = 0
product([]) = 1
 
it's worth getting these right because (from experience), while no-one is likely to write these, they often end up getting created as parts of more interesting expressions.
 
 Oz:
min([]) and max([]) are a bit different, as min([])=x is always false, but this falseness will arise naturally from the fact they will end up turning into an 'and([])' and an 'or([])', and the or will be false, so there is no need to special-case empty min([]) and max([]) (hopefully!)
 
we can define an abstraction which has a zero vale and an append operator for these.
and is true, /\
or is false, \/
sum is 0, +
product is 1, *
regarding min and max, we already did a bunch of definedness work with Felix last semester (Soph and Yehor taking over this now)
 "