### PR TITLE
refactor(rules/minion): only use bool_to_wlit for Not(Lit::Bool)

### DIFF
--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-expected-rule-trace.json
@@ -1,10 +1,5 @@
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([a, b]), Or([Not(c), And([b, d])]), b, Or([d, c])]), resulting in: And([Or([a, b]), Or([Not(c), And([b, d])]), WatchedLiteral(b,true), Or([d, c])])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: distribute_or_over_and ([(\"Base\", 8400)]), to expression: Or([Not(c), And([b, d])]), resulting in: And([Or([Not(c), b]), Or([Not(c), d])])","target":"rule_engine"}
-{"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), And([Or([Not(c), b]), Or([Not(c), d])]), WatchedLiteral(b,true), Or([d, c])]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), Or([Not(c), b]), Or([Not(c), d]), WatchedLiteral(b,true), Or([d, c])])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([Not(c), b]), resulting in: Or([Not(c), WatchedLiteral(b,true)])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([Not(c), d]), resulting in: Or([Not(c), WatchedLiteral(d,true)])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([d, c]), resulting in: Or([WatchedLiteral(d,true), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":9,"message":" Number of rules applied"}
+{"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([a, b]), And([Or([Not(c), b]), Or([Not(c), d])]), b, Or([d, c])]), resulting in: And([Or([a, b]), Or([Not(c), b]), Or([Not(c), d]), b, Or([d, c])])","target":"rule_engine"}
+{"message":"Rule applicable: not_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
+{"message":"Rule applicable: not_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
+{"count":4,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-generated-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-generated-rule-trace.json
@@ -1,10 +1,5 @@
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([a, b]), Or([Not(c), And([b, d])]), b, Or([d, c])]), resulting in: And([Or([a, b]), Or([Not(c), And([b, d])]), WatchedLiteral(b,true), Or([d, c])])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: distribute_or_over_and ([(\"Base\", 8400)]), to expression: Or([Not(c), And([b, d])]), resulting in: And([Or([Not(c), b]), Or([Not(c), d])])","target":"rule_engine"}
-{"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), And([Or([Not(c), b]), Or([Not(c), d])]), WatchedLiteral(b,true), Or([d, c])]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), Or([Not(c), b]), Or([Not(c), d]), WatchedLiteral(b,true), Or([d, c])])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([Not(c), b]), resulting in: Or([Not(c), WatchedLiteral(b,true)])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([Not(c), d]), resulting in: Or([Not(c), WatchedLiteral(d,true)])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([d, c]), resulting in: Or([WatchedLiteral(d,true), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":9,"message":" Number of rules applied"}
+{"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([a, b]), And([Or([Not(c), b]), Or([Not(c), d])]), b, Or([d, c])]), resulting in: And([Or([a, b]), Or([Not(c), b]), Or([Not(c), d]), b, Or([d, c])])","target":"rule_engine"}
+{"message":"Rule applicable: not_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
+{"message":"Rule applicable: not_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Not(c), resulting in: WatchedLiteral(c,false)","target":"rule_engine"}
+{"count":4,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
@@ -14,30 +14,28 @@
             },
             [
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "a"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "a"
+                    }
                   }
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "b"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "b"
+                    }
                   }
                 ]
               }
@@ -66,16 +64,15 @@
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "b"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "b"
+                    }
                   }
                 ]
               }
@@ -104,16 +101,15 @@
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "d"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "d"
+                    }
                   }
                 ]
               }
@@ -121,16 +117,15 @@
           ]
         },
         {
-          "WatchedLiteral": [
+          "Atomic": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "UserName": "b"
-            },
-            {
-              "Bool": true
+              "Reference": {
+                "UserName": "b"
+              }
             }
           ]
         },
@@ -142,30 +137,28 @@
             },
             [
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "d"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "d"
+                    }
                   }
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "c"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "c"
+                    }
                   }
                 ]
               }

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace.json
@@ -1,9 +1,7 @@
 {"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), And([c, true])]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), WatchedLiteral(c,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([Or([a, b]), false]), resulting in: Or([Or([a, b])])","target":"rule_engine"}
 {"message":"Rule applicable: unwrap_nested_or ([(\"Base\", 8800)]), to expression: Or([Or([a, b])]), resulting in: Or([a, b])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([AllDiff([1, 2, 3]), true]), resulting in: true","target":"rule_engine"}
-{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), true, WatchedLiteral(c,true)]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":8,"message":" Number of rules applied"}
+{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([a, b]), true, c]), resulting in: And([Or([a, b]), c])","target":"rule_engine"}
+{"count":6,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-generated-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-generated-rule-trace.json
@@ -1,9 +1,7 @@
 {"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), And([c, true])]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), WatchedLiteral(c,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([Or([a, b]), false]), resulting in: Or([Or([a, b])])","target":"rule_engine"}
 {"message":"Rule applicable: unwrap_nested_or ([(\"Base\", 8800)]), to expression: Or([Or([a, b])]), resulting in: Or([a, b])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([AllDiff([1, 2, 3]), true]), resulting in: true","target":"rule_engine"}
-{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), true, WatchedLiteral(c,true)]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":8,"message":" Number of rules applied"}
+{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([a, b]), true, c]), resulting in: And([Or([a, b]), c])","target":"rule_engine"}
+{"count":6,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
@@ -14,30 +14,28 @@
             },
             [
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "a"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "a"
+                    }
                   }
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "b"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "b"
+                    }
                   }
                 ]
               }
@@ -45,16 +43,15 @@
           ]
         },
         {
-          "WatchedLiteral": [
+          "Atomic": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "UserName": "c"
-            },
-            {
-              "Bool": true
+              "Reference": {
+                "UserName": "c"
+              }
             }
           ]
         }

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace.json
@@ -1,9 +1,7 @@
 {"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), And([c, true])]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), WatchedLiteral(c,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([Or([a, b]), false]), resulting in: Or([Or([a, b])])","target":"rule_engine"}
 {"message":"Rule applicable: unwrap_nested_or ([(\"Base\", 8800)]), to expression: Or([Or([a, b])]), resulting in: Or([a, b])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([AllDiff([1, 2, 3]), true]), resulting in: true","target":"rule_engine"}
-{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), true, WatchedLiteral(c,true)]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":8,"message":" Number of rules applied"}
+{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([a, b]), true, c]), resulting in: And([Or([a, b]), c])","target":"rule_engine"}
+{"count":6,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-generated-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-generated-rule-trace.json
@@ -1,9 +1,7 @@
 {"message":"Rule applicable: unwrap_nested_and ([(\"Base\", 8800)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), And([c, true])]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c, true]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), c]), resulting in: And([Or([Or([a, b]), false]), Or([AllDiff([1, 2, 3]), true]), WatchedLiteral(c,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([Or([a, b]), false]), resulting in: Or([Or([a, b])])","target":"rule_engine"}
 {"message":"Rule applicable: unwrap_nested_or ([(\"Base\", 8800)]), to expression: Or([Or([a, b])]), resulting in: Or([a, b])","target":"rule_engine"}
-{"message":"Rule applicable: boolean_literal_to_wliteral ([(\"Minion\", 4100)]), to expression: Or([a, b]), resulting in: Or([WatchedLiteral(a,true), WatchedLiteral(b,true)])","target":"rule_engine"}
 {"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: Or([AllDiff([1, 2, 3]), true]), resulting in: true","target":"rule_engine"}
-{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), true, WatchedLiteral(c,true)]), resulting in: And([Or([WatchedLiteral(a,true), WatchedLiteral(b,true)]), WatchedLiteral(c,true)])","target":"rule_engine"}
-{"count":8,"message":" Number of rules applied"}
+{"message":"Rule applicable: partial_evaluator ([(\"Base\", 9000)]), to expression: And([Or([a, b]), true, c]), resulting in: And([Or([a, b]), c])","target":"rule_engine"}
+{"count":6,"message":" Number of rules applied"}

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
@@ -14,30 +14,28 @@
             },
             [
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "a"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "a"
+                    }
                   }
                 ]
               },
               {
-                "WatchedLiteral": [
+                "Atomic": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UserName": "b"
-                  },
-                  {
-                    "Bool": true
+                    "Reference": {
+                      "UserName": "b"
+                    }
                   }
                 ]
               }
@@ -45,16 +43,15 @@
           ]
         },
         {
-          "WatchedLiteral": [
+          "Atomic": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "UserName": "c"
-            },
-            {
-              "Bool": true
+              "Reference": {
+                "UserName": "c"
+              }
             }
           ]
         }

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -499,12 +499,10 @@ fn x_leq_y_plus_k_to_ineq(expr: &Expr, _: &Model) -> ApplicationResult {
 //     }
 // }
 
-/// Flattening rule that converts boolean variables to watched-literal constraints.
+/// Flattening rule for not(bool_lit)
 ///
 /// For some boolean variable x:
 /// ```text
-/// and([x,...]) ~> and([w-literal(x,1),..])
-///  or([x,...]) ~>  or([w-literal(x,1),..])
 ///  not(x)      ~>  w-literal(x,0)
 /// ```
 ///
@@ -514,57 +512,13 @@ fn x_leq_y_plus_k_to_ineq(expr: &Expr, _: &Model) -> ApplicationResult {
 ///
 /// This restates boolean variables as the equivalent constraint "SAT if x is true".
 ///
+/// The regular bool_lit case is dealt with directly by the Minion solver interface (as it is a
+/// trivial match).
+
 #[register_rule(("Minion", 4100))]
-fn boolean_literal_to_wliteral(expr: &Expr, mdl: &Model) -> ApplicationResult {
+fn not_literal_to_wliteral(expr: &Expr, mdl: &Model) -> ApplicationResult {
     use Domain::BoolDomain;
     match expr {
-        Or(m, vec) => {
-            let mut changed = false;
-            let mut new_vec = Vec::new();
-            for expr in vec {
-                new_vec.push(match expr {
-                    Atomic(m, Reference(name))
-                        if mdl
-                            .get_domain(name)
-                            .is_some_and(|x| matches!(x, BoolDomain)) =>
-                    {
-                        changed = true;
-                        WatchedLiteral(m.clone_dirty(), name.clone(), Bool(true))
-                    }
-                    e => e.clone(),
-                });
-            }
-
-            if !changed {
-                return Err(RuleNotApplicable);
-            }
-
-            Ok(Reduction::pure(Or(m.clone_dirty(), new_vec)))
-        }
-        And(m, vec) => {
-            let mut changed = false;
-            let mut new_vec = Vec::new();
-            for expr in vec {
-                new_vec.push(match expr {
-                    Atomic(m, Reference(name))
-                        if mdl
-                            .get_domain(name)
-                            .is_some_and(|x| matches!(x, BoolDomain)) =>
-                    {
-                        changed = true;
-                        WatchedLiteral(m.clone_dirty(), name.clone(), Bool(true))
-                    }
-                    e => e.clone(),
-                });
-            }
-
-            if !changed {
-                return Err(RuleNotApplicable);
-            }
-
-            Ok(Reduction::pure(And(m.clone_dirty(), new_vec)))
-        }
-
         Not(m, expr) => {
             if let Atomic(_, Reference(name)) = (**expr).clone() {
                 if mdl


### PR DESCRIPTION
Rename bool_to_wlit to not_literal_to_wliteral and make it only applicable for Not(Lit::Bool) expressions.

PR #473 made non negated boolean literals be converted to w-lit in the solver interface directly, making this rule mostly redundant.

As Not(Lit::Bool) is a nested expression, I still think it is reasonable to convert this to a watched literal in a rule instead of in the solver interface. Also, if it were to happen in the solver interface, there is a chance that the literal could be reified instead, which is not what we want.

Fixes: #474 
