### PR TITLE
Add Naive Rewriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -688,12 +688,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -1091,9 +1091,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1138,9 +1138,9 @@ checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
  "tracing-core",
@@ -2254,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2633,9 +2633,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2644,9 +2644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2669,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2682,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wasmparser"

--- a/conjure_oxide/examples/solver-hello-minion.rs
+++ b/conjure_oxide/examples/solver-hello-minion.rs
@@ -13,7 +13,10 @@ use std::collections::HashMap;
 #[allow(clippy::unwrap_used)]
 pub fn main() {
     use conjure_core::solver::SolverFamily;
-    use conjure_core::{parse::get_example_model, rule_engine::resolve_rule_sets};
+    use conjure_core::{
+        ast::pretty::pretty_expressions_as_top_level, parse::get_example_model,
+        rule_engine::resolve_rule_sets,
+    };
     use conjure_core::{
         rule_engine::rewrite_model,
         solver::{adaptors, Solver},
@@ -22,13 +25,19 @@ pub fn main() {
 
     // Load an example model and rewrite it with conjure oxide.
     let model = get_example_model("div-05").unwrap();
-    println!("Input model: \n {:?} \n", model.constraints);
+    println!(
+        "Input model: \n {} \n",
+        pretty_expressions_as_top_level(&model.constraints)
+    );
 
     // TODO: We will have a nicer way to do this in the future
     let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets()).unwrap();
 
     let model = rewrite_model(&model, &rule_sets).unwrap();
-    println!("Rewritten model: \n {:?} \n", model.constraints);
+    println!(
+        "Rewritten model: \n {} \n",
+        pretty_expressions_as_top_level(&model.constraints)
+    );
 
     // To tell the `Solver` type what solver to use, you pass it a `SolverAdaptor`.
     // Here we use Minion.

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -265,7 +265,7 @@ pub fn main() -> AnyhowResult<()> {
 
     if cli.use_naive_rewriter {
         log::info!(target: "file", "Using the naive rewriter...");
-        model = rewrite_naive(&model, &rule_sets)?;
+        model = rewrite_naive(&model, &rule_sets, false)?;
     } else {
         log::info!(target: "file", "Rewriting model...");
         model = rewrite_model(&model, &rule_sets)?;

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use anyhow::Result as AnyhowResult;
 use anyhow::{anyhow, bail};
 use clap::{arg, command, Parser};
+use conjure_core::ast::pretty::pretty_expressions_as_top_level;
 use conjure_oxide::defaults::get_default_rule_sets;
 use schemars::schema_for;
 use serde_json::json;
@@ -254,8 +255,8 @@ pub fn main() -> AnyhowResult<()> {
 
     log::info!(target: "file", "Rewriting model...");
     model = rewrite_model(&model, &rule_sets)?;
-    let constraints_string = format!("{:?}", model.constraints);
-    tracing::info!(%constraints_string, model=%json!(model),"Rewritten model");
+    let constraints_string = pretty_expressions_as_top_level(&model.constraints);
+    tracing::info!(constraints=%constraints_string, model=%json!(model),"Rewritten model");
 
     let solutions = get_minion_solutions(model, cli.number_of_solutions)?; // ToDo we need to properly set the solver adaptor here, not hard code minion
     log::info!(target: "file", "Solutions: {}", minion_solutions_to_json(&solutions));

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -26,7 +26,6 @@ use conjure_core::ast::{Expression, Literal, Name};
 use conjure_core::context::Context;
 use conjure_oxide::defaults::get_default_rule_sets;
 use conjure_oxide::rule_engine::resolve_rule_sets;
-use conjure_oxide::rule_engine::rewrite_model;
 use conjure_oxide::utils::conjure::minion_solutions_to_json;
 use conjure_oxide::utils::conjure::{
     get_minion_solutions, get_solutions_from_conjure, parse_essence_file,
@@ -185,11 +184,11 @@ fn integration_test_inner(
     // remove before merging?
     // or we can decide to make native the default.
     // let model = if let Some(true) = config.use_naive_rewriter {
-    //     rewrite_naive(&model, &rule_sets)?
+    //     rewrite_naive(&model, &rule_sets, true)?
     // } else {
     //     rewrite_model(&model, &rule_sets)?
     // };
-    let model = rewrite_naive(&model, &rule_sets)?;
+    let model = rewrite_naive(&model, &rule_sets, false)?;
 
     if verbose {
         println!("Rewritten model: {:#?}", model)

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -181,11 +181,15 @@ fn integration_test_inner(
     // Stage 2: Rewrite the model using the rule engine and check that the result is as expected
     let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets())?;
 
-    let model = if let Some(true) = config.use_naive_rewriter {
-        rewrite_naive(&model, &rule_sets)?
-    } else {
-        rewrite_model(&model, &rule_sets)?
-    };
+    // TODO: temporarily set to always use rewrite_naive
+    // remove before merging?
+    // or we can decide to make native the default.
+    // let model = if let Some(true) = config.use_naive_rewriter {
+    //     rewrite_naive(&model, &rule_sets)?
+    // } else {
+    //     rewrite_model(&model, &rule_sets)?
+    // };
+    let model = rewrite_naive(&model, &rule_sets)?;
 
     if verbose {
         println!("Rewritten model: {:#?}", model)

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -1,3 +1,4 @@
+use conjure_core::rule_engine::rewrite_naive;
 use conjure_oxide::utils::essence_parser::parse_essence_file_native;
 use conjure_oxide::utils::testing::read_human_rule_trace;
 use glob::glob;
@@ -43,6 +44,7 @@ use pretty_assertions::assert_eq;
 struct TestConfig {
     extra_rewriter_asserts: Option<Vec<String>>,
     skip_native_parser: Option<bool>,
+    use_naive_rewriter: Option<bool>,
 }
 
 fn main() {
@@ -178,7 +180,12 @@ fn integration_test_inner(
 
     // Stage 2: Rewrite the model using the rule engine and check that the result is as expected
     let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets())?;
-    let model = rewrite_model(&model, &rule_sets)?;
+
+    let model = if let Some(true) = config.use_naive_rewriter {
+        rewrite_naive(&model, &rule_sets)?
+    } else {
+        rewrite_model(&model, &rule_sets)?
+    };
 
     if verbose {
         println!("Rewritten model: {:#?}", model)

--- a/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeDiv(a, b) = 1), And([(b != 0)])])
 
 --
 
-(SafeDiv(a, b) = 1), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(a, b, 1) 
-
---
-
 And([(b != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (b != 0) 
+
+--
+
+(SafeDiv(a, b) = 1), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(a, b, 1) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/02/input-expected-rule-trace-human.txt
@@ -1,12 +1,12 @@
-(a >= UnsafeDiv(4, 2)), 
-   ~~> geq_to_ineq ([("Minion", 4100)]) 
-Ineq(UnsafeDiv(4, 2), a, 0) 
-
---
-
 UnsafeDiv(4, 2), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 2 
+
+--
+
+(a >= 2), 
+   ~~> geq_to_ineq ([("Minion", 4100)]) 
+Ineq(2, a, 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(2 = SafeDiv(8, a)), And([(a != 0)])])
 
 --
 
-(2 = SafeDiv(8, a)), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(8, a, 2) 
-
---
-
 And([(a != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (a != 0) 
+
+--
+
+(2 = SafeDiv(8, a)), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(8, a, 2) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
@@ -16,9 +16,15 @@ And([(a = SafeDiv(b, c)), And([(c != 0)])])
 
 --
 
-Not(And([(a = SafeDiv(b, c)), And([(c != 0)])])), 
+And([(c != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(c != 0) 
+
+--
+
+Not(And([(a = SafeDiv(b, c)), (c != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeDiv(b, c))), Not(And([(c != 0)]))]) 
+Or([Not((a = SafeDiv(b, c))), Not((c != 0))]) 
 
 --
 
@@ -28,21 +34,15 @@ Not((a = SafeDiv(b, c))),
 
 --
 
-(a != SafeDiv(b, c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
-Not(And([(c != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((c != 0)) 
-
---
-
 Not((c != 0)), 
    ~~> negated_neq_to_eq ([("Base", 8800)]) 
 (c = 0) 
+
+--
+
+(a != SafeDiv(b, c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(a != SafeDiv(b, c)), And([(c != 0)])])
 
 --
 
-(a != SafeDiv(b, c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
 And([(c != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
+
+--
+
+(a != SafeDiv(b, c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
@@ -16,9 +16,15 @@ And([(a = SafeDiv(b, c)), And([(c != 0)])])
 
 --
 
-Not(And([(a = SafeDiv(b, c)), And([(c != 0)])])), 
+And([(c != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(c != 0) 
+
+--
+
+Not(And([(a = SafeDiv(b, c)), (c != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeDiv(b, c))), Not(And([(c != 0)]))]) 
+Or([Not((a = SafeDiv(b, c))), Not((c != 0))]) 
 
 --
 
@@ -28,21 +34,15 @@ Not((a = SafeDiv(b, c))),
 
 --
 
-(a != SafeDiv(b, c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
-Not(And([(c != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((c != 0)) 
-
---
-
 Not((c != 0)), 
    ~~> negated_neq_to_eq ([("Base", 8800)]) 
 (c = 0) 
+
+--
+
+(a != SafeDiv(b, c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeMod(a,b) = 1), And([(b != 0)])])
 
 --
 
-(SafeMod(a,b) = 1), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(a, b, 1) 
-
---
-
 And([(b != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (b != 0) 
+
+--
+
+(SafeMod(a,b) = 1), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(a, b, 1) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/02/input-expected-rule-trace-human.txt
@@ -1,12 +1,12 @@
-(a >= 4 % 2), 
-   ~~> geq_to_ineq ([("Minion", 4100)]) 
-Ineq(4 % 2, a, 0) 
-
---
-
 4 % 2, 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 0 
+
+--
+
+(a >= 0), 
+   ~~> geq_to_ineq ([("Minion", 4100)]) 
+Ineq(0, a, 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(2 = SafeMod(8,a)), And([(a != 0)])])
 
 --
 
-(2 = SafeMod(8,a)), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(8, a, 2) 
-
---
-
 And([(a != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (a != 0) 
+
+--
+
+(2 = SafeMod(8,a)), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(8, a, 2) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
@@ -16,9 +16,15 @@ And([(a = SafeMod(b,c)), And([(c != 0)])])
 
 --
 
-Not(And([(a = SafeMod(b,c)), And([(c != 0)])])), 
+And([(c != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(c != 0) 
+
+--
+
+Not(And([(a = SafeMod(b,c)), (c != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeMod(b,c))), Not(And([(c != 0)]))]) 
+Or([Not((a = SafeMod(b,c))), Not((c != 0))]) 
 
 --
 
@@ -28,21 +34,15 @@ Not((a = SafeMod(b,c))),
 
 --
 
-(a != SafeMod(b,c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
-Not(And([(c != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((c != 0)) 
-
---
-
 Not((c != 0)), 
    ~~> negated_neq_to_eq ([("Base", 8800)]) 
 (c = 0) 
+
+--
+
+(a != SafeMod(b,c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(a != SafeMod(b,c)), And([(c != 0)])])
 
 --
 
-(a != SafeMod(b,c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
 And([(c != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
+
+--
+
+(a != SafeMod(b,c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
@@ -16,9 +16,15 @@ And([(a = SafeMod(b,c)), And([(c != 0)])])
 
 --
 
-Not(And([(a = SafeMod(b,c)), And([(c != 0)])])), 
+And([(c != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(c != 0) 
+
+--
+
+Not(And([(a = SafeMod(b,c)), (c != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeMod(b,c))), Not(And([(c != 0)]))]) 
+Or([Not((a = SafeMod(b,c))), Not((c != 0))]) 
 
 --
 
@@ -28,21 +34,15 @@ Not((a = SafeMod(b,c))),
 
 --
 
-(a != SafeMod(b,c)), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(a != __0) 
-
---
-
-Not(And([(c != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((c != 0)) 
-
---
-
 Not((c != 0)), 
    ~~> negated_neq_to_eq ([("Base", 8800)]) 
 (c = 0) 
+
+--
+
+(a != SafeMod(b,c)), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(a != __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
@@ -1,12 +1,12 @@
-(Sum([Min([5, 7]), c]) <= 10), 
-   ~~> sum_leq_to_sumleq ([("Minion", 4400)]) 
-SumLeq([Min([5, 7]), c], 10) 
-
---
-
 Min([5, 7]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 5 
+
+--
+
+(Sum([5, c]) <= 10), 
+   ~~> sum_leq_to_sumleq ([("Minion", 4400)]) 
+SumLeq([5, c], 10) 
 
 --
 

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-rewrite.serialised.json
@@ -37,7 +37,7 @@
       ]
     }
   ],
-  "next_var": 1,
+  "next_var": 0,
   "variables": [
     [
       {

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
@@ -4,13 +4,19 @@ Sum([x, 10, 20, y, 5])
 
 --
 
-(Sum([x, 10, 20, y, 5]) = 100), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4400)]) 
-SumEq([x, 10, 20, y, 5], 100) 
+Sum([x, 10, 20, y, 5]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Sum([x, y, 35]) 
 
 --
 
-SumEq([x, 10, 20, y, 5], 100), 
+(Sum([x, y, 35]) = 100), 
+   ~~> sum_eq_to_sumeq ([("Minion", 4400)]) 
+SumEq([x, y, 35], 100) 
+
+--
+
+SumEq([x, y, 35], 100), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 SumEq([x, y], 65) 
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
@@ -1,18 +1,12 @@
-Or([Or([a, b]), false]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b])]) 
-
---
-
-Or([Or([a, b])]), 
-   ~~> normalise_associative_commutative ([("Base", 8400)]) 
-Or([a, b]) 
-
---
-
 Or([AllDiff([1, 2, 3]), true]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
+
+--
+
+Or([Or([a, b]), false]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([Or([a, b])]) 
 
 --
 
@@ -25,6 +19,12 @@ And([c])
 And([c]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 c 
+
+--
+
+Or([Or([a, b])]), 
+   ~~> normalise_associative_commutative ([("Base", 8400)]) 
+Or([a, b]) 
 
 --
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
@@ -4,13 +4,19 @@ Sum([x, 10, 20, y, 5])
 
 --
 
-(Sum([x, 10, 20, y, 5]) = 100), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4400)]) 
-SumEq([x, 10, 20, y, 5], 100) 
+Sum([x, 10, 20, y, 5]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Sum([x, y, 35]) 
 
 --
 
-SumEq([x, 10, 20, y, 5], 100), 
+(Sum([x, y, 35]) = 100), 
+   ~~> sum_eq_to_sumeq ([("Minion", 4400)]) 
+SumEq([x, y, 35], 100) 
+
+--
+
+SumEq([x, y, 35], 100), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 SumEq([x, y], 65) 
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
@@ -1,18 +1,12 @@
-Or([Or([a, b]), false]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b])]) 
-
---
-
-Or([Or([a, b])]), 
-   ~~> normalise_associative_commutative ([("Base", 8400)]) 
-Or([a, b]) 
-
---
-
 Or([AllDiff([1, 2, 3]), true]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
+
+--
+
+Or([Or([a, b]), false]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([Or([a, b])]) 
 
 --
 
@@ -25,6 +19,12 @@ And([c])
 And([c]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 c 
+
+--
+
+Or([Or([a, b])]), 
+   ~~> normalise_associative_commutative ([("Base", 8400)]) 
+Or([a, b]) 
 
 --
 

--- a/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
@@ -1,15 +1,3 @@
-(Max([a, b]) >= 2), 
-   ~~> geq_to_ineq ([("Minion", 4100)]) 
-Ineq(2, Max([a, b]), 0) 
-
---
-
-Max([a, b]), 
-   ~~> max_to_var ([("Base", 100)]) 
-__0 
-
---
-
 (x = Sum([Max([a, b]), 1])), 
    ~~> sum_eq_to_sumeq ([("Minion", 4400)]) 
 SumEq([Max([a, b]), 1], x) 
@@ -22,15 +10,15 @@ And([SumGeq([Max([a, b]), 1], x), SumLeq([Max([a, b]), 1], x)])
 
 --
 
-Max([a, b]), 
-   ~~> max_to_var ([("Base", 100)]) 
-__1 
+(Max([a, b]) >= 2), 
+   ~~> geq_to_ineq ([("Minion", 4100)]) 
+Ineq(2, Max([a, b]), 0) 
 
 --
 
 Max([a, b]), 
    ~~> max_to_var ([("Base", 100)]) 
-__2 
+__0 
 
 --
 
@@ -46,6 +34,12 @@ Ineq(b, __0, 0)
 
 --
 
+Max([a, b]), 
+   ~~> max_to_var ([("Base", 100)]) 
+__1 
+
+--
+
 (__1 >= a), 
    ~~> geq_to_ineq ([("Minion", 4100)]) 
 Ineq(a, __1, 0) 
@@ -55,6 +49,12 @@ Ineq(a, __1, 0)
 (__1 >= b), 
    ~~> geq_to_ineq ([("Minion", 4100)]) 
 Ineq(b, __1, 0) 
+
+--
+
+Max([a, b]), 
+   ~~> max_to_var ([("Base", 100)]) 
+__2 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeDiv(x, y) = 5), And([(y != 0)])])
 
 --
 
-(SafeDiv(x, y) = 5), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(x, y, 5) 
-
---
-
 And([(y != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
+
+--
+
+(SafeDiv(x, y) = 5), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(x, y, 5) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeDiv(x, y) = z), And([(y != 0)])])
 
 --
 
-(SafeDiv(x, y) = z), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(x, y, z) 
-
---
-
 And([(y != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
+
+--
+
+(SafeDiv(x, y) = z), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(x, y, z) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(UnsafeDiv(x, SafeDiv(y, z)) = 10), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 UnsafeDiv(x, SafeDiv(y, z)), 
    ~~> div_to_bubble ([("Bubble", 6000)]) 
 {SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} 
@@ -40,7 +52,13 @@ And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])])
 
 --
 
-And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]), And([And([(z != 0)])])]), 
+And([(SafeDiv(y, z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeDiv(y, z) != 0) 
+
+--
+
+And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0)]), (z != 0)]), 
    ~~> normalise_associative_commutative ([("Base", 8400)]) 
 And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)]) 
 
@@ -52,15 +70,15 @@ SafeDiv(x, __0)
 
 --
 
-(SafeDiv(x, __0) = 10), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(x, __0, 10) 
-
---
-
 (SafeDiv(y, z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+
+--
+
+(SafeDiv(x, __0) = 10), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(x, __0, 10) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(UnsafeDiv(x, SafeDiv(y, z)) != 10), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 UnsafeDiv(x, SafeDiv(y, z)), 
    ~~> div_to_bubble ([("Bubble", 6000)]) 
 {SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} 
@@ -40,7 +52,13 @@ And([(SafeDiv(x, SafeDiv(y, z)) != 10), And([(SafeDiv(y, z) != 0)])])
 
 --
 
-And([And([(SafeDiv(x, SafeDiv(y, z)) != 10), And([(SafeDiv(y, z) != 0)])]), And([And([(z != 0)])])]), 
+And([(SafeDiv(y, z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeDiv(y, z) != 0) 
+
+--
+
+And([And([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) != 0)]), (z != 0)]), 
    ~~> normalise_associative_commutative ([("Base", 8400)]) 
 And([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) != 0), (z != 0)]) 
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(UnsafeDiv(x, SafeDiv(y, z)) = 10), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 UnsafeDiv(x, SafeDiv(y, z)), 
    ~~> div_to_bubble ([("Bubble", 6000)]) 
 {SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} 
@@ -40,63 +52,15 @@ And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])])
 
 --
 
-Not(And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]), And([And([(z != 0)])])])), 
+And([(SafeDiv(y, z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeDiv(y, z) != 0) 
+
+--
+
+Not(And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0)]), (z != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not(And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])])), Not(And([And([(z != 0)])]))]) 
-
---
-
-Not(And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)), Not(And([(SafeDiv(y, z) != 0)]))]) 
-
---
-
-Or([Or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)), Not(And([(SafeDiv(y, z) != 0)]))]), Not(And([And([(z != 0)])]))]), 
-   ~~> normalise_associative_commutative ([("Base", 8400)]) 
-Or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)), Not(And([(SafeDiv(y, z) != 0)])), Not(And([And([(z != 0)])]))]) 
-
---
-
-Not((SafeDiv(x, SafeDiv(y, z)) = 10)), 
-   ~~> negated_eq_to_neq ([("Base", 8800)]) 
-(SafeDiv(x, SafeDiv(y, z)) != 10) 
-
---
-
-(SafeDiv(x, SafeDiv(y, z)) != 10), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(__0 != 10) 
-
---
-
-Not(And([(SafeDiv(y, z) != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((SafeDiv(y, z) != 0)) 
-
---
-
-Not((SafeDiv(y, z) != 0)), 
-   ~~> negated_neq_to_eq ([("Base", 8800)]) 
-(SafeDiv(y, z) = 0) 
-
---
-
-(SafeDiv(y, z) = 0), 
-   ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(y, z, 0) 
-
---
-
-Not(And([And([(z != 0)])])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not(And([(z != 0)])) 
-
---
-
-Not(And([(z != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((z != 0)) 
+Or([Not(And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0)])), Not((z != 0))]) 
 
 --
 
@@ -106,9 +70,45 @@ Not((z != 0)),
 
 --
 
+Not(And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0)])), 
+   ~~> distribute_not_over_and ([("Base", 8400)]) 
+Or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)), Not((SafeDiv(y, z) != 0))]) 
+
+--
+
+Not((SafeDiv(x, SafeDiv(y, z)) = 10)), 
+   ~~> negated_eq_to_neq ([("Base", 8800)]) 
+(SafeDiv(x, SafeDiv(y, z)) != 10) 
+
+--
+
+Not((SafeDiv(y, z) != 0)), 
+   ~~> negated_neq_to_eq ([("Base", 8800)]) 
+(SafeDiv(y, z) = 0) 
+
+--
+
+Or([Or([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) = 0)]), (z = 0)]), 
+   ~~> normalise_associative_commutative ([("Base", 8400)]) 
+Or([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) = 0), (z = 0)]) 
+
+--
+
+(SafeDiv(x, SafeDiv(y, z)) != 10), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(__0 != 10) 
+
+--
+
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __1) 
+
+--
+
+(SafeDiv(y, z) = 0), 
+   ~~> introduce_diveq ([("Minion", 4200)]) 
+DivEq(y, z, 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeMod(x,y) = 3), And([(y != 0)])])
 
 --
 
-(SafeMod(x,y) = 3), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(x, y, 3) 
-
---
-
 And([(y != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
+
+--
+
+(SafeMod(x,y) = 3), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(x, y, 3) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -16,15 +16,15 @@ And([(SafeMod(x,y) = z), And([(y != 0)])])
 
 --
 
-(SafeMod(x,y) = z), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(x, y, z) 
-
---
-
 And([(y != 0)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
+
+--
+
+(SafeMod(x,y) = z), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(x, y, z) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(x % SafeMod(y,z) = 3), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 x % SafeMod(y,z), 
    ~~> mod_to_bubble ([("Bubble", 6000)]) 
 {SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} 
@@ -40,7 +52,13 @@ And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])])
 
 --
 
-And([And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]), And([And([(z != 0)])])]), 
+And([(SafeMod(y,z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeMod(y,z) != 0) 
+
+--
+
+And([And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0)]), (z != 0)]), 
    ~~> normalise_associative_commutative ([("Base", 8400)]) 
 And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)]) 
 
@@ -52,15 +70,15 @@ SafeMod(x,__0)
 
 --
 
-(SafeMod(x,__0) = 3), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(x, __0, 3) 
-
---
-
 (SafeMod(y,z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+
+--
+
+(SafeMod(x,__0) = 3), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(x, __0, 3) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(x % SafeMod(y,z) != 3), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 x % SafeMod(y,z), 
    ~~> mod_to_bubble ([("Bubble", 6000)]) 
 {SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} 
@@ -40,7 +52,13 @@ And([(SafeMod(x,SafeMod(y,z)) != 3), And([(SafeMod(y,z) != 0)])])
 
 --
 
-And([And([(SafeMod(x,SafeMod(y,z)) != 3), And([(SafeMod(y,z) != 0)])]), And([And([(z != 0)])])]), 
+And([(SafeMod(y,z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeMod(y,z) != 0) 
+
+--
+
+And([And([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) != 0)]), (z != 0)]), 
    ~~> normalise_associative_commutative ([("Base", 8400)]) 
 And([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) != 0), (z != 0)]) 
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -22,6 +22,18 @@ And([(x % SafeMod(y,z) = 3), And([And([(z != 0)])])])
 
 --
 
+And([And([(z != 0)])]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+And([(z != 0)]) 
+
+--
+
+And([(z != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(z != 0) 
+
+--
+
 x % SafeMod(y,z), 
    ~~> mod_to_bubble ([("Bubble", 6000)]) 
 {SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} 
@@ -40,63 +52,15 @@ And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])])
 
 --
 
-Not(And([And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]), And([And([(z != 0)])])])), 
+And([(SafeMod(y,z) != 0)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(SafeMod(y,z) != 0) 
+
+--
+
+Not(And([And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0)]), (z != 0)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not(And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])])), Not(And([And([(z != 0)])]))]) 
-
---
-
-Not(And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((SafeMod(x,SafeMod(y,z)) = 3)), Not(And([(SafeMod(y,z) != 0)]))]) 
-
---
-
-Or([Or([Not((SafeMod(x,SafeMod(y,z)) = 3)), Not(And([(SafeMod(y,z) != 0)]))]), Not(And([And([(z != 0)])]))]), 
-   ~~> normalise_associative_commutative ([("Base", 8400)]) 
-Or([Not((SafeMod(x,SafeMod(y,z)) = 3)), Not(And([(SafeMod(y,z) != 0)])), Not(And([And([(z != 0)])]))]) 
-
---
-
-Not((SafeMod(x,SafeMod(y,z)) = 3)), 
-   ~~> negated_eq_to_neq ([("Base", 8800)]) 
-(SafeMod(x,SafeMod(y,z)) != 3) 
-
---
-
-(SafeMod(x,SafeMod(y,z)) != 3), 
-   ~~> flatten_binop ([("Minion", 4400)]) 
-(__0 != 3) 
-
---
-
-Not(And([(SafeMod(y,z) != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((SafeMod(y,z) != 0)) 
-
---
-
-Not((SafeMod(y,z) != 0)), 
-   ~~> negated_neq_to_eq ([("Base", 8800)]) 
-(SafeMod(y,z) = 0) 
-
---
-
-(SafeMod(y,z) = 0), 
-   ~~> introduce_modeq ([("Minion", 4200)]) 
-ModEq(y, z, 0) 
-
---
-
-Not(And([And([(z != 0)])])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not(And([(z != 0)])) 
-
---
-
-Not(And([(z != 0)])), 
-   ~~> distribute_not_over_and ([("Base", 8400)]) 
-Not((z != 0)) 
+Or([Not(And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0)])), Not((z != 0))]) 
 
 --
 
@@ -106,9 +70,45 @@ Not((z != 0)),
 
 --
 
+Not(And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0)])), 
+   ~~> distribute_not_over_and ([("Base", 8400)]) 
+Or([Not((SafeMod(x,SafeMod(y,z)) = 3)), Not((SafeMod(y,z) != 0))]) 
+
+--
+
+Not((SafeMod(x,SafeMod(y,z)) = 3)), 
+   ~~> negated_eq_to_neq ([("Base", 8800)]) 
+(SafeMod(x,SafeMod(y,z)) != 3) 
+
+--
+
+Not((SafeMod(y,z) != 0)), 
+   ~~> negated_neq_to_eq ([("Base", 8800)]) 
+(SafeMod(y,z) = 0) 
+
+--
+
+Or([Or([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) = 0)]), (z = 0)]), 
+   ~~> normalise_associative_commutative ([("Base", 8400)]) 
+Or([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) = 0), (z = 0)]) 
+
+--
+
+(SafeMod(x,SafeMod(y,z)) != 3), 
+   ~~> flatten_binop ([("Minion", 4400)]) 
+(__0 != 3) 
+
+--
+
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__1) 
+
+--
+
+(SafeMod(y,z) = 0), 
+   ~~> introduce_modeq ([("Minion", 4200)]) 
+ModEq(y, z, 0) 
 
 --
 

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -2,6 +2,7 @@ mod atom;
 mod domains;
 mod expressions;
 mod literals;
+pub mod pretty;
 mod symbol_table;
 pub mod types;
 mod variables;

--- a/crates/conjure_core/src/ast/pretty.rs
+++ b/crates/conjure_core/src/ast/pretty.rs
@@ -3,6 +3,8 @@
 //! Most things can be pretty printed using `Display`; however some, notably collections
 //! can not, for example, Vec<Expression>
 
+use std::fmt::Display;
+
 use itertools::Itertools;
 
 use super::Expression;
@@ -37,6 +39,23 @@ pub fn pretty_expressions_as_conjunction(expressions: &[Expression]) -> String {
 
     str.insert(0, '(');
     str.push(')');
+
+    str
+}
+
+/// Pretty prints a `Vec<T>` in a vector like syntax.
+///
+/// For some input values A,B,C:
+///
+/// ```text
+/// [A,B,C]
+/// ````
+///
+/// Each element is printed using its underlying `Display` implementation.
+pub fn pretty_vec<T: Display>(elems: &[T]) -> String {
+    let mut str = elems.iter().map(|x| format!("{}", x)).join(", ");
+    str.insert(0, '[');
+    str.push(']');
 
     str
 }

--- a/crates/conjure_core/src/ast/pretty.rs
+++ b/crates/conjure_core/src/ast/pretty.rs
@@ -1,0 +1,42 @@
+//! Functions for pretty printing Conjure models.
+//!
+//! Most things can be pretty printed using `Display`; however some, notably collections
+//! can not, for example, Vec<Expression>
+
+use itertools::Itertools;
+
+use super::Expression;
+
+/// Pretty prints a `Vec<Expression>` as if it were a top level constraint list in a `such that`.
+///
+/// Each expression is printed on a new line, and expressions are delimited by commas.
+///
+/// For some input expressions A,B,C:
+/// ```text
+/// A,
+/// B,
+/// C
+/// ```
+///
+/// Each `Expression` is printed using its underlying `Display` implementation.
+pub fn pretty_expressions_as_top_level(expressions: &[Expression]) -> String {
+    expressions.iter().map(|x| format!("{}", x)).join(",\n")
+}
+
+/// Pretty prints a `Vec<Expression>` as if it were a conjunction.
+///
+/// For some input expressions A,B,C:
+///
+/// ```text
+/// (A /\ B /\ C)
+/// ```
+///
+/// Each `Expression` is printed using its underlying `Display` implementation.
+pub fn pretty_expressions_as_conjunction(expressions: &[Expression]) -> String {
+    let mut str = expressions.iter().map(|x| format!("{}", x)).join(" /\\ ");
+
+    str.insert(0, '(');
+    str.push(')');
+
+    str
+}

--- a/crates/conjure_core/src/rule_engine/mod.rs
+++ b/crates/conjure_core/src/rule_engine/mod.rs
@@ -65,6 +65,7 @@ pub use conjure_macros::register_rule;
 pub use conjure_macros::register_rule_set;
 pub use resolve_rules::{get_rule_priorities, get_rules_vec, resolve_rule_sets};
 pub use rewrite::{rewrite_model, RewriteError};
+pub use rewrite_naive::rewrite_naive;
 pub use rule::{ApplicationError, ApplicationResult, Reduction, Rule};
 pub use rule_set::RuleSet;
 
@@ -72,6 +73,7 @@ use crate::solver::SolverFamily;
 
 mod resolve_rules;
 mod rewrite;
+mod rewrite_naive;
 mod rule;
 mod rule_set;
 

--- a/crates/conjure_core/src/rule_engine/mod.rs
+++ b/crates/conjure_core/src/rule_engine/mod.rs
@@ -64,8 +64,9 @@ pub use conjure_macros::register_rule;
 #[doc(inline)]
 pub use conjure_macros::register_rule_set;
 pub use resolve_rules::{get_rule_priorities, get_rules_vec, resolve_rule_sets};
-pub use rewrite::{rewrite_model, RewriteError};
+pub use rewrite::rewrite_model;
 pub use rewrite_naive::rewrite_naive;
+pub use rewriter_common::RewriteError;
 pub use rule::{ApplicationError, ApplicationResult, Reduction, Rule};
 pub use rule_set::RuleSet;
 
@@ -74,6 +75,7 @@ use crate::solver::SolverFamily;
 mod resolve_rules;
 mod rewrite;
 mod rewrite_naive;
+mod rewriter_common;
 mod rule;
 mod rule_set;
 

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use thiserror::Error;
 
-use crate::ast::pretty::pretty_expressions_as_conjunction;
+use crate::ast::pretty::pretty_vec;
 use crate::ast::ReturnType;
 use crate::bug;
 use crate::stats::RewriterStats;
@@ -395,7 +395,7 @@ fn choose_rewrite(results: &[RuleResult], initial_expression: &Expression) -> Op
     }
     let red = results[0].reduction.clone();
     let rule = results[0].rule;
-    let new_top_string = pretty_expressions_as_conjunction(&red.new_top);
+    let new_top_string = pretty_vec(&red.new_top);
     tracing::info!(
         %new_top_string,
         "Rule applicable: {} ({:?}), to expression: {}, resulting in: {}",

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 
 use thiserror::Error;
 
+use crate::ast::pretty::pretty_expressions_as_conjunction;
 use crate::ast::ReturnType;
 use crate::bug;
 use crate::stats::RewriterStats;
@@ -394,7 +395,7 @@ fn choose_rewrite(results: &[RuleResult], initial_expression: &Expression) -> Op
     }
     let red = results[0].reduction.clone();
     let rule = results[0].rule;
-    let new_top_string = format!("{:?}", red.new_top);
+    let new_top_string = pretty_expressions_as_conjunction(&red.new_top);
     tracing::info!(
         %new_top_string,
         "Rule applicable: {} ({:?}), to expression: {}, resulting in: {}",
@@ -445,7 +446,7 @@ fn check_priority<'a>(
 
     if !duplicate_rules.is_empty() {
         //accumulates all duplicates into a formatted message
-        let mut message = format!("Found multiple rules of the same priority applicable to to expression: {:?} \n resulting in expression: {:?}", initial_expr, new_expr);
+        let mut message = format!("Found multiple rules of the same priority applicable to to expression: {} \n resulting in expression: {}", initial_expr, new_expr);
         for (priority, rules) in &duplicate_rules {
             message.push_str(&format!("Priority {:?} \n Rules: {:?}", priority, rules));
         }
@@ -453,7 +454,7 @@ fn check_priority<'a>(
 
     //no duplicate rules of the same priorities were found in the set of applicable rules
     } else {
-        log::warn!("Multiple rules of different priorities are applicable to expression {:?} \n resulting in expression: {:?}
+        log::warn!("Multiple rules of different priorities are applicable to expression {} \n resulting in expression: {}
         \n Rules{:?}", initial_expr, new_expr, rules)
     }
 }

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -102,7 +102,7 @@ pub fn rewrite_naive<'a>(
             [] => {
                 break;
             }
-            [(result, priority, expr, ctx), ..] => {
+            [(result, priority, expr, ctx)] => {
                 // Extract the single applicable rule and apply it
                 tracing::info!(
                     new_top = %pretty_vec(&result.reduction.new_top),

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -42,7 +42,7 @@ pub fn rewrite_naive<'a>(
     let mut results: Vec<(Reduction, String, u16, Expr, CtxFn)>;
 
     let mut model = model.clone();
-    let mut highest_applicable_rule_priority = 0;
+    let mut highest_applicable_rule_priority;
 
     loop {
         results = vec![];

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -1,17 +1,18 @@
 use std::sync::Arc;
 
-use uniplate::Biplate;
-
 use super::{RewriteError, RuleSet};
 use crate::{
-    ast::Expression as Expr,
+    ast::{pretty::pretty_vec, Expression as Expr},
     bug,
     rule_engine::{
-        get_rule_priorities, get_rules_vec,
+        get_rule_priorities,
         rewriter_common::{log_rule_application, RuleResult},
+        Reduction, Rule,
     },
     Model,
 };
+use std::collections::{BTreeMap, HashSet};
+use uniplate::Biplate;
 
 /// A naive, exhaustive rewriter.
 ///
@@ -30,80 +31,175 @@ pub fn rewrite_naive<'a>(
     // At each iteration, rules are checked against all expressions in order of priority until one
     // is applicable. This is done until no more rules can be applied to any expression.
 
-    // rules sorted by priority
-    let rules = get_rules_vec(
-        &get_rule_priorities(rule_sets).unwrap_or_else(|_| bug!("get_rule_priorities() failed!")),
-    );
+    let priorities =
+        get_rule_priorities(rule_sets).unwrap_or_else(|_| bug!("get_rule_priorities() failed!"));
+
+    // Invert the map: group rules by their priority.
+    // BTreeMap because it maintains keys in sorted order
+    let mut grouped: BTreeMap<u16, HashSet<&'a Rule<'a>>> = BTreeMap::new();
+
+    for (rule, priority) in priorities {
+        grouped
+            .entry(priority)
+            .or_insert_with(HashSet::new)
+            .insert(rule);
+    }
+
+    // `grouped` now holds rules organised by ascending priority
+    // If needed, you can convert this into a Vec of sets:
+    let rules_by_priority: Vec<(u16, HashSet<&'a Rule<'a>>)> = grouped.into_iter().collect();
 
     type CtxFn = Arc<dyn Fn(Expr) -> Vec<Expr>>;
 
-    // List of applicable rules for this pass:
-    //
-    // (ruleresult, original expression, context function)
-    //
-    // Each rule in this list should be at the same priority level
-    let mut results: Vec<(RuleResult, Expr, CtxFn)>;
-
     let mut model = model.clone();
-    let mut highest_applicable_rule_priority;
 
     loop {
-        results = vec![];
+        // List of applicable rules for this pass:
+        //
+        // (reduction, rule name, priority, original expression, context function)
+        //
+        // Each rule in this list should be at the same priority level
+        let mut results: Vec<(RuleResult<'_>, u16, Expr, CtxFn)> = vec![];
 
-        // already found a rule of x priority that's applicable, do not bother trying ones that are
-        // lower.
-        highest_applicable_rule_priority = 0;
+        // Iterate over priority levels in descending order
+        for (priority, rule_set) in rules_by_priority.iter().rev() {
+            for (expr, ctx) in Biplate::<Expr>::contexts_bi(&model.get_constraints_vec()) {
+                // Clone expr and ctx so they can be reused
+                let expr = expr.clone();
+                let ctx = ctx.clone();
+                for rule in rule_set {
+                    match (rule.application)(&expr, &model) {
+                        Ok(red) => {
+                            // Collect applicable rules
+                            results.push((
+                                RuleResult {
+                                    rule: rule,
+                                    reduction: red,
+                                },
+                                *priority,
+                                expr.clone(),
+                                ctx.clone(),
+                            ));
+                        }
+                        Err(_) => {
+                            tracing::trace!(
+                                "Rule attempted but not applied: {} (priority {}), to expression: {}",
+                                rule.name,
+                                priority,
+                                expr
+                            );
+                        }
+                    }
+                }
+                // If any results were found at the current priority level, stop checking lower priorities
+                if !results.is_empty() {
+                    break;
+                }
+            }
+        }
 
-        for rule in &rules {
-            let rule_priority = rule.rule_sets[0].1;
-
-            if rule_priority < highest_applicable_rule_priority {
+        match results.as_slice() {
+            [] => {
                 break;
             }
+            [(result, priority, expr, ctx), ..] => {
+                // Extract the single applicable rule and apply it
+                tracing::info!(
+                    new_top = %pretty_vec(&result.reduction.new_top),
+                    "Applying rule: {} (priority {}), to expression: {}, resulting in: {}",
+                    result.rule.name,
+                    priority,
+                    expr,
+                    result.reduction.new_expression
+                );
+                // let (result, expr, ctx) = results[0].clone();
 
-            for (expr, ctx) in Biplate::<Expr>::contexts_bi(&model.get_constraints_vec()) {
-                let Ok(reduction) = (rule.application)(&expr, &model) else {
-                    tracing::trace!(
-                        "Rule attempted but not applied: {} ({:?}), to expression: {}",
-                        rule.name,
-                        rule.rule_sets,
-                        expr
-                    );
-                    continue;
-                };
+                log_rule_application(result, &expr);
 
-                highest_applicable_rule_priority = rule_priority;
-                results.push((RuleResult { rule, reduction }, expr, ctx));
+                // Replace expr with new_expression
+                model.set_constraints(ctx(result.reduction.new_expression.clone()));
+
+                // Apply new symbols and top level
+                result.reduction.clone().apply(&mut model);
+            }
+            _ => {
+                let names: Vec<_> = results
+                    .iter()
+                    .map(|(result, _, _, _)| result.rule.name)
+                    .collect();
+
+                // Extract the expression from the first result
+                let expr = results[0].2.clone();
+
+                // bug!("Multiple equally applicable rules for {expr}: {names:#?}");
+
+                // TODO, debugging code, remove before merging
+                // TODO: write a separate test which generates this for a given backend solver and tests it using generated/expected style. Good for documentation too.
+                // Current output:
+                // Priority 9001:
+                // - apply_eval_constant
+                // Priority 9000:
+                // - partial_evaluator
+                // Priority 8900:
+                // - bubble_up
+                // - expand_bubble
+                // Priority 8800:
+                // - remove_empty_expression
+                // - remove_unit_vector_and
+                // - remove_unit_vector_sum
+                // - negated_eq_to_neq
+                // - negated_neq_to_eq
+                // - remove_unit_vector_or
+                // Priority 8400:
+                // - distribute_negation_over_sum
+                // - distribute_not_over_or
+                // - minus_to_sum
+                // - distribute_not_over_and
+                // - remove_double_negation
+                // - distribute_or_over_and
+                // - normalise_associative_commutative
+                // - elmininate_double_negation
+                // Priority 6000:
+                // - mod_to_bubble
+                // - div_to_bubble
+                // Priority 4400:
+                // - flatten_vecop
+                // - flatten_eq
+                // - sum_leq_to_sumleq
+                // - sum_eq_to_sumeq
+                // - x_leq_y_plus_k_to_ineq
+                // - flatten_sum_geq
+                // - flatten_binop
+                // - sumeq_to_minion
+                // Priority 4200:
+                // - introduce_modeq
+                // - introduce_diveq
+                // Priority 4100:
+                // - leq_to_ineq
+                // - gt_to_ineq
+                // - geq_to_ineq
+                // - lt_to_ineq
+                // - not_literal_to_wliteral
+                // Priority 4090:
+                // - not_constraint_to_reify
+                // Priority 2000:
+                // - min_to_var
+                // Priority 100:
+                // - max_to_var
+
+                // Construct a single string to display the names of the rules grouped by priority
+                let mut rules_by_priority_string = String::new();
+                rules_by_priority_string.push_str("Rules grouped by priority:\n");
+                for (priority, rule_set) in rules_by_priority.iter().rev() {
+                    rules_by_priority_string.push_str(&format!("Priority {}:\n", priority));
+                    for rule in rule_set {
+                        rules_by_priority_string.push_str(&format!("  - {}\n", rule.name));
+                    }
+                }
+                bug!("Multiple equally applicable rules for {expr}: {names:#?}\n\n{rules_by_priority_string}");
             }
         }
-
-        // have we found a valid reduction?
-        if results.is_empty() {
-            break;
-        };
-
-        let (result, expr, ctx) = results[0].clone();
-
-        // are there any equally applicable rules?
-        let mut also_applicable: Vec<_> = results[1..]
-            .iter()
-            .filter(|(r, e, _)| *e == expr && r.rule.rule_sets[0].1 == result.rule.rule_sets[0].1)
-            .collect();
-
-        if !also_applicable.is_empty() {
-            also_applicable.push(&results[0]);
-            let names: Vec<_> = also_applicable.iter().map(|x| x.0.rule.name).collect();
-            let expr = &expr;
-            bug!("Multiple equally applicable rules for {expr}: {names:#?}");
-        }
-
-        log_rule_application(&result, &expr);
-
-        // replace expr with new_expression
-        model.set_constraints(ctx(result.reduction.new_expression.clone()));
-
-        // apply new symbols and top level
-        result.reduction.apply(&mut model);
     }
+
     Ok(model)
 }

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -7,7 +7,7 @@ use crate::{
     rule_engine::{
         get_rule_priorities,
         rewriter_common::{log_rule_application, RuleResult},
-        Reduction, Rule,
+        Rule,
     },
     Model,
 };

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use uniplate::Biplate;
+
+use super::{RewriteError, RuleSet};
+use crate::{
+    ast::{pretty::pretty_expressions_as_conjunction, Expression as Expr},
+    bug,
+    rule_engine::{get_rule_priorities, get_rules_vec, Reduction},
+    Model,
+};
+
+/// A naive, exhaustive rewriter.
+///
+/// **This rewriter should not be used in production, and is intended as a development tool.**
+///
+/// The goal of this rewriter is to model the correct rule application order. To this end, it uses
+/// the simplest implementation possible, disregarding performance.
+///
+/// **Rule application order:** apply the highest priority rule possible anywhere in the tree,
+/// favouring larger expressions as a tie-breaker.
+
+pub fn rewrite_naive<'a>(
+    model: &Model,
+    rule_sets: &Vec<&'a RuleSet<'a>>,
+) -> Result<Model, RewriteError> {
+    // At each iteration, rules are checked against all expressions in order of priority until one
+    // is applicable. This is done until no more rules can be applied to any expression.
+
+    // rules sorted by priority
+    let rules = get_rules_vec(
+        &get_rule_priorities(rule_sets).unwrap_or_else(|_| bug!("get_rule_priorities() failed!")),
+    );
+
+    type CtxFn = Arc<dyn Fn(Expr) -> Vec<Expr>>;
+
+    // result of the pass, including some logging information
+    // reduction,rule name, priority, original expression, context fn
+    let mut result: Option<(Reduction, String, u16, Expr, CtxFn)>;
+
+    let mut model = model.clone();
+
+    loop {
+        result = None;
+
+        'rules: for rule in &rules {
+            for (expr, ctx) in Biplate::<Expr>::contexts_bi(&model.get_constraints_vec()) {
+                let Ok(red) = (rule.application)(&expr, &model) else {
+                    tracing::trace!(
+                        "Rule attempted but not applied: {} ({:?}), to expression: {}",
+                        rule.name,
+                        rule.rule_sets,
+                        expr
+                    );
+                    continue;
+                };
+
+                result = Some((red, rule.name.into(), rule.rule_sets[0].1, expr, ctx));
+                break 'rules;
+            }
+        }
+
+        // have we found a valid reduction?
+        let Some((red, name, priority, expr, ctx)) = result else {
+            break;
+        };
+
+        tracing::info!(
+            new_top = %pretty_expressions_as_conjunction(&red.new_top),
+            "Applying rule: {} (priority {}), to expression: {}, resulting in: {}",
+            name,
+            priority,
+            expr,
+            &red.new_expression
+        );
+
+        // replace expr with new_expression
+        model.set_constraints(ctx(red.new_expression.clone()));
+
+        // apply new symbols and top level
+        red.apply(&mut model);
+    }
+    Ok(model)
+}

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -27,6 +27,7 @@ use uniplate::Biplate;
 pub fn rewrite_naive<'a>(
     model: &Model,
     rule_sets: &Vec<&'a RuleSet<'a>>,
+    prop_multiple_equally_applicable: bool,
 ) -> Result<Model, RewriteError> {
     // At each iteration, rules are checked against all expressions in order of priority until one
     // is applicable. This is done until no more rules can be applied to any expression.
@@ -102,7 +103,7 @@ pub fn rewrite_naive<'a>(
             [] => {
                 break;
             }
-            [(result, priority, expr, ctx)] => {
+            [(result, priority, expr, ctx), ..] => {
                 // Extract the single applicable rule and apply it
                 tracing::info!(
                     new_top = %pretty_vec(&result.reduction.new_top),
@@ -121,82 +122,83 @@ pub fn rewrite_naive<'a>(
 
                 // Apply new symbols and top level
                 result.reduction.clone().apply(&mut model);
-            }
-            _ => {
-                let names: Vec<_> = results
-                    .iter()
-                    .map(|(result, _, _, _)| result.rule.name)
-                    .collect();
 
-                // Extract the expression from the first result
-                let expr = results[0].2.clone();
+                if results.len() > 1 && prop_multiple_equally_applicable {
+                    let names: Vec<_> = results
+                        .iter()
+                        .map(|(result, _, _, _)| result.rule.name)
+                        .collect();
 
-                // bug!("Multiple equally applicable rules for {expr}: {names:#?}");
+                    // Extract the expression from the first result
+                    let expr = results[0].2.clone();
 
-                // TODO, debugging code, remove before merging
-                // TODO: write a separate test which generates this for a given backend solver and tests it using generated/expected style. Good for documentation too.
-                // Current output:
-                // Priority 9001:
-                // - apply_eval_constant
-                // Priority 9000:
-                // - partial_evaluator
-                // Priority 8900:
-                // - bubble_up
-                // - expand_bubble
-                // Priority 8800:
-                // - remove_empty_expression
-                // - remove_unit_vector_and
-                // - remove_unit_vector_sum
-                // - negated_eq_to_neq
-                // - negated_neq_to_eq
-                // - remove_unit_vector_or
-                // Priority 8400:
-                // - distribute_negation_over_sum
-                // - distribute_not_over_or
-                // - minus_to_sum
-                // - distribute_not_over_and
-                // - remove_double_negation
-                // - distribute_or_over_and
-                // - normalise_associative_commutative
-                // - elmininate_double_negation
-                // Priority 6000:
-                // - mod_to_bubble
-                // - div_to_bubble
-                // Priority 4400:
-                // - flatten_vecop
-                // - flatten_eq
-                // - sum_leq_to_sumleq
-                // - sum_eq_to_sumeq
-                // - x_leq_y_plus_k_to_ineq
-                // - flatten_sum_geq
-                // - flatten_binop
-                // - sumeq_to_minion
-                // Priority 4200:
-                // - introduce_modeq
-                // - introduce_diveq
-                // Priority 4100:
-                // - leq_to_ineq
-                // - gt_to_ineq
-                // - geq_to_ineq
-                // - lt_to_ineq
-                // - not_literal_to_wliteral
-                // Priority 4090:
-                // - not_constraint_to_reify
-                // Priority 2000:
-                // - min_to_var
-                // Priority 100:
-                // - max_to_var
+                    // bug!("Multiple equally applicable rules for {expr}: {names:#?}");
 
-                // Construct a single string to display the names of the rules grouped by priority
-                let mut rules_by_priority_string = String::new();
-                rules_by_priority_string.push_str("Rules grouped by priority:\n");
-                for (priority, rule_set) in rules_by_priority.iter().rev() {
-                    rules_by_priority_string.push_str(&format!("Priority {}:\n", priority));
-                    for rule in rule_set {
-                        rules_by_priority_string.push_str(&format!("  - {}\n", rule.name));
+                    // TODO, debugging code, remove before merging
+                    // TODO: write a separate test which generates this for a given backend solver and tests it using generated/expected style. Good for documentation too.
+                    // Current output:
+                    // Priority 9001:
+                    // - apply_eval_constant
+                    // Priority 9000:
+                    // - partial_evaluator
+                    // Priority 8900:
+                    // - bubble_up
+                    // - expand_bubble
+                    // Priority 8800:
+                    // - remove_empty_expression
+                    // - remove_unit_vector_and
+                    // - remove_unit_vector_sum
+                    // - negated_eq_to_neq
+                    // - negated_neq_to_eq
+                    // - remove_unit_vector_or
+                    // Priority 8400:
+                    // - distribute_negation_over_sum
+                    // - distribute_not_over_or
+                    // - minus_to_sum
+                    // - distribute_not_over_and
+                    // - remove_double_negation
+                    // - distribute_or_over_and
+                    // - normalise_associative_commutative
+                    // - elmininate_double_negation
+                    // Priority 6000:
+                    // - mod_to_bubble
+                    // - div_to_bubble
+                    // Priority 4400:
+                    // - flatten_vecop
+                    // - flatten_eq
+                    // - sum_leq_to_sumleq
+                    // - sum_eq_to_sumeq
+                    // - x_leq_y_plus_k_to_ineq
+                    // - flatten_sum_geq
+                    // - flatten_binop
+                    // - sumeq_to_minion
+                    // Priority 4200:
+                    // - introduce_modeq
+                    // - introduce_diveq
+                    // Priority 4100:
+                    // - leq_to_ineq
+                    // - gt_to_ineq
+                    // - geq_to_ineq
+                    // - lt_to_ineq
+                    // - not_literal_to_wliteral
+                    // Priority 4090:
+                    // - not_constraint_to_reify
+                    // Priority 2000:
+                    // - min_to_var
+                    // Priority 100:
+                    // - max_to_var
+
+                    // Construct a single string to display the names of the rules grouped by priority
+                    let mut rules_by_priority_string = String::new();
+                    rules_by_priority_string.push_str("Rules grouped by priority:\n");
+                    for (priority, rule_set) in rules_by_priority.iter().rev() {
+                        rules_by_priority_string.push_str(&format!("Priority {}:\n", priority));
+                        for rule in rule_set {
+                            rules_by_priority_string.push_str(&format!("  - {}\n", rule.name));
+                        }
                     }
+                    bug!("Multiple equally applicable rules for {expr}: {names:#?}\n\n{rules_by_priority_string}");
                 }
-                bug!("Multiple equally applicable rules for {expr}: {names:#?}\n\n{rules_by_priority_string}");
             }
         }
     }

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -4,7 +4,7 @@ use uniplate::Biplate;
 
 use super::{RewriteError, RuleSet};
 use crate::{
-    ast::{pretty::pretty_expressions_as_conjunction, Expression as Expr},
+    ast::{pretty::pretty_vec, Expression as Expr},
     bug,
     rule_engine::{get_rule_priorities, get_rules_vec, Reduction},
     Model,
@@ -66,7 +66,7 @@ pub fn rewrite_naive<'a>(
         };
 
         tracing::info!(
-            new_top = %pretty_expressions_as_conjunction(&red.new_top),
+            new_top = %pretty_vec(&red.new_top),
             "Applying rule: {} (priority {}), to expression: {}, resulting in: {}",
             name,
             priority,

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -1,0 +1,52 @@
+//! Common utilities and types for rewriters.
+
+use super::{resolve_rules::ResolveRulesError, Reduction, Rule};
+use crate::ast::{pretty::pretty_vec, Expression};
+
+use thiserror::Error;
+use tracing::{info, trace};
+
+#[derive(Debug, Clone)]
+pub struct RuleResult<'a> {
+    pub rule: &'a Rule<'a>,
+    pub reduction: Reduction,
+}
+
+/// Logs, to the main log, and the human readable traces used by the integration tester, that the
+/// rule has been applied to the expression
+pub fn log_rule_application(result: &RuleResult, initial_expression: &Expression) {
+    let red = &result.reduction;
+    let rule = result.rule;
+    let new_top_string = pretty_vec(&red.new_top);
+
+    info!(
+        %new_top_string,
+        "Rule applicable: {} ({:?}), to expression: {}, resulting in: {}",
+        rule.name,
+        rule.rule_sets,
+        initial_expression,
+        red.new_expression
+    );
+
+    trace!(
+        target: "rule_engine_human",
+        "{}, \n   ~~> {} ({:?}) \n{} \n\n--\n",
+        initial_expression,
+        rule.name,
+        rule.rule_sets,
+        red.new_expression,
+    );
+}
+
+/// Represents errors that can occur during the model rewriting process.
+#[derive(Debug, Error)]
+pub enum RewriteError {
+    #[error("Error resolving rules {0}")]
+    ResolveRulesError(ResolveRulesError),
+}
+
+impl From<ResolveRulesError> for RewriteError {
+    fn from(error: ResolveRulesError) -> Self {
+        RewriteError::ResolveRulesError(error)
+    }
+}


### PR DESCRIPTION
**Based on #435**

Add a new rewriter that naively implements the upcoming rewrite ordering changes for testing purposes.

Currently we rewrite larger expressions before smaller ones regardless of priority; however, we will soon be changing this so that higher priority rules are always applied first, regardless of the depth of the expression they are being applied to.

This rewriter allows me to test rules with the new upcoming rewriter changes before they land.  In particular, this will unblock my PR https://github.com/conjure-cp/conjure-oxide/pull/518, which introduces rules that only work with the new semantics.

This rewriter is exhaustive and simple, so would be too slow for production, but once these changes land, keeping this may be helpful for correctness testing, performance analysis, and debugging.

## Changelog


- update uniplate to v0.1.5
- feat(ast): add pretty printer for `Vec<Expression>`
- rewriter: add naive rewriter for debugging
- feat(cli): add `--use-naive-rewriter` flag to enable the naive rewriter
- tester: add `use_naive_rewriter` bool to config.toml
