### PR TITLE
logging: log rule applicable at info! not trace!

### DIFF
--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -300,7 +300,13 @@ fn apply_all_rules<'a>(
     for rule in rules {
         match rule.apply(expression, model) {
             Ok(red) => {
-                log::trace!(target: "file", "Rule applicable: {:?}, to Expression: {:?}, resulting in: {:?}", rule, expression, red.new_expression);
+                log::info!(
+                    "Rule applicable: {} ({:?}), to expression: {}, resulting in: {}",
+                    rule.name,
+                    rule.rule_sets,
+                    expression,
+                    red.new_expression
+                );
                 stats.rewriter_rule_application_attempts =
                     Some(stats.rewriter_rule_application_attempts.unwrap() + 1);
                 stats.rewriter_rule_applications =
@@ -314,7 +320,12 @@ fn apply_all_rules<'a>(
                 });
             }
             Err(_) => {
-                log::trace!(target: "file", "Rule attempted but not applied: {:?}, to Expression: {:?}", rule, expression);
+                log::trace!(
+                    "Rule attempted but not applied: {} ({:?}), to expression: {}",
+                    rule.name,
+                    rule.rule_sets,
+                    expression
+                );
                 stats.rewriter_rule_application_attempts =
                     Some(stats.rewriter_rule_application_attempts.unwrap() + 1);
                 continue;


### PR DESCRIPTION
Log "rule applicable" at info level, making it visible with the default
--verbose flag.

Also make the rule output display not debug for readability and
conciseness.
