### PR TITLE
ci: block merging PRs with fixup! commits

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,13 @@
+name: PR Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    name: "No fixup! commits"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Block any PRs with any commits called fixup!, amend!, squash! from being merged.

As discussed in #425, force pushing to existing commits is annoying to code reviewers. Another approach is to do `git commit --fixup <commit>` when you need to respond to a code review comment on a particular commit, then run `git rebase --autosquash` before merging to get rid of these fixup commits. (https://rietta.com/blog/git-rebase-autosquash-code-reviews/)

This way, code reviewers can see the code review changes to the PR in a linear order, but still keep a proper git history.
