### PR TITLE
Handle atomic in read_expr

### DIFF
--- a/crates/conjure_core/src/solver/adaptors/minion.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion.rs
@@ -285,6 +285,10 @@ fn parse_expr(
 
 fn read_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, SolverError> {
     match expr {
+        conjure_ast::Expression::Atomic(_metadata, reff) => Ok(minion_ast::Constraint::WLiteral(
+            read_var(reff.into())?,
+            minion_ast::Constant::Integer(1),
+        )),
         conjure_ast::Expression::SumLeq(_metadata, lhs, rhs) => Ok(minion_ast::Constraint::SumLeq(
             read_vars(lhs)?,
             read_var(*rhs)?,


### PR DESCRIPTION
read_expr wasn't handling Expression::Atomic which caused conjure-oxide to fail on simple one variable constraint models such as 

```
language ESSENCE' 1.0 

find b: bool 
such that
    b
```

Now we handle it.