### PR TITLE
refactor(tester)!: cleanup defaults handling for test config.toml

### DIFF
--- a/conjure_oxide/tests/integration/basic/min/01/config.toml
+++ b/conjure_oxide/tests/integration/basic/min/01/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/01-negeq/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/01-negeq/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/config.toml
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/savilerow/divide-mod-novar/config.toml
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod-novar/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false

--- a/conjure_oxide/tests/integration/savilerow/divide-mod/config.toml
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod/config.toml
@@ -1,1 +1,1 @@
-skip_native_parser=true
+use_native_parser=false


### PR DESCRIPTION
* Cleanup the handling of missing / default values in test `config.toml` files.

  Previously, flags were represented as `Option<bool>`. They had three possible values: true, false, or not specified. Now, these are represented as `bool`, with any missing values filled in with their defaults by serde during de-serialisation.

* Rename `skip_native_parser` config option to `use_native_parser`.

  Previously, all other options were opt-in, apart from this one. Make this opt-in for consistency.
