### PR TITLE
feat(ast): add Expression::is_associative_commutative_operator()

### DIFF
--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -342,6 +342,14 @@ impl Expression {
             None
         }
     }
+
+    /// True if the expression is an associative and commutative operator
+    pub fn is_associative_commutative_operator(&self) -> bool {
+        matches!(
+            self,
+            Expression::Sum(_, _) | Expression::Or(_, _) | Expression::And(_, _)
+        )
+    }
 }
 
 fn display_expressions(expressions: &[Expression]) -> String {


### PR DESCRIPTION
Implement method of Expression to check whether an expression is an associative-commutative operator. The concept of an AC operator will be useful down the line for A-CSE, generic normalisation rules, and quantified expressions.

Related-issues: [#491,#493]

Fixes: #494
