### PR TITLE
[eprime-arithmetic #2] tester: add pretty_assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "linkme",
  "log",
  "minion_rs",
+ "pretty_assertions",
  "rand",
  "regex",
  "schemars",
@@ -431,6 +432,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dyn-clone"
@@ -867,6 +874,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -1772,6 +1789,12 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -39,3 +39,6 @@ unstable-solver-interface = ["unstable"]
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -25,6 +25,8 @@ use uniplate::Uniplate;
 
 use serde::Deserialize;
 
+use pretty_assertions::assert_eq;
+
 #[derive(Deserialize, Default)]
 struct TestConfig {
     extra_rewriter_asserts: Vec<String>,
@@ -211,7 +213,7 @@ fn integration_test_inner(
 
         assert_eq!(
             username_solutions_json, conjure_solutions_json,
-            "Solutions do not match conjure!"
+            "Solutions (left) do not match conjure (right)!"
         );
     }
 


### PR DESCRIPTION
Add `pretty_assertions` crate to the integration tester for more readable output.

For example:
![Screenshot 2024-11-01 at 12 48 48](https://github.com/user-attachments/assets/8a679f00-500e-4668-a256-33cfa566b284)
