### PR TITLE
cli: remove default Essence file

### DIFF
--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -1,5 +1,3 @@
-// (niklasdewally): temporary, gut this if you want!
-
 use std::fs::File;
 use std::io::stdout;
 use std::io::Write;
@@ -26,11 +24,7 @@ use conjure_oxide::SolverFamily;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(
-        value_name = "INPUT_ESSENCE",
-        default_value = "./conjure_oxide/tests/integration/basic/max/input.essence",
-        help = "The input Essence file"
-    )]
+    #[arg(value_name = "INPUT_ESSENCE", help = "The input Essence file")]
     input_file: PathBuf,
 
     #[arg(


### PR DESCRIPTION
Remove default essence file parameter, requiring the model to solve to
be passed as an argument.

Closes: #396
