### PR TITLE
ci: exclude rule macros from coverage

### DIFF
--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -15,8 +15,7 @@ env:
 jobs:
   coverage:
     name: "Generate Code Coverage Reports"
-    timeout-minutes: 10
-    # only do coverage for ready PRs
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,6 +6,7 @@ on:
       - conjure_oxide/**
       - solvers/**
       - crates/**
+      - tools/coverage.sh
       - .github/workflows/code-coverage.yml
   workflow_dispatch:
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   coverage:
     name: "Generate Code Coverage Reports"
-    timeout-minutes: 10
+    timeout-minutes: 20 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Exclude rule macro invocations from the code coverage.

Fixes: #469
