### PR TITLE
refactor(ast): add more `TryFrom` and `From` impls for `Atom`

### DIFF
--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use crate::metadata::Metadata;
 
 use super::{Expression, Literal, Name};
@@ -34,5 +36,136 @@ impl From<Literal> for Atom {
 impl From<Name> for Atom {
     fn from(value: Name) -> Self {
         Atom::Reference(value)
+    }
+}
+
+impl From<i32> for Atom {
+    fn from(value: i32) -> Self {
+        Atom::Literal(value.into())
+    }
+}
+
+impl From<bool> for Atom {
+    fn from(value: bool) -> Self {
+        Atom::Literal(value.into())
+    }
+}
+
+impl TryFrom<Expression> for Atom {
+    type Error = &'static str;
+
+    fn try_from(value: Expression) -> Result<Self, Self::Error> {
+        match value {
+            Expression::Atomic(_, atom) => Ok(atom),
+            _ => Err("Cannot convert non-atomic expression to Atom"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Expression> for &'a Atom {
+    type Error = &'static str;
+
+    fn try_from(value: &'a Expression) -> Result<Self, Self::Error> {
+        match value {
+            Expression::Atomic(_, atom) => Ok(atom),
+            _ => Err("Cannot convert non-atomic expression to Atom"),
+        }
+    }
+}
+
+impl TryFrom<Box<Expression>> for Atom {
+    type Error = &'static str;
+
+    fn try_from(value: Box<Expression>) -> Result<Self, Self::Error> {
+        (*value).try_into()
+    }
+}
+
+impl<'a> TryFrom<&'a Box<Expression>> for &'a Atom {
+    type Error = &'static str;
+
+    fn try_from(value: &'a Box<Expression>) -> Result<Self, Self::Error> {
+        let expr: &'a Expression = value.borrow();
+        expr.try_into()
+    }
+}
+
+impl TryFrom<Atom> for Literal {
+    type Error = &'static str;
+
+    fn try_from(value: Atom) -> Result<Self, Self::Error> {
+        match value {
+            Atom::Literal(l) => Ok(l),
+            _ => Err("Cannot convert non-literal atom to Literal"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Atom> for &'a Literal {
+    type Error = &'static str;
+
+    fn try_from(value: &'a Atom) -> Result<Self, Self::Error> {
+        match value {
+            Atom::Literal(l) => Ok(l),
+            _ => Err("Cannot convert non-literal atom to Literal"),
+        }
+    }
+}
+
+impl TryFrom<Atom> for Name {
+    type Error = &'static str;
+
+    fn try_from(value: Atom) -> Result<Self, Self::Error> {
+        match value {
+            Atom::Reference(n) => Ok(n),
+            _ => Err("Cannot convert non-reference atom to Name"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Atom> for &'a Name {
+    type Error = &'static str;
+
+    fn try_from(value: &'a Atom) -> Result<Self, Self::Error> {
+        match value {
+            Atom::Reference(n) => Ok(n),
+            _ => Err("Cannot convert non-reference atom to Name"),
+        }
+    }
+}
+
+impl TryFrom<Atom> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: Atom) -> Result<Self, Self::Error> {
+        let lit: Literal = value.try_into()?;
+        lit.try_into()
+    }
+}
+
+impl TryFrom<&Atom> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: &Atom) -> Result<Self, Self::Error> {
+        let lit: &Literal = value.try_into()?;
+        lit.try_into()
+    }
+}
+
+impl TryFrom<Atom> for bool {
+    type Error = &'static str;
+
+    fn try_from(value: Atom) -> Result<Self, Self::Error> {
+        let lit: Literal = value.try_into()?;
+        lit.try_into()
+    }
+}
+
+impl TryFrom<&Atom> for bool {
+    type Error = &'static str;
+
+    fn try_from(value: &Atom) -> Result<Self, Self::Error> {
+        let lit: &Literal = value.try_into()?;
+        lit.try_into()
     }
 }

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -382,14 +382,6 @@ impl Expression {
         self.set_meta(metadata);
     }
 
-    pub fn as_atom(&self) -> Option<Atom> {
-        if let Expression::Atomic(_m, f) = self {
-            Some(f.clone())
-        } else {
-            None
-        }
-    }
-
     /// True if the expression is an associative and commutative operator
     pub fn is_associative_commutative_operator(&self) -> bool {
         matches!(

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -21,12 +21,35 @@ impl TryFrom<Literal> for i32 {
         }
     }
 }
+
+impl TryFrom<&Literal> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: &Literal) -> Result<Self, Self::Error> {
+        match value {
+            Literal::Int(i) => Ok(*i),
+            _ => Err("Cannot convert non-i32 literal to i32"),
+        }
+    }
+}
+
 impl TryFrom<Literal> for bool {
     type Error = &'static str;
 
     fn try_from(value: Literal) -> Result<Self, Self::Error> {
         match value {
             Literal::Bool(b) => Ok(b),
+            _ => Err("Cannot convert non-bool literal to bool"),
+        }
+    }
+}
+
+impl TryFrom<&Literal> for bool {
+    type Error = &'static str;
+
+    fn try_from(value: &Literal) -> Result<Self, Self::Error> {
+        match value {
+            Literal::Bool(b) => Ok(*b),
             _ => Err("Cannot convert non-bool literal to bool"),
         }
     }

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -74,9 +74,9 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
         }
         Expr::DivEqUndefZero(_, a, b, c) => {
             // div always rounds down
-            let a = unwrap_atom::<i32>(a)?;
-            let b = unwrap_atom::<i32>(b)?;
-            let c = unwrap_atom::<i32>(c)?;
+            let a: i32 = a.try_into().ok()?;
+            let b: i32 = b.try_into().ok()?;
+            let c: i32 = c.try_into().ok()?;
 
             if b == 0 {
                 return None;
@@ -100,9 +100,10 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             //
             // We don't use % as it has the same semantics as /. We don't use / as we want to round
             // down instead, not towards zero.
-            let a = unwrap_atom::<i32>(a)?;
-            let b = unwrap_atom::<i32>(b)?;
-            let c = unwrap_atom::<i32>(c)?;
+
+            let a: i32 = a.try_into().ok()?;
+            let b: i32 = b.try_into().ok()?;
+            let c: i32 = c.try_into().ok()?;
 
             if b == 0 {
                 return None;
@@ -128,17 +129,22 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
         Expr::WatchedLiteral(_, _, _) => None,
         Expr::AuxDeclaration(_, _, _) => None,
         Expr::Neg(_, a) => {
-            let a = unwrap_atom::<i32>(&a.as_atom()?)?;
+            let a: &Atom = a.try_into().ok()?;
+            let a: i32 = a.try_into().ok()?;
             Some(Lit::Int(-a))
         }
         Expr::Minus(_, a, b) => {
-            let a = unwrap_atom::<i32>(&a.as_atom()?)?;
-            let b = unwrap_atom::<i32>(&b.as_atom()?)?;
+            let a: &Atom = a.try_into().ok()?;
+            let a: i32 = a.try_into().ok()?;
+
+            let b: &Atom = b.try_into().ok()?;
+            let b: i32 = b.try_into().ok()?;
+
             Some(Lit::Int(a - b))
         }
         Expr::MinusEq(_, a, b) => {
-            let a = unwrap_atom::<i32>(a)?;
-            let b = unwrap_atom::<i32>(b)?;
+            let a: i32 = a.try_into().ok()?;
+            let b: i32 = b.try_into().ok()?;
             Some(Lit::Bool(a == -b))
         } // _ => {
           //     warn!(%expr,"Unimplemented constant eval");
@@ -202,13 +208,6 @@ where
 fn unwrap_expr<T: TryFrom<Lit>>(expr: &Expr) -> Option<T> {
     let c = eval_constant(expr)?;
     TryInto::<T>::try_into(c).ok()
-}
-
-fn unwrap_atom<T: TryFrom<Lit>>(atom: &Atom) -> Option<T> {
-    let Atom::Literal(c) = atom else {
-        return None;
-    };
-    TryInto::<T>::try_into(c.clone()).ok()
 }
 
 #[cfg(test)]

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -36,13 +36,17 @@ fn introduce_diveq(expr: &Expr, _: &Model) -> ApplicationResult {
     match expr.clone() {
         Expr::Eq(m, a, b) => {
             meta = m;
-            if let Some(f) = a.as_atom() {
+
+            let a_atom: Option<&Atom> = (&a).try_into().ok();
+            let b_atom: Option<&Atom> = (&b).try_into().ok();
+
+            if let Some(f) = a_atom {
                 // val = div
-                val = f;
+                val = f.clone();
                 div = *b;
-            } else if let Some(f) = b.as_atom() {
+            } else if let Some(f) = b_atom {
                 // div = val
-                val = f;
+                val = f.clone();
                 div = *a;
             } else {
                 return Err(RuleNotApplicable);
@@ -63,13 +67,13 @@ fn introduce_diveq(expr: &Expr, _: &Model) -> ApplicationResult {
     }
 
     let children = div.children();
-    let a = children[0].as_atom().ok_or(RuleNotApplicable)?;
-    let b = children[1].as_atom().ok_or(RuleNotApplicable)?;
+    let a: &Atom = (&children[0]).try_into().or(Err(RuleNotApplicable))?;
+    let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(DivEqUndefZero(
         meta.clone_dirty(),
-        a,
-        b,
+        a.clone(),
+        b.clone(),
         val,
     )))
 }
@@ -84,13 +88,16 @@ fn introduce_modeq(expr: &Expr, _: &Model) -> ApplicationResult {
     match expr.clone() {
         Expr::Eq(m, a, b) => {
             meta = m;
-            if let Some(f) = a.as_atom() {
+            let a_atom: Option<&Atom> = (&a).try_into().ok();
+            let b_atom: Option<&Atom> = (&b).try_into().ok();
+
+            if let Some(f) = a_atom {
                 // val = div
-                val = f;
+                val = f.clone();
                 div = *b;
-            } else if let Some(f) = b.as_atom() {
+            } else if let Some(f) = b_atom {
                 // div = val
-                val = f;
+                val = f.clone();
                 div = *a;
             } else {
                 return Err(RuleNotApplicable);
@@ -111,13 +118,13 @@ fn introduce_modeq(expr: &Expr, _: &Model) -> ApplicationResult {
     }
 
     let children = div.children();
-    let a = children[0].as_atom().ok_or(RuleNotApplicable)?;
-    let b = children[1].as_atom().ok_or(RuleNotApplicable)?;
+    let a: &Atom = (&children[0]).try_into().or(Err(RuleNotApplicable))?;
+    let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(ModuloEqUndefZero(
         meta.clone_dirty(),
-        a,
-        b,
+        a.clone(),
+        b.clone(),
         val,
     )))
 }
@@ -136,14 +143,14 @@ fn introduce_minuseq_from_eq(expr: &Expr, _: &Model) -> ApplicationResult {
     };
 
     fn try_get_atoms(a: &Expr, b: &Expr) -> Option<(Atom, Atom)> {
-        let a = a.as_atom()?;
+        let a: &Atom = a.try_into().ok()?;
         let Neg(_, b) = b else {
             return None;
         };
 
-        let b = (*b).as_atom()?;
+        let b: &Atom = b.try_into().ok()?;
 
-        Some((a, b))
+        Some((a.clone(), b.clone()))
     }
 
     let a = *a.clone();
@@ -178,7 +185,7 @@ fn introduce_minuseq_from_aux_decl(expr: &Expr, _: &Model) -> ApplicationResult 
         return Err(RuleNotApplicable);
     };
 
-    let Some(b) = b.as_atom() else {
+    let Ok(b) = b.try_into() else {
         return Err(RuleNotApplicable);
     };
 


### PR DESCRIPTION
Add more `TryFrom` and `From` impls for Atom. These new impls allow atoms to be cast directly to integers and bools.

Remove the following functions, as they are now redundant:

  * `conjure_core::rules::constant_eval::unwrap_atom`

  * `conjure_core::ast::expressions::Expression::as_atom`
