### PR TITLE
Add a 5 minute time limit to CI actions

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   deploy-coverage:
     name: "Info: Code Coverage"
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   coverage:
     name: "Generate Code Coverage Reports"
+    timeout-minutes: 5
     # only do coverage for ready PRs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   coverage:
     name: "Generate Code Coverage Reports"
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   coverage:
     name: "Generate Documentation"
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/essence-feature-stats.yml
+++ b/.github/workflows/essence-feature-stats.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   build:
     name: "tools/essence-feature-stats: Build the tool and clone EssenceCatalog repo"
+    timeout-minutes: 5
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   rust:
     name: "Check Rust Formatting"
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   build-and-test:
     name: "Build and Test"
+    timeout-minutes: 5
     strategy:
       # run all combinations of the matrix even if one combination fails.
       fail-fast: false


### PR DESCRIPTION
We don't expect our tests to take longer than 5 minutes at the moment. If they take a very long time this might be an error (like an infinite loop). We can increase the 5 minutes if we genuinely needed more time in the future.