### PR TITLE
fix(cli): make cli and tester use same rule-sets

### DIFF
--- a/conjure_oxide/src/defaults.rs
+++ b/conjure_oxide/src/defaults.rs
@@ -1,0 +1,8 @@
+/// Returns the default rule sets, excluding solver specific ones.
+pub fn get_default_rule_sets() -> Vec<String> {
+    vec![
+        "Base".to_string(),
+        "Constant".to_string(),
+        "Bubble".to_string(),
+    ]
+}

--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -20,3 +20,5 @@ pub mod utils;
 
 #[doc(hidden)]
 pub mod unstable;
+
+pub mod defaults;

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -7,6 +7,7 @@ use std::process::exit;
 use anyhow::Result as AnyhowResult;
 use anyhow::{anyhow, bail};
 use clap::{arg, command, Parser};
+use conjure_oxide::defaults::get_default_rule_sets;
 use schemars::schema_for;
 use serde_json::json;
 use serde_json::to_string_pretty;
@@ -74,7 +75,9 @@ pub fn main() -> AnyhowResult<()> {
     }
 
     let target_family = cli.solver.unwrap_or(SolverFamily::Minion);
-    let extra_rule_sets: Vec<String> = cli.extra_rule_sets;
+    let mut extra_rule_sets: Vec<String> = get_default_rule_sets();
+    extra_rule_sets.extend(cli.extra_rule_sets);
+
     let out_file: Option<File> = match &cli.output {
         None => None,
         Some(pth) => Some(

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -9,6 +9,7 @@ use std::sync::RwLock;
 
 use conjure_core::ast::{Constant, Expression, Name};
 use conjure_core::context::Context;
+use conjure_oxide::defaults::get_default_rule_sets;
 use conjure_oxide::rule_engine::resolve_rule_sets;
 use conjure_oxide::rule_engine::rewrite_model;
 use conjure_oxide::utils::conjure::minion_solutions_to_json;
@@ -123,10 +124,7 @@ fn integration_test_inner(
     assert_eq!(model, expected_model);
 
     // Stage 2: Rewrite the model using the rule engine and check that the result is as expected
-    let rule_sets = resolve_rule_sets(
-        SolverFamily::Minion,
-        &vec!["Constant".to_string(), "Bubble".to_string()],
-    )?;
+    let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets())?;
     let model = rewrite_model(&model, &rule_sets)?;
     if verbose {
         println!("Rewritten model: {:#?}", model)


### PR DESCRIPTION
The CLI and tester are using different, hard-coded lists of rule-sets.
This causes models that run in the tester to fail when run with the CLI.

Replace these hard-coded values with a call to get_default_rule_sets(),
making the rule-sets used consistent.
