### PR TITLE
[eprime-arithmetic #1] tools: add watch-tests.sh to rerun integration tests on changes.

### DIFF
--- a/tools/test-summary.sh
+++ b/tools/test-summary.sh
@@ -8,11 +8,21 @@
 #
 #   Unlike cargo test, this script reports the number of disabled tests.
 #
-# USAGE: -
+# USAGE: 
+#   -F: only show failing tests
 #
 # Author: niklasdewally
 # Date: 2024/10/02
 # SPDX-Licence-Identifier: MPL-2.0
+
+failonly=false
+
+while getopts "F" flag; do
+  case ${flag} in
+      F) failonly=true
+        ;;
+  esac
+done
 
 cargo locate-project &>/dev/null || { echo_err "Cannot find a rust project"; usage; exit 1; }
 
@@ -32,12 +42,7 @@ DISABLED_EPRIME_TESTS=$(find -iname '*.eprime.disabled' -exec dirname "{}" \; | 
 
 cd ../..
 
-# cast all wc outputs to numbers, otherwise spacing is wierd on macos
-# also , wc -l returns one for empty input, so we need to -1
-echo "Passed: $(($(wc -l <<< $PASSED_TESTS) -1))"
-echo "Failed: $(($(wc -l <<< $FAILED_TESTS) -1))"
-echo "Disabled: $(($(wc -l <<< $DISABLED_ESSENCE_TESTS ) + $(wc -l <<< $DISABLED_EPRIME_TESTS) -1))"
-echo ""
+clear
 
 # put a dummy field at the beginning without colour then remove it, as sort doesnt like ansi codes
 {
@@ -46,15 +51,26 @@ echo ""
     echo -e "$test_p , \033[0;31m$test_p, fail\033[0m\n"
   done
 
-  for test in $PASSED_TESTS; do
-    test_p=$(sed 's/tests_integration_\(.*\)/\1/' <<< $test)
-    echo -e "$test_p , \033[0;32m$test_p, pass\033[0m\n"
-  done
+  if  [ $failonly = false ]; then
 
-  for test in $DISABLED_ESSENCE_TESTS; do
-    echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
-  done
-  for test in $DISABLED_EPRIME_TESTS; do
-    echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
-  done
+    for test in $PASSED_TESTS; do
+      test_p=$(sed 's/tests_integration_\(.*\)/\1/' <<< $test)
+      echo -e "$test_p , \033[0;32m$test_p, pass\033[0m\n"
+    done
+
+    for test in $DISABLED_ESSENCE_TESTS; do
+      echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
+    done
+    for test in $DISABLED_EPRIME_TESTS; do
+      echo -e "$test, \033[0;33m$test , disabled \033[0m\n"
+    done
+  fi
+
 } | sort -k1 -t, | cut -d, -f 2,3 | column -t -s,
+
+# cast all wc outputs to numbers, otherwise spacing is wierd on macos
+# also , wc -l returns one for empty input, so we need to -1
+echo ""
+echo "Passed: $(($(wc -l <<< $PASSED_TESTS) -1))"
+echo "Failed: $(($(wc -l <<< $FAILED_TESTS) -1))"
+echo "Disabled: $(($(wc -l <<< $DISABLED_ESSENCE_TESTS ) + $(wc -l <<< $DISABLED_EPRIME_TESTS) -1))"

--- a/tools/watch-tests.sh
+++ b/tools/watch-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# ./watch-tests.sh.
+#
+# DESCRIPTION: give a live-updating summary of integration test passes and failures.
+#
+# USAGE: 
+#   Environment variables such as ACCEPT and ALLTESTS are passed directly
+#   through to the tester.
+#
+#   This tool requires watchman.
+#
+# Author: niklasdewally
+# Date: 2024/10/31
+
+[ $(command -v watchman) ] || { >&2 echo "fatal: watchman not found!"; exit 1; }
+
+cargo locate-project &>/dev/null || { echo_err "Cannot find a rust project"; usage; exit 1; }
+PROJECT_ROOT=$(dirname $(cargo locate-project | jq -r .root 2> /dev/null))
+cd "$PROJECT_ROOT"
+
+./tools/test-summary.sh -F
+watchman-make -p '**/*.rs' '**/*.essence' '**/*.eprime' --run "./tools/test-summary.sh -F"


### PR DESCRIPTION
Add a script watch-tests.sh to rerun the integration tests on changes to
the code or essence/eprime files. This gives a summary of failing tests
that is updated only when the source-code is.

While similar to bacon, bacon ignores ACCEPT=true, while this script
recognises it. Also, the output of this script is more readable, as it
uses the output of test-summary.sh not cargo test.
