### PR TITLE
fix(ast): inconsistent `Display` implementations for variables

### DIFF
--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-minion.solutions.json
@@ -1,8 +1,8 @@
 [
   {
-    "UserName(x)": 0
+    "x": 0
   },
   {
-    "UserName(x)": 1
+    "x": 1
   }
 ]

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-minion.solutions.json
@@ -1,18 +1,18 @@
 [
   {
-    "UserName(x)": 0,
-    "UserName(y)": 0
+    "x": 0,
+    "y": 0
   },
   {
-    "UserName(x)": 0,
-    "UserName(y)": 1
+    "x": 0,
+    "y": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 0
+    "x": 1,
+    "y": 0
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1
+    "x": 1,
+    "y": 1
   }
 ]

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-minion.solutions.json
@@ -1,10 +1,10 @@
 [
   {
-    "UserName(x)": 0,
-    "UserName(y)": 1
+    "x": 0,
+    "y": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 0
+    "x": 1,
+    "y": 0
   }
 ]

--- a/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-minion.solutions.json
@@ -1,7 +1,7 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 42
+    "x": 1,
+    "y": 1,
+    "z": 42
   }
 ]

--- a/conjure_oxide/tests/integration/basic/div/01/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/div/01/input.expected-minion.solutions.json
@@ -1,18 +1,18 @@
 [
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1
+    "a": 1,
+    "b": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2
+    "a": 2,
+    "b": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2
+    "a": 3,
+    "b": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3
+    "a": 3,
+    "b": 3
   }
 ]

--- a/conjure_oxide/tests/integration/basic/div/02/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/div/02/input.expected-minion.solutions.json
@@ -1,8 +1,8 @@
 [
   {
-    "UserName(a)": 2
+    "a": 2
   },
   {
-    "UserName(a)": 3
+    "a": 3
   }
 ]

--- a/conjure_oxide/tests/integration/basic/div/03/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/div/03/input.expected-minion.solutions.json
@@ -1,8 +1,8 @@
 [
   {
-    "UserName(a)": 3
+    "a": 3
   },
   {
-    "UserName(a)": 4
+    "a": 4
   }
 ]

--- a/conjure_oxide/tests/integration/basic/div/04/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/div/04/input.expected-minion.solutions.json
@@ -1,262 +1,262 @@
 [
   {
-    "UserName(a)": 0,
-    "UserName(b)": 0,
-    "UserName(c)": 0
+    "a": 0,
+    "b": 0,
+    "c": 0
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 0
+    "a": 0,
+    "b": 1,
+    "c": 0
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 2,
-    "UserName(c)": 0
+    "a": 0,
+    "b": 2,
+    "c": 0
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 0,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 0
+    "a": 0,
+    "b": 3,
+    "c": 0
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 0,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 0,
+    "b": 3,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 0
+    "a": 1,
+    "b": 0,
+    "c": 0
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 0
+    "a": 1,
+    "b": 1,
+    "c": 0
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(c)": 0
+    "a": 1,
+    "b": 2,
+    "c": 0
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 3,
-    "UserName(c)": 0
+    "a": 1,
+    "b": 3,
+    "c": 0
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 0
+    "a": 2,
+    "b": 0,
+    "c": 0
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 0
+    "a": 2,
+    "b": 1,
+    "c": 0
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(c)": 0
+    "a": 2,
+    "b": 2,
+    "c": 0
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 0
+    "a": 2,
+    "b": 3,
+    "c": 0
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 3,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 0
+    "a": 3,
+    "b": 0,
+    "c": 0
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 0
+    "a": 3,
+    "b": 1,
+    "c": 0
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 0
+    "a": 3,
+    "b": 2,
+    "c": 0
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(c)": 0
+    "a": 3,
+    "b": 3,
+    "c": 0
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 3,
+    "c": 3
   }
 ]

--- a/conjure_oxide/tests/integration/basic/div/05/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/div/05/input.expected-minion.solutions.json
@@ -1,182 +1,182 @@
 [
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 0,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 0,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 0,
+    "b": 3,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 1,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 3,
+    "c": 1
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 2,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 2,
+    "b": 3,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 0,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 0,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 0,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 1,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 1
+    "a": 3,
+    "b": 2,
+    "c": 1
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 2,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 2,
+    "c": 3
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(c)": 2
+    "a": 3,
+    "b": 3,
+    "c": 2
   },
   {
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(c)": 3
+    "a": 3,
+    "b": 3,
+    "c": 3
   }
 ]

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-minion.solutions.json
@@ -1,14 +1,14 @@
 [
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 0
+    "__0": 2,
+    "a": 0
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 1
+    "__0": 2,
+    "a": 1
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2
+    "__0": 2,
+    "a": 2
   }
 ]

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-minion.solutions.json
@@ -1,7 +1,7 @@
 [
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 3,
+    "b": 3
   }
 ]

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-minion.solutions.json
@@ -1,42 +1,42 @@
 [
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 1,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 2
+    "__0": 1,
+    "a": 1,
+    "b": 2
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 3
+    "__0": 1,
+    "a": 1,
+    "b": 3
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 2,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 2,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 3,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 3,
+    "b": 1
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 2,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 3
+    "__0": 2,
+    "a": 2,
+    "b": 3
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 3,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 3,
+    "b": 2
   }
 ]

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-minion.solutions.json
@@ -1,37 +1,37 @@
 [
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 2
+    "__0": 1,
+    "a": 1,
+    "b": 2
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 3
+    "__0": 1,
+    "a": 1,
+    "b": 3
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 4
+    "__0": 1,
+    "a": 1,
+    "b": 4
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 2,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 3
+    "__0": 2,
+    "a": 2,
+    "b": 3
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 4
+    "__0": 2,
+    "a": 2,
+    "b": 4
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 3,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 3,
+    "b": 2
   }
 ]

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-minion.solutions.json
@@ -1,47 +1,47 @@
 [
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 2
+    "__0": 1,
+    "a": 1,
+    "b": 2
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 3
+    "__0": 1,
+    "a": 1,
+    "b": 3
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 4
+    "__0": 1,
+    "a": 1,
+    "b": 4
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 2,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 3
+    "__0": 2,
+    "a": 2,
+    "b": 3
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 4
+    "__0": 2,
+    "a": 2,
+    "b": 4
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 3,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 3,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 4,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 4,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 5,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 5,
+    "b": 2
   }
 ]

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-minion.solutions.json
@@ -1,202 +1,202 @@
 [
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 1,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 2
+    "__0": 1,
+    "a": 1,
+    "b": 2
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 3
+    "__0": 1,
+    "a": 1,
+    "b": 3
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 4
+    "__0": 1,
+    "a": 1,
+    "b": 4
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 5
+    "__0": 1,
+    "a": 1,
+    "b": 5
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 6
+    "__0": 1,
+    "a": 1,
+    "b": 6
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 1,
-    "UserName(b)": 7
+    "__0": 1,
+    "a": 1,
+    "b": 7
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 2,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 2,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 3,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 3,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 4,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 4,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 5,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 5,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 6,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 6,
+    "b": 1
   },
   {
-    "MachineName(0)": 1,
-    "UserName(a)": 7,
-    "UserName(b)": 1
+    "__0": 1,
+    "a": 7,
+    "b": 1
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 2,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 3
+    "__0": 2,
+    "a": 2,
+    "b": 3
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 4
+    "__0": 2,
+    "a": 2,
+    "b": 4
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 5
+    "__0": 2,
+    "a": 2,
+    "b": 5
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 6
+    "__0": 2,
+    "a": 2,
+    "b": 6
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 7
+    "__0": 2,
+    "a": 2,
+    "b": 7
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 3,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 3,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 4,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 4,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 5,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 5,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 6,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 6,
+    "b": 2
   },
   {
-    "MachineName(0)": 2,
-    "UserName(a)": 7,
-    "UserName(b)": 2
+    "__0": 2,
+    "a": 7,
+    "b": 2
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 3,
+    "b": 3
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 4
+    "__0": 3,
+    "a": 3,
+    "b": 4
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 5
+    "__0": 3,
+    "a": 3,
+    "b": 5
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 6
+    "__0": 3,
+    "a": 3,
+    "b": 6
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 7
+    "__0": 3,
+    "a": 3,
+    "b": 7
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 4,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 4,
+    "b": 3
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 5,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 5,
+    "b": 3
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 6,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 6,
+    "b": 3
   },
   {
-    "MachineName(0)": 3,
-    "UserName(a)": 7,
-    "UserName(b)": 3
+    "__0": 3,
+    "a": 7,
+    "b": 3
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 4,
-    "UserName(b)": 4
+    "__0": 4,
+    "a": 4,
+    "b": 4
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 4,
-    "UserName(b)": 5
+    "__0": 4,
+    "a": 4,
+    "b": 5
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 4,
-    "UserName(b)": 6
+    "__0": 4,
+    "a": 4,
+    "b": 6
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 4,
-    "UserName(b)": 7
+    "__0": 4,
+    "a": 4,
+    "b": 7
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 5,
-    "UserName(b)": 4
+    "__0": 4,
+    "a": 5,
+    "b": 4
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 6,
-    "UserName(b)": 4
+    "__0": 4,
+    "a": 6,
+    "b": 4
   },
   {
-    "MachineName(0)": 4,
-    "UserName(a)": 7,
-    "UserName(b)": 4
+    "__0": 4,
+    "a": 7,
+    "b": 4
   }
 ]

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-minion.solutions.json
@@ -1,17 +1,17 @@
 [
   {
-    "UserName(c)": 1
+    "c": 1
   },
   {
-    "UserName(c)": 2
+    "c": 2
   },
   {
-    "UserName(c)": 3
+    "c": 3
   },
   {
-    "UserName(c)": 4
+    "c": 4
   },
   {
-    "UserName(c)": 5
+    "c": 5
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-minion.solutions.json
@@ -1,26 +1,26 @@
 [
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 0,
-    "UserName(d)": 1
+    "a": 0,
+    "b": 1,
+    "c": 0,
+    "d": 1
   },
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 1,
-    "UserName(d)": 1
+    "a": 0,
+    "b": 1,
+    "c": 1,
+    "d": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 0,
-    "UserName(d)": 1
+    "a": 1,
+    "b": 1,
+    "c": 0,
+    "d": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 1,
-    "UserName(d)": 1
+    "a": 1,
+    "b": 1,
+    "c": 1,
+    "d": 1
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-minion.solutions.json
@@ -1,146 +1,146 @@
 [
   {
-    "UserName(x)": 15,
-    "UserName(y)": 50
+    "x": 15,
+    "y": 50
   },
   {
-    "UserName(x)": 16,
-    "UserName(y)": 49
+    "x": 16,
+    "y": 49
   },
   {
-    "UserName(x)": 17,
-    "UserName(y)": 48
+    "x": 17,
+    "y": 48
   },
   {
-    "UserName(x)": 18,
-    "UserName(y)": 47
+    "x": 18,
+    "y": 47
   },
   {
-    "UserName(x)": 19,
-    "UserName(y)": 46
+    "x": 19,
+    "y": 46
   },
   {
-    "UserName(x)": 20,
-    "UserName(y)": 45
+    "x": 20,
+    "y": 45
   },
   {
-    "UserName(x)": 21,
-    "UserName(y)": 44
+    "x": 21,
+    "y": 44
   },
   {
-    "UserName(x)": 22,
-    "UserName(y)": 43
+    "x": 22,
+    "y": 43
   },
   {
-    "UserName(x)": 23,
-    "UserName(y)": 42
+    "x": 23,
+    "y": 42
   },
   {
-    "UserName(x)": 24,
-    "UserName(y)": 41
+    "x": 24,
+    "y": 41
   },
   {
-    "UserName(x)": 25,
-    "UserName(y)": 40
+    "x": 25,
+    "y": 40
   },
   {
-    "UserName(x)": 26,
-    "UserName(y)": 39
+    "x": 26,
+    "y": 39
   },
   {
-    "UserName(x)": 27,
-    "UserName(y)": 38
+    "x": 27,
+    "y": 38
   },
   {
-    "UserName(x)": 28,
-    "UserName(y)": 37
+    "x": 28,
+    "y": 37
   },
   {
-    "UserName(x)": 29,
-    "UserName(y)": 36
+    "x": 29,
+    "y": 36
   },
   {
-    "UserName(x)": 30,
-    "UserName(y)": 35
+    "x": 30,
+    "y": 35
   },
   {
-    "UserName(x)": 31,
-    "UserName(y)": 34
+    "x": 31,
+    "y": 34
   },
   {
-    "UserName(x)": 32,
-    "UserName(y)": 33
+    "x": 32,
+    "y": 33
   },
   {
-    "UserName(x)": 33,
-    "UserName(y)": 32
+    "x": 33,
+    "y": 32
   },
   {
-    "UserName(x)": 34,
-    "UserName(y)": 31
+    "x": 34,
+    "y": 31
   },
   {
-    "UserName(x)": 35,
-    "UserName(y)": 30
+    "x": 35,
+    "y": 30
   },
   {
-    "UserName(x)": 36,
-    "UserName(y)": 29
+    "x": 36,
+    "y": 29
   },
   {
-    "UserName(x)": 37,
-    "UserName(y)": 28
+    "x": 37,
+    "y": 28
   },
   {
-    "UserName(x)": 38,
-    "UserName(y)": 27
+    "x": 38,
+    "y": 27
   },
   {
-    "UserName(x)": 39,
-    "UserName(y)": 26
+    "x": 39,
+    "y": 26
   },
   {
-    "UserName(x)": 40,
-    "UserName(y)": 25
+    "x": 40,
+    "y": 25
   },
   {
-    "UserName(x)": 41,
-    "UserName(y)": 24
+    "x": 41,
+    "y": 24
   },
   {
-    "UserName(x)": 42,
-    "UserName(y)": 23
+    "x": 42,
+    "y": 23
   },
   {
-    "UserName(x)": 43,
-    "UserName(y)": 22
+    "x": 43,
+    "y": 22
   },
   {
-    "UserName(x)": 44,
-    "UserName(y)": 21
+    "x": 44,
+    "y": 21
   },
   {
-    "UserName(x)": 45,
-    "UserName(y)": 20
+    "x": 45,
+    "y": 20
   },
   {
-    "UserName(x)": 46,
-    "UserName(y)": 19
+    "x": 46,
+    "y": 19
   },
   {
-    "UserName(x)": 47,
-    "UserName(y)": 18
+    "x": 47,
+    "y": 18
   },
   {
-    "UserName(x)": 48,
-    "UserName(y)": 17
+    "x": 48,
+    "y": 17
   },
   {
-    "UserName(x)": 49,
-    "UserName(y)": 16
+    "x": 49,
+    "y": 16
   },
   {
-    "UserName(x)": 50,
-    "UserName(y)": 15
+    "x": 50,
+    "y": 15
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-minion.solutions.json
@@ -1,17 +1,17 @@
 [
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 1,
+    "c": 1
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-minion.solutions.json
@@ -1,146 +1,146 @@
 [
   {
-    "UserName(x)": 15,
-    "UserName(y)": 50
+    "x": 15,
+    "y": 50
   },
   {
-    "UserName(x)": 16,
-    "UserName(y)": 49
+    "x": 16,
+    "y": 49
   },
   {
-    "UserName(x)": 17,
-    "UserName(y)": 48
+    "x": 17,
+    "y": 48
   },
   {
-    "UserName(x)": 18,
-    "UserName(y)": 47
+    "x": 18,
+    "y": 47
   },
   {
-    "UserName(x)": 19,
-    "UserName(y)": 46
+    "x": 19,
+    "y": 46
   },
   {
-    "UserName(x)": 20,
-    "UserName(y)": 45
+    "x": 20,
+    "y": 45
   },
   {
-    "UserName(x)": 21,
-    "UserName(y)": 44
+    "x": 21,
+    "y": 44
   },
   {
-    "UserName(x)": 22,
-    "UserName(y)": 43
+    "x": 22,
+    "y": 43
   },
   {
-    "UserName(x)": 23,
-    "UserName(y)": 42
+    "x": 23,
+    "y": 42
   },
   {
-    "UserName(x)": 24,
-    "UserName(y)": 41
+    "x": 24,
+    "y": 41
   },
   {
-    "UserName(x)": 25,
-    "UserName(y)": 40
+    "x": 25,
+    "y": 40
   },
   {
-    "UserName(x)": 26,
-    "UserName(y)": 39
+    "x": 26,
+    "y": 39
   },
   {
-    "UserName(x)": 27,
-    "UserName(y)": 38
+    "x": 27,
+    "y": 38
   },
   {
-    "UserName(x)": 28,
-    "UserName(y)": 37
+    "x": 28,
+    "y": 37
   },
   {
-    "UserName(x)": 29,
-    "UserName(y)": 36
+    "x": 29,
+    "y": 36
   },
   {
-    "UserName(x)": 30,
-    "UserName(y)": 35
+    "x": 30,
+    "y": 35
   },
   {
-    "UserName(x)": 31,
-    "UserName(y)": 34
+    "x": 31,
+    "y": 34
   },
   {
-    "UserName(x)": 32,
-    "UserName(y)": 33
+    "x": 32,
+    "y": 33
   },
   {
-    "UserName(x)": 33,
-    "UserName(y)": 32
+    "x": 33,
+    "y": 32
   },
   {
-    "UserName(x)": 34,
-    "UserName(y)": 31
+    "x": 34,
+    "y": 31
   },
   {
-    "UserName(x)": 35,
-    "UserName(y)": 30
+    "x": 35,
+    "y": 30
   },
   {
-    "UserName(x)": 36,
-    "UserName(y)": 29
+    "x": 36,
+    "y": 29
   },
   {
-    "UserName(x)": 37,
-    "UserName(y)": 28
+    "x": 37,
+    "y": 28
   },
   {
-    "UserName(x)": 38,
-    "UserName(y)": 27
+    "x": 38,
+    "y": 27
   },
   {
-    "UserName(x)": 39,
-    "UserName(y)": 26
+    "x": 39,
+    "y": 26
   },
   {
-    "UserName(x)": 40,
-    "UserName(y)": 25
+    "x": 40,
+    "y": 25
   },
   {
-    "UserName(x)": 41,
-    "UserName(y)": 24
+    "x": 41,
+    "y": 24
   },
   {
-    "UserName(x)": 42,
-    "UserName(y)": 23
+    "x": 42,
+    "y": 23
   },
   {
-    "UserName(x)": 43,
-    "UserName(y)": 22
+    "x": 43,
+    "y": 22
   },
   {
-    "UserName(x)": 44,
-    "UserName(y)": 21
+    "x": 44,
+    "y": 21
   },
   {
-    "UserName(x)": 45,
-    "UserName(y)": 20
+    "x": 45,
+    "y": 20
   },
   {
-    "UserName(x)": 46,
-    "UserName(y)": 19
+    "x": 46,
+    "y": 19
   },
   {
-    "UserName(x)": 47,
-    "UserName(y)": 18
+    "x": 47,
+    "y": 18
   },
   {
-    "UserName(x)": 48,
-    "UserName(y)": 17
+    "x": 48,
+    "y": 17
   },
   {
-    "UserName(x)": 49,
-    "UserName(y)": 16
+    "x": 49,
+    "y": 16
   },
   {
-    "UserName(x)": 50,
-    "UserName(y)": 15
+    "x": 50,
+    "y": 15
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-minion.solutions.json
@@ -1,17 +1,17 @@
 [
   {
-    "UserName(a)": 0,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 0,
+    "b": 1,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 0,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 0,
+    "c": 1
   },
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 1,
+    "b": 1,
+    "c": 1
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-minion.solutions.json
@@ -1,12 +1,12 @@
 [
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 1,
+    "c": 1
   }
 ]

--- a/conjure_oxide/tests/integration/experiment/works/max2/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input.expected-minion.solutions.json
@@ -1,66 +1,66 @@
 [
   {
-    "MachineName(0)": 2,
-    "MachineName(1)": 2,
-    "MachineName(2)": 2,
-    "UserName(a)": 1,
-    "UserName(b)": 2,
-    "UserName(x)": 3
+    "__0": 2,
+    "__1": 2,
+    "__2": 2,
+    "a": 1,
+    "b": 2,
+    "x": 3
   },
   {
-    "MachineName(0)": 2,
-    "MachineName(1)": 2,
-    "MachineName(2)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(x)": 3
+    "__0": 2,
+    "__1": 2,
+    "__2": 2,
+    "a": 2,
+    "b": 1,
+    "x": 3
   },
   {
-    "MachineName(0)": 2,
-    "MachineName(1)": 2,
-    "MachineName(2)": 2,
-    "UserName(a)": 2,
-    "UserName(b)": 2,
-    "UserName(x)": 3
+    "__0": 2,
+    "__1": 2,
+    "__2": 2,
+    "a": 2,
+    "b": 2,
+    "x": 3
   },
   {
-    "MachineName(0)": 3,
-    "MachineName(1)": 3,
-    "MachineName(2)": 3,
-    "UserName(a)": 1,
-    "UserName(b)": 3,
-    "UserName(x)": 4
+    "__0": 3,
+    "__1": 3,
+    "__2": 3,
+    "a": 1,
+    "b": 3,
+    "x": 4
   },
   {
-    "MachineName(0)": 3,
-    "MachineName(1)": 3,
-    "MachineName(2)": 3,
-    "UserName(a)": 2,
-    "UserName(b)": 3,
-    "UserName(x)": 4
+    "__0": 3,
+    "__1": 3,
+    "__2": 3,
+    "a": 2,
+    "b": 3,
+    "x": 4
   },
   {
-    "MachineName(0)": 3,
-    "MachineName(1)": 3,
-    "MachineName(2)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 1,
-    "UserName(x)": 4
+    "__0": 3,
+    "__1": 3,
+    "__2": 3,
+    "a": 3,
+    "b": 1,
+    "x": 4
   },
   {
-    "MachineName(0)": 3,
-    "MachineName(1)": 3,
-    "MachineName(2)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 2,
-    "UserName(x)": 4
+    "__0": 3,
+    "__1": 3,
+    "__2": 3,
+    "a": 3,
+    "b": 2,
+    "x": 4
   },
   {
-    "MachineName(0)": 3,
-    "MachineName(1)": 3,
-    "MachineName(2)": 3,
-    "UserName(a)": 3,
-    "UserName(b)": 3,
-    "UserName(x)": 4
+    "__0": 3,
+    "__1": 3,
+    "__2": 3,
+    "a": 3,
+    "b": 3,
+    "x": 4
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-minion.solutions.json
@@ -1,26 +1,26 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2
+    "x": 1,
+    "y": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3
+    "x": 1,
+    "y": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1
+    "x": 2,
+    "y": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3
+    "x": 2,
+    "y": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1
+    "x": 3,
+    "y": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2
+    "x": 3,
+    "y": 2
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-minion.solutions.json
@@ -1,6 +1,6 @@
 [
   {
-    "UserName(x)": 10,
-    "UserName(y)": 2
+    "x": 10,
+    "y": 2
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-minion.solutions.json
@@ -1,32 +1,32 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 1
+    "x": 1,
+    "y": 1,
+    "z": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 2
+    "x": 2,
+    "y": 1,
+    "z": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 1
+    "x": 2,
+    "y": 2,
+    "z": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 1
+    "x": 3,
+    "y": 2,
+    "z": 1
   },
   {
-    "UserName(x)": 4,
-    "UserName(y)": 2,
-    "UserName(z)": 2
+    "x": 4,
+    "y": 2,
+    "z": 2
   },
   {
-    "UserName(x)": 5,
-    "UserName(y)": 2,
-    "UserName(z)": 2
+    "x": 5,
+    "y": 2,
+    "z": 2
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-minion.solutions.json
@@ -1,10 +1,10 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1
+    "x": 1,
+    "y": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2
+    "x": 2,
+    "y": 2
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-minion.solutions.json
@@ -1,26 +1,26 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2
+    "x": 1,
+    "y": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3
+    "x": 1,
+    "y": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 4
+    "x": 1,
+    "y": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3
+    "x": 2,
+    "y": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 4
+    "x": 2,
+    "y": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 4
+    "x": 3,
+    "y": 4
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-minion.solutions.json
@@ -1,42 +1,42 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1
+    "x": 1,
+    "y": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2
+    "x": 1,
+    "y": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3
+    "x": 1,
+    "y": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 4
+    "x": 1,
+    "y": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2
+    "x": 2,
+    "y": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3
+    "x": 2,
+    "y": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 4
+    "x": 2,
+    "y": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3
+    "x": 3,
+    "y": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 4
+    "x": 3,
+    "y": 4
   },
   {
-    "UserName(x)": 4,
-    "UserName(y)": 4
+    "x": 4,
+    "y": 4
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-minion.solutions.json
@@ -1,38 +1,38 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1
+    "x": 1,
+    "y": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2
+    "x": 1,
+    "y": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3
+    "x": 1,
+    "y": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1
+    "x": 2,
+    "y": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2
+    "x": 2,
+    "y": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3
+    "x": 2,
+    "y": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1
+    "x": 3,
+    "y": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2
+    "x": 3,
+    "y": 2
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3
+    "x": 3,
+    "y": 3
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-minion.solutions.json
@@ -1,177 +1,177 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 1
+    "x": 1,
+    "y": 1,
+    "z": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 2
+    "x": 1,
+    "y": 1,
+    "z": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 1
+    "x": 1,
+    "y": 2,
+    "z": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 2
+    "x": 1,
+    "y": 2,
+    "z": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 3
+    "x": 1,
+    "y": 2,
+    "z": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 1
+    "x": 1,
+    "y": 3,
+    "z": 1
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 2
+    "x": 1,
+    "y": 3,
+    "z": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 3
+    "x": 1,
+    "y": 3,
+    "z": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 4
+    "x": 1,
+    "y": 3,
+    "z": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 1
+    "x": 2,
+    "y": 1,
+    "z": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 2
+    "x": 2,
+    "y": 1,
+    "z": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 3
+    "x": 2,
+    "y": 1,
+    "z": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 1
+    "x": 2,
+    "y": 2,
+    "z": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 2
+    "x": 2,
+    "y": 2,
+    "z": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 3
+    "x": 2,
+    "y": 2,
+    "z": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 4
+    "x": 2,
+    "y": 2,
+    "z": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 1
+    "x": 2,
+    "y": 3,
+    "z": 1
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 2
+    "x": 2,
+    "y": 3,
+    "z": 2
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 3
+    "x": 2,
+    "y": 3,
+    "z": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 4
+    "x": 2,
+    "y": 3,
+    "z": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 5
+    "x": 2,
+    "y": 3,
+    "z": 5
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 1
+    "x": 3,
+    "y": 1,
+    "z": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 2
+    "x": 3,
+    "y": 1,
+    "z": 2
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 3
+    "x": 3,
+    "y": 1,
+    "z": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 4
+    "x": 3,
+    "y": 1,
+    "z": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 1
+    "x": 3,
+    "y": 2,
+    "z": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 2
+    "x": 3,
+    "y": 2,
+    "z": 2
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 3
+    "x": 3,
+    "y": 2,
+    "z": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 4
+    "x": 3,
+    "y": 2,
+    "z": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 5
+    "x": 3,
+    "y": 2,
+    "z": 5
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3,
-    "UserName(z)": 1
+    "x": 3,
+    "y": 3,
+    "z": 1
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3,
-    "UserName(z)": 2
+    "x": 3,
+    "y": 3,
+    "z": 2
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3,
-    "UserName(z)": 3
+    "x": 3,
+    "y": 3,
+    "z": 3
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3,
-    "UserName(z)": 4
+    "x": 3,
+    "y": 3,
+    "z": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 3,
-    "UserName(z)": 5
+    "x": 3,
+    "y": 3,
+    "z": 5
   }
 ]

--- a/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-minion.solutions.json
@@ -1,92 +1,92 @@
 [
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 2
+    "x": 1,
+    "y": 1,
+    "z": 2
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 3
+    "x": 1,
+    "y": 1,
+    "z": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 4
+    "x": 1,
+    "y": 1,
+    "z": 4
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 1,
-    "UserName(z)": 5
+    "x": 1,
+    "y": 1,
+    "z": 5
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 3
+    "x": 1,
+    "y": 2,
+    "z": 3
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 4
+    "x": 1,
+    "y": 2,
+    "z": 4
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 2,
-    "UserName(z)": 5
+    "x": 1,
+    "y": 2,
+    "z": 5
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 4
+    "x": 1,
+    "y": 3,
+    "z": 4
   },
   {
-    "UserName(x)": 1,
-    "UserName(y)": 3,
-    "UserName(z)": 5
+    "x": 1,
+    "y": 3,
+    "z": 5
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 3
+    "x": 2,
+    "y": 1,
+    "z": 3
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 4
+    "x": 2,
+    "y": 1,
+    "z": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 1,
-    "UserName(z)": 5
+    "x": 2,
+    "y": 1,
+    "z": 5
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 4
+    "x": 2,
+    "y": 2,
+    "z": 4
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 2,
-    "UserName(z)": 5
+    "x": 2,
+    "y": 2,
+    "z": 5
   },
   {
-    "UserName(x)": 2,
-    "UserName(y)": 3,
-    "UserName(z)": 5
+    "x": 2,
+    "y": 3,
+    "z": 5
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 4
+    "x": 3,
+    "y": 1,
+    "z": 4
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 1,
-    "UserName(z)": 5
+    "x": 3,
+    "y": 1,
+    "z": 5
   },
   {
-    "UserName(x)": 3,
-    "UserName(y)": 2,
-    "UserName(z)": 5
+    "x": 3,
+    "y": 2,
+    "z": 5
   }
 ]

--- a/conjure_oxide/tests/integration/xyz/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-minion.solutions.json
@@ -1,12 +1,12 @@
 [
   {
-    "UserName(a)": 1,
-    "UserName(b)": 1,
-    "UserName(c)": 2
+    "a": 1,
+    "b": 1,
+    "c": 2
   },
   {
-    "UserName(a)": 2,
-    "UserName(b)": 1,
-    "UserName(c)": 1
+    "a": 2,
+    "b": 1,
+    "c": 1
   }
 ]

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -311,14 +311,7 @@ impl Display for Expression {
     // TODO: (flm8) this will change once we implement a parser (two-way conversion)
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
-            Expression::FactorE(_, Factor::Literal(c)) => match c {
-                Literal::Bool(b) => write!(f, "{}", b),
-                Literal::Int(i) => write!(f, "{}", i),
-            },
-            Expression::FactorE(_, Factor::Reference(name)) => match name {
-                Name::MachineName(n) => write!(f, "_{}", n),
-                Name::UserName(s) => write!(f, "{}", s),
-            },
+            Expression::FactorE(_, factor) => factor.fmt(f),
             Expression::Sum(_, expressions) => {
                 write!(f, "Sum({})", display_expressions(expressions))
             }

--- a/crates/conjure_core/src/ast/factor.rs
+++ b/crates/conjure_core/src/ast/factor.rs
@@ -20,15 +20,7 @@ impl std::fmt::Display for Factor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Factor::Literal(x) => x.fmt(f),
-            Factor::Reference(Name::UserName(n)) => {
-                write!(f, "{n}")?;
-                Ok(())
-            }
-
-            Factor::Reference(Name::MachineName(x)) => {
-                write!(f, "__{x}")?;
-                Ok(())
-            }
+            Factor::Reference(x) => x.fmt(f),
         }
     }
 }

--- a/crates/conjure_core/src/ast/symbol_table.rs
+++ b/crates/conjure_core/src/ast/symbol_table.rs
@@ -17,8 +17,8 @@ uniplate::derive_unplateable!(Name);
 impl Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Name::UserName(s) => write!(f, "UserName({})", s),
-            Name::MachineName(i) => write!(f, "MachineName({})", i),
+            Name::UserName(s) => write!(f, "{}", s),
+            Name::MachineName(i) => write!(f, "__{}", i),
         }
     }
 }


### PR DESCRIPTION
Change display implementations of Name, Factor, and Expression so that variables are always printed the same way.

Previously, each of these implemented the printing of references themselves in different ways. For example, Name display used `MachineName(x)`, and Expressions `__x`.

Now, variable display is only defined in `Name`. Instead of directly displaying references for `FactorE(Factor::Reference(...))` in Expression's display implementation, this instead calls display for `Factor`. In turn, `Factor` calls display for `Name` and `Literal` instead of implementing this itself.
