### PR TITLE
update uniplate to v0.1.4

### DIFF
--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -13,7 +13,7 @@ conjure_core = { path = "../crates/conjure_core" }
 minion_rs = { path = "../solvers/minion" }
 
 
-uniplate = "0.1.3"
+uniplate = "0.1.4"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 serde_with = "3.11.0"

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -11,7 +11,7 @@ conjure_macros = { path = "../conjure_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }
 minion_rs = { path = "../../solvers/minion" }
 
-uniplate = "0.1.3"
+uniplate = "0.1.4"
 project-root = "0.2.2"
 linkme = "0.3.31"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-uniplate = { version = "0.1.3" }
+uniplate = { version = "0.1.4" }
 
 
 [lints]


### PR DESCRIPTION
Didn't realise that `Biplate::with_children_bi` didn't exist, so another little uniplate update is needed.
