### PR TITLE
implemented bug! when multiple rules can be applied to an expression

### DIFF
--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -28,7 +28,7 @@ use conjure_oxide::SolverFamily;
 struct Cli {
     #[arg(
         value_name = "INPUT_ESSENCE",
-        default_value = "./conjure_oxide/tests/integration/basic/max/input.essence",
+        default_value = "./conjure_oxide/tests/integration//xyz/input.essence",
         help = "The input Essence file"
     )]
     input_file: PathBuf,
@@ -132,8 +132,8 @@ pub fn main() -> AnyhowResult<()> {
     let rule_priorities = get_rule_priorities(&rule_sets)?;
     let rules_vec = get_rules_vec(&rule_priorities);
 
-    log::info!(target: "file", 
-         "Rules and priorities: {}", 
+    log::info!(target: "file",
+         "Rules and priorities: {}",
          rules_vec.iter()
             .map(|rule| format!("{}: {}", rule.name, rule_priorities.get(rule).unwrap_or(&0)))
             .collect::<Vec<_>>()


### PR DESCRIPTION
bug! is thrown when `apply_all_rules` returns a vector of `RuleResult` containing more than 1 element. A message is displayed informing us what expression we are dealing with and all the rules that are applicable to it. 

Example of the message:
```
More than 1 rule can be applied to expression: 
SumGeq(Metadata { clean: false, etype: None }, [Reference(Metadata { clean: false, etype: None }, UserName("x")), Reference(Metadata { clean: false, etype: None }, UserName("y"))], Reference(Metadata { clean: false, etype: None }, UserName("z"))) 

Rules: [Rule { name: "flatten_sum_geq", application: 0x5601461fc250, rule_sets: [("Minion", 4400)] }, Rule { name: "geq_to_ineq", application: 0x5601461fd8f0, rule_sets: [("Minion", 4100)] }]
```