### PR TITLE
rules: add extra_check! macro for conditionally compiling rule checks.

### DIFF
--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -34,6 +34,8 @@ tracing-subscriber = { version = "0.3.18", features = ["ansi", "env-filter", "js
 
 [features]
 
+default = ["extra-rule-checks"]
+extra-rule-checks = ["conjure_core/extra-rule-checks"]
 unstable = []
 unstable-solver-interface = ["unstable"]
 

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -233,6 +233,12 @@ pub fn main() -> AnyhowResult<()> {
 
     context.write().unwrap().file_name = Some(cli.input_file.to_str().expect("").into());
 
+    if cfg!(feature = "extra-rule-checks") {
+        log::info!("extra-rule-checks: enabled");
+    } else {
+        log::info!("extra-rule-checks: disabled");
+    }
+
     let mut model = model_from_json(&astjson, context.clone())?;
 
     log::info!(target: "file", "Initial model: {}", json!(model));

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -3,6 +3,9 @@ name = "conjure_core"
 version = "0.0.1"
 edition = "2021"
 
+[features]
+extra-rule-checks = []
+
 [dependencies]
 conjure_macros = { path = "../conjure_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }

--- a/crates/conjure_core/src/rules/mod.rs
+++ b/crates/conjure_core/src/rules/mod.rs
@@ -13,3 +13,22 @@ mod cnf;
 mod constant;
 mod minion;
 mod partial_eval;
+
+/// Denotes a block of code as extra, optional checks for a rule. Primarily, these are checks that
+/// are too expensive to do normally, or are implicit in the rule priorities and application order.
+///
+/// The latter is necessary as, at the time of writing, rules that cover more of the tree are
+/// applied over more local rules of higher priority. In the future, rules will be applied strictly
+/// by priority not size; however, for now, if we want a given global rule G to only run after a
+/// local rule R, we must make it explicit by making G check that R is not applicable to any child
+/// expressions.
+///
+/// These only run when the extra-rule-checks feature flag is enabled. At time of writing, this is
+/// on by default.
+macro_rules! extra_check {
+    {$($stmt:stmt)*} => {
+        if cfg!(feature ="extra-rule-checks") {
+            ($($stmt)*)
+        }
+    };
+}


### PR DESCRIPTION
Add extra_check! macro, and the extra-rule-checks feature, allowing
rules to specify potentially expensive extra checks to be optionally
ran.

In the future, we will assume that the highest priority applicable rule
will be applied, regardless of where in the tree it applies. However, we
currently only apply the most applicable rule for our current
expression, ignoring any higher priority rules that could apply to child
expressions.

For example, consider partial evaluation. In general, we want to ensure
that the entire tree is in a simplest form before proceeding.

```
R1 (priority 10): collapse constants in addition
R2 (priority 5): f(M) ~> g(M) /\ h(M) /\ i(M) /\ ...
  where M is a sum
```

For some expression `f(1+b+2)` we would want to apply R1 to the
arguments before doing R2; however, the current rewriter would apply R2
first, as this is the largest expression.

To fix this in the current rewriter, R2 would have to say that it is
only applicable when R1 isn't. This is an expensive check, and would be
unnecessary with the new rewriter; however, it is necessary for now.

extra_check! delineates these checks and will allows us to trivially
compile them out once we have the new rewriter functionality.

These checks may be helpful to retain to identify incorrect rule
priorities or spot bugs in the rewriting engine; hence I suggest keeping
them accessible under a compilation flag in the future.

This work will help my upcoming work on flattening rules.

---

Submitting this separately as it affects the rule engine as well as my Minion work. I definitely need something like this, but I am flexible about the exact approach we take. 
