### PR TITLE
Remove "either two or none bubbles" check from div_to_bubble and mod_to_bubble

### DIFF
--- a/crates/conjure_core/src/rules/bubble.rs
+++ b/crates/conjure_core/src/rules/bubble.rs
@@ -81,12 +81,6 @@ fn div_to_bubble(expr: &Expression, _: &Model) -> ApplicationResult {
             return Err(RuleNotApplicable);
         }
 
-        // either do bubble / bubble or not bubble / not bubble
-        if matches!(**a, Expression::Bubble(_, _, _)) != matches!(**b, Expression::Bubble(_, _, _))
-        {
-            return Err(RuleNotApplicable);
-        }
-
         return Ok(Reduction::pure(Expression::Bubble(
             Metadata::new(),
             Box::new(Expression::SafeDiv(Metadata::new(), a.clone(), b.clone())),
@@ -118,12 +112,6 @@ fn mod_to_bubble(expr: &Expression, _: &Model) -> ApplicationResult {
     if let Expression::UnsafeMod(_, a, b) = expr {
         // bubble bottom up
         if a.can_be_undefined() || b.can_be_undefined() {
-            return Err(RuleNotApplicable);
-        }
-
-        // either do bubble / bubble or not bubble / not bubble
-        if matches!(**a, Expression::Bubble(_, _, _)) != matches!(**b, Expression::Bubble(_, _, _))
-        {
             return Err(RuleNotApplicable);
         }
 


### PR DESCRIPTION
Remove unnecessary check in div_to_bubble and mod_to_bubble.

Fixes #472
