### PR TITLE
Print new top level expressions to human-readable rule trace

### DIFF
--- a/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
@@ -43,7 +43,11 @@ Not((c != 0)),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeDiv(b, c)
 
+with changed declarations:
+  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
@@ -43,11 +43,10 @@ Not((c != 0)),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..3)
+new constraints:
   __0 =aux SafeDiv(b, c)
-
-with changed declarations:
-  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
@@ -25,7 +25,11 @@ And([(c != 0)]),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeDiv(b, c)
 
+with changed declarations:
+  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
@@ -25,11 +25,10 @@ And([(c != 0)]),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..3)
+new constraints:
   __0 =aux SafeDiv(b, c)
-
-with changed declarations:
-  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
@@ -43,7 +43,11 @@ Not((c != 0)),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeDiv(b, c)
 
+with changed declarations:
+  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
@@ -43,11 +43,10 @@ Not((c != 0)),
 (a != SafeDiv(b, c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..3)
+new constraints:
   __0 =aux SafeDiv(b, c)
-
-with changed declarations:
-  + __0: int(0..3)
 --
 
 __0 =aux SafeDiv(b, c), 

--- a/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Max([2, a]), 
    ~~> max_to_var ([("Base", 100)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(2..3)
+new constraints:
   (__0 >= 2)
   (__0 >= a)
   Or([(__0 = 2), (__0 = a)])
-
-with changed declarations:
-  + __0: int(2..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Max([2, a]), 
    ~~> max_to_var ([("Base", 100)]) 
 __0 
+with new top level expressions:
+  (__0 >= 2)
+  (__0 >= a)
+  Or([(__0 = 2), (__0 = a)])
 
+with changed declarations:
+  + __0: int(2..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(1..3)
+new constraints:
   (__0 <= a)
   (__0 <= b)
   Or([(__0 = a), (__0 = b)])
-
-with changed declarations:
-  + __0: int(1..3)
 --
 
 (__0 >= 3), 

--- a/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
+with new top level expressions:
+  (__0 <= a)
+  (__0 <= b)
+  Or([(__0 = a), (__0 = b)])
 
+with changed declarations:
+  + __0: int(1..3)
 --
 
 (__0 >= 3), 

--- a/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
+with new top level expressions:
+  (__0 <= a)
+  (__0 <= b)
+  Or([(__0 = a), (__0 = b)])
 
+with changed declarations:
+  + __0: int(1..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(1..3)
+new constraints:
   (__0 <= a)
   (__0 <= b)
   Or([(__0 = a), (__0 = b)])
-
-with changed declarations:
-  + __0: int(1..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
+with new top level expressions:
+  (__0 <= a)
+  (__0 <= b)
+  Or([(__0 = a), (__0 = b)])
 
+with changed declarations:
+  + __0: int(1..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(1..3)
+new constraints:
   (__0 <= a)
   (__0 <= b)
   Or([(__0 = a), (__0 = b)])
-
-with changed declarations:
-  + __0: int(1..3)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
+with new top level expressions:
+  (__0 <= a)
+  (__0 <= b)
+  Or([(__0 = a), (__0 = b)])
 
+with changed declarations:
+  + __0: int(1..2)
 --
 
 (__0 >= 3), 

--- a/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(1..2)
+new constraints:
   (__0 <= a)
   (__0 <= b)
   Or([(__0 = a), (__0 = b)])
-
-with changed declarations:
-  + __0: int(1..2)
 --
 
 (__0 >= 3), 

--- a/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
@@ -1,7 +1,13 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
+with new top level expressions:
+  (__0 <= a)
+  (__0 <= b)
+  Or([(__0 = a), (__0 = b)])
 
+with changed declarations:
+  + __0: int(1..4)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
@@ -1,13 +1,12 @@
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __0 
-with new top level expressions:
+new variables:
+  __0: int(1..4)
+new constraints:
   (__0 <= a)
   (__0 <= b)
   Or([(__0 = a), (__0 = b)])
-
-with changed declarations:
-  + __0: int(1..4)
 --
 
 (__0 <= 2), 

--- a/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
@@ -43,11 +43,10 @@ Not((c != 0)),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..2)
+new constraints:
   __0 =aux SafeMod(b,c)
-
-with changed declarations:
-  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
@@ -43,7 +43,11 @@ Not((c != 0)),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeMod(b,c)
 
+with changed declarations:
+  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
@@ -25,11 +25,10 @@ And([(c != 0)]),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..2)
+new constraints:
   __0 =aux SafeMod(b,c)
-
-with changed declarations:
-  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
@@ -25,7 +25,11 @@ And([(c != 0)]),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeMod(b,c)
 
+with changed declarations:
+  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
@@ -43,11 +43,10 @@ Not((c != 0)),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..2)
+new constraints:
   __0 =aux SafeMod(b,c)
-
-with changed declarations:
-  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
@@ -43,7 +43,11 @@ Not((c != 0)),
 (a != SafeMod(b,c)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (a != __0) 
+with new top level expressions:
+  __0 =aux SafeMod(b,c)
 
+with changed declarations:
+  + __0: int(0..2)
 --
 
 __0 =aux SafeMod(b,c), 

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
@@ -25,11 +25,10 @@ And([(z != 0)]),
 SafeDiv(-(y), z), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, z) 
-with new top level expressions:
+new variables:
+  __0: int(-1..1)
+new constraints:
   __0 =aux -(y)
-
-with changed declarations:
-  + __0: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
@@ -25,7 +25,11 @@ And([(z != 0)]),
 SafeDiv(-(y), z), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, z) 
+with new top level expressions:
+  __0 =aux -(y)
 
+with changed declarations:
+  + __0: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
@@ -37,7 +37,11 @@ And([(z != 0)]),
 (x = -(SafeDiv(y, z))), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(x,__0) 
+with new top level expressions:
+  __0 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __0: int(-1..1)
 --
 
 __0 =aux SafeDiv(y, z), 

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
@@ -37,11 +37,10 @@ And([(z != 0)]),
 (x = -(SafeDiv(y, z))), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(x,__0) 
-with new top level expressions:
+new variables:
+  __0: int(-1..1)
+new constraints:
   __0 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __0: int(-1..1)
 --
 
 __0 =aux SafeDiv(y, z), 

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
@@ -73,21 +73,19 @@ And([(x = SafeDiv(-(SafeDiv(y, z)), z)), (z != 0), (z != 0)])
 SafeDiv(-(SafeDiv(y, z)), z), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, z) 
-with new top level expressions:
+new variables:
+  __0: int(-1..1)
+new constraints:
   __0 =aux -(SafeDiv(y, z))
-
-with changed declarations:
-  + __0: int(-1..1)
 --
 
 __0 =aux -(SafeDiv(y, z)), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(__0,__1) 
-with new top level expressions:
+new variables:
+  __1: int(-1..1)
+new constraints:
   __1 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __1: int(-1..1)
 --
 
 (x = SafeDiv(__0, z)), 

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
@@ -73,13 +73,21 @@ And([(x = SafeDiv(-(SafeDiv(y, z)), z)), (z != 0), (z != 0)])
 SafeDiv(-(SafeDiv(y, z)), z), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, z) 
+with new top level expressions:
+  __0 =aux -(SafeDiv(y, z))
 
+with changed declarations:
+  + __0: int(-1..1)
 --
 
 __0 =aux -(SafeDiv(y, z)), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(__0,__1) 
+with new top level expressions:
+  __1 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __1: int(-1..1)
 --
 
 (x = SafeDiv(__0, z)), 

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
@@ -1,11 +1,10 @@
 Sum([-(y), z]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, z]) 
-with new top level expressions:
+new variables:
+  __0: int(-1..1)
+new constraints:
   __0 =aux -(y)
-
-with changed declarations:
-  + __0: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
@@ -1,7 +1,11 @@
 Sum([-(y), z]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, z]) 
+with new top level expressions:
+  __0 =aux -(y)
 
+with changed declarations:
+  + __0: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
@@ -43,7 +43,13 @@ a
 Sum([-(y), -(z), -1, a, b]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1, -1, a, b]) 
+with new top level expressions:
+  __0 =aux -(y)
+  __1 =aux -(z)
 
+with changed declarations:
+  + __0: int(-1..1)
+  + __1: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
@@ -43,13 +43,12 @@ a
 Sum([-(y), -(z), -1, a, b]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1, -1, a, b]) 
-with new top level expressions:
+new variables:
+  __0: int(-1..1)
+  __1: int(-1..1)
+new constraints:
   __0 =aux -(y)
   __1 =aux -(z)
-
-with changed declarations:
-  + __0: int(-1..1)
-  + __1: int(-1..1)
 --
 
 __0 =aux -(y), 

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
@@ -31,11 +31,10 @@ And([(a != 0)]),
 SafeDiv(Sum([x, y, z]), a), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, a) 
-with new top level expressions:
+new variables:
+  __0: int(6..14)
+new constraints:
   __0 =aux Sum([x, y, z])
-
-with changed declarations:
-  + __0: int(6..14)
 --
 
 (SafeDiv(__0, a) = 3), 

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
@@ -31,7 +31,11 @@ And([(a != 0)]),
 SafeDiv(Sum([x, y, z]), a), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(__0, a) 
+with new top level expressions:
+  __0 =aux Sum([x, y, z])
 
+with changed declarations:
+  + __0: int(6..14)
 --
 
 (SafeDiv(__0, a) = 3), 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
@@ -1,6 +1,12 @@
 Sum([Product([2, x]), Product([3, y])]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1]) 
+with new top level expressions:
+  __0 =aux Product([2, x])
+  __1 =aux Product([3, y])
 
+with changed declarations:
+  + __0: int(4..8)
+  + __1: int(6..12)
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
@@ -1,12 +1,11 @@
 Sum([Product([2, x]), Product([3, y])]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1]) 
-with new top level expressions:
+new variables:
+  __0: int(4..8)
+  __1: int(6..12)
+new constraints:
   __0 =aux Product([2, x])
   __1 =aux Product([3, y])
-
-with changed declarations:
-  + __0: int(4..8)
-  + __1: int(6..12)
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
@@ -43,28 +43,26 @@ Product([-5, y])
 Sum([Product([5, x]), Product([9, y]), -(Product([3, x])), Product([-1, y]), Product([-5, y])]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1, __2, __3, __4]) 
-with new top level expressions:
+new variables:
+  __0: int(10..25)
+  __1: int(18..45)
+  __2: int(-15..-6)
+  __3: int(-5..-2)
+  __4: int(-25..-10)
+new constraints:
   __0 =aux Product([5, x])
   __1 =aux Product([9, y])
   __2 =aux -(Product([3, x]))
   __3 =aux Product([-1, y])
   __4 =aux Product([-5, y])
-
-with changed declarations:
-  + __0: int(10..25)
-  + __1: int(18..45)
-  + __2: int(-15..-6)
-  + __3: int(-5..-2)
-  + __4: int(-25..-10)
 --
 
 __2 =aux -(Product([3, x])), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(__2,__5) 
-with new top level expressions:
+new variables:
+  __5: int(6..15)
+new constraints:
   __5 =aux Product([3, x])
-
-with changed declarations:
-  + __5: int(6..15)
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
@@ -43,12 +43,28 @@ Product([-5, y])
 Sum([Product([5, x]), Product([9, y]), -(Product([3, x])), Product([-1, y]), Product([-5, y])]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, __1, __2, __3, __4]) 
+with new top level expressions:
+  __0 =aux Product([5, x])
+  __1 =aux Product([9, y])
+  __2 =aux -(Product([3, x]))
+  __3 =aux Product([-1, y])
+  __4 =aux Product([-5, y])
 
+with changed declarations:
+  + __0: int(10..25)
+  + __1: int(18..45)
+  + __2: int(-15..-6)
+  + __3: int(-5..-2)
+  + __4: int(-25..-10)
 --
 
 __2 =aux -(Product([3, x])), 
    ~~> flatten_minuseq ([("Minion", 4400)]) 
 MinusEq(__2,__5) 
+with new top level expressions:
+  __5 =aux Product([3, x])
 
+with changed declarations:
+  + __5: int(6..15)
 --
 

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
@@ -1,11 +1,10 @@
 Sum([Min([a, b]), 6]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, 6]) 
-with new top level expressions:
+new variables:
+  __0: int(1..7)
+new constraints:
   __0 =aux Min([a, b])
-
-with changed declarations:
-  + __0: int(1..7)
 --
 
 (Sum([__0, 6]) <= 10), 
@@ -17,13 +16,12 @@ SumLeq([__0, 6], 10)
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __1 
-with new top level expressions:
+new variables:
+  __1: int(1..7)
+new constraints:
   (__1 <= a)
   (__1 <= b)
   Or([(__1 = a), (__1 = b)])
-
-with changed declarations:
-  + __1: int(1..7)
 --
 
 (__1 <= a), 

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
@@ -1,7 +1,11 @@
 Sum([Min([a, b]), 6]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, 6]) 
+with new top level expressions:
+  __0 =aux Min([a, b])
 
+with changed declarations:
+  + __0: int(1..7)
 --
 
 (Sum([__0, 6]) <= 10), 
@@ -13,7 +17,13 @@ SumLeq([__0, 6], 10)
 Min([a, b]), 
    ~~> min_to_var ([("Base", 2000)]) 
 __1 
+with new top level expressions:
+  (__1 <= a)
+  (__1 <= b)
+  Or([(__1 = a), (__1 = b)])
 
+with changed declarations:
+  + __1: int(1..7)
 --
 
 (__1 <= a), 

--- a/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
@@ -1,7 +1,11 @@
 Sum([Max([a, b]), 1]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, 1]) 
+with new top level expressions:
+  __0 =aux Max([a, b])
 
+with changed declarations:
+  + __0: int(1..4)
 --
 
 (x = Sum([__0, 1])), 
@@ -19,7 +23,13 @@ And([SumLeq([__0, 1], x), SumGeq([__0, 1], x)])
 Max([a, b]), 
    ~~> max_to_var ([("Base", 100)]) 
 __1 
+with new top level expressions:
+  (__1 >= a)
+  (__1 >= b)
+  Or([(__1 = a), (__1 = b)])
 
+with changed declarations:
+  + __1: int(1..4)
 --
 
 (__1 >= 2), 
@@ -43,7 +53,13 @@ Ineq(b, __1, 0)
 Max([a, b]), 
    ~~> max_to_var ([("Base", 100)]) 
 __2 
+with new top level expressions:
+  (__2 >= a)
+  (__2 >= b)
+  Or([(__2 = a), (__2 = b)])
 
+with changed declarations:
+  + __2: int(1..4)
 --
 
 (__2 >= a), 

--- a/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
@@ -1,11 +1,10 @@
 Sum([Max([a, b]), 1]), 
    ~~> flatten_vecop ([("Minion", 4400)]) 
 Sum([__0, 1]) 
-with new top level expressions:
+new variables:
+  __0: int(1..4)
+new constraints:
   __0 =aux Max([a, b])
-
-with changed declarations:
-  + __0: int(1..4)
 --
 
 (x = Sum([__0, 1])), 
@@ -23,13 +22,12 @@ And([SumLeq([__0, 1], x), SumGeq([__0, 1], x)])
 Max([a, b]), 
    ~~> max_to_var ([("Base", 100)]) 
 __1 
-with new top level expressions:
+new variables:
+  __1: int(1..4)
+new constraints:
   (__1 >= a)
   (__1 >= b)
   Or([(__1 = a), (__1 = b)])
-
-with changed declarations:
-  + __1: int(1..4)
 --
 
 (__1 >= 2), 
@@ -53,13 +51,12 @@ Ineq(b, __1, 0)
 Max([a, b]), 
    ~~> max_to_var ([("Base", 100)]) 
 __2 
-with new top level expressions:
+new variables:
+  __2: int(1..4)
+new constraints:
   (__2 >= a)
   (__2 >= b)
   Or([(__2 = a), (__2 = b)])
-
-with changed declarations:
-  + __2: int(1..4)
 --
 
 (__2 >= a), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -61,21 +61,19 @@ And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)])
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __0) 
-with new top level expressions:
+new variables:
+  __0: int(0..5)
+new constraints:
   __0 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __0: int(0..5)
 --
 
 (SafeDiv(y, z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
-with new top level expressions:
+new variables:
+  __1: int(0..5)
+new constraints:
   __1 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __1: int(0..5)
 --
 
 (SafeDiv(x, __0) = 10), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -61,13 +61,21 @@ And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)])
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __0) 
+with new top level expressions:
+  __0 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __0: int(0..5)
 --
 
 (SafeDiv(y, z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+with new top level expressions:
+  __1 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __1: int(0..5)
 --
 
 (SafeDiv(x, __0) = 10), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -61,31 +61,28 @@ And([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) != 0), (z != 0)])
 (SafeDiv(x, SafeDiv(y, z)) != 10), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 10) 
-with new top level expressions:
+new variables:
+  __0: int(0..20)
+new constraints:
   __0 =aux SafeDiv(x, SafeDiv(y, z))
-
-with changed declarations:
-  + __0: int(0..20)
 --
 
 (SafeDiv(y, z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
-with new top level expressions:
+new variables:
+  __1: int(0..5)
+new constraints:
   __1 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __1: int(0..5)
 --
 
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __2) 
-with new top level expressions:
+new variables:
+  __2: int(0..5)
+new constraints:
   __2 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __2: int(0..5)
 --
 
 __0 =aux SafeDiv(x, __2), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -61,19 +61,31 @@ And([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) != 0), (z != 0)])
 (SafeDiv(x, SafeDiv(y, z)) != 10), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 10) 
+with new top level expressions:
+  __0 =aux SafeDiv(x, SafeDiv(y, z))
 
+with changed declarations:
+  + __0: int(0..20)
 --
 
 (SafeDiv(y, z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+with new top level expressions:
+  __1 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __1: int(0..5)
 --
 
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __2) 
+with new top level expressions:
+  __2 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __2: int(0..5)
 --
 
 __0 =aux SafeDiv(x, __2), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -85,13 +85,21 @@ Not((z != 0)),
 (SafeDiv(x, SafeDiv(y, z)) != 10), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 10) 
+with new top level expressions:
+  __0 =aux SafeDiv(x, SafeDiv(y, z))
 
+with changed declarations:
+  + __0: int(0..20)
 --
 
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __1) 
+with new top level expressions:
+  __1 =aux SafeDiv(y, z)
 
+with changed declarations:
+  + __1: int(0..5)
 --
 
 (SafeDiv(y, z) = 0), 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -85,21 +85,19 @@ Not((z != 0)),
 (SafeDiv(x, SafeDiv(y, z)) != 10), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 10) 
-with new top level expressions:
+new variables:
+  __0: int(0..20)
+new constraints:
   __0 =aux SafeDiv(x, SafeDiv(y, z))
-
-with changed declarations:
-  + __0: int(0..20)
 --
 
 SafeDiv(x, SafeDiv(y, z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeDiv(x, __1) 
-with new top level expressions:
+new variables:
+  __1: int(0..5)
+new constraints:
   __1 =aux SafeDiv(y, z)
-
-with changed declarations:
-  + __1: int(0..5)
 --
 
 (SafeDiv(y, z) = 0), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -61,13 +61,21 @@ And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)])
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__0) 
+with new top level expressions:
+  __0 =aux SafeMod(y,z)
 
+with changed declarations:
+  + __0: int(0..5)
 --
 
 (SafeMod(y,z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+with new top level expressions:
+  __1 =aux SafeMod(y,z)
 
+with changed declarations:
+  + __1: int(0..5)
 --
 
 (SafeMod(x,__0) = 3), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -61,21 +61,19 @@ And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)])
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__0) 
-with new top level expressions:
+new variables:
+  __0: int(0..5)
+new constraints:
   __0 =aux SafeMod(y,z)
-
-with changed declarations:
-  + __0: int(0..5)
 --
 
 (SafeMod(y,z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
-with new top level expressions:
+new variables:
+  __1: int(0..5)
+new constraints:
   __1 =aux SafeMod(y,z)
-
-with changed declarations:
-  + __1: int(0..5)
 --
 
 (SafeMod(x,__0) = 3), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -61,19 +61,31 @@ And([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) != 0), (z != 0)])
 (SafeMod(x,SafeMod(y,z)) != 3), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 3) 
+with new top level expressions:
+  __0 =aux SafeMod(x,SafeMod(y,z))
 
+with changed declarations:
+  + __0: int(0..2)
 --
 
 (SafeMod(y,z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
+with new top level expressions:
+  __1 =aux SafeMod(y,z)
 
+with changed declarations:
+  + __1: int(0..3)
 --
 
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__2) 
+with new top level expressions:
+  __2 =aux SafeMod(y,z)
 
+with changed declarations:
+  + __2: int(0..3)
 --
 
 __0 =aux SafeMod(x,__2), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -61,31 +61,28 @@ And([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) != 0), (z != 0)])
 (SafeMod(x,SafeMod(y,z)) != 3), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 3) 
-with new top level expressions:
+new variables:
+  __0: int(0..2)
+new constraints:
   __0 =aux SafeMod(x,SafeMod(y,z))
-
-with changed declarations:
-  + __0: int(0..2)
 --
 
 (SafeMod(y,z) != 0), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__1 != 0) 
-with new top level expressions:
+new variables:
+  __1: int(0..3)
+new constraints:
   __1 =aux SafeMod(y,z)
-
-with changed declarations:
-  + __1: int(0..3)
 --
 
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__2) 
-with new top level expressions:
+new variables:
+  __2: int(0..3)
+new constraints:
   __2 =aux SafeMod(y,z)
-
-with changed declarations:
-  + __2: int(0..3)
 --
 
 __0 =aux SafeMod(x,__2), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -85,21 +85,19 @@ Not((z != 0)),
 (SafeMod(x,SafeMod(y,z)) != 3), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 3) 
-with new top level expressions:
+new variables:
+  __0: int(0..2)
+new constraints:
   __0 =aux SafeMod(x,SafeMod(y,z))
-
-with changed declarations:
-  + __0: int(0..2)
 --
 
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__1) 
-with new top level expressions:
+new variables:
+  __1: int(0..3)
+new constraints:
   __1 =aux SafeMod(y,z)
-
-with changed declarations:
-  + __1: int(0..3)
 --
 
 (SafeMod(y,z) = 0), 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -85,13 +85,21 @@ Not((z != 0)),
 (SafeMod(x,SafeMod(y,z)) != 3), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 (__0 != 3) 
+with new top level expressions:
+  __0 =aux SafeMod(x,SafeMod(y,z))
 
+with changed declarations:
+  + __0: int(0..2)
 --
 
 SafeMod(x,SafeMod(y,z)), 
    ~~> flatten_binop ([("Minion", 4400)]) 
 SafeMod(x,__1) 
+with new top level expressions:
+  __1 =aux SafeMod(y,z)
 
+with changed declarations:
+  + __1: int(0..3)
 --
 
 (SafeMod(y,z) = 0), 

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -217,7 +217,7 @@ fn rewrite_iteration<'a>(
     let rule_results = apply_all_rules(&expression, model, rules, stats);
     if let Some(result) = choose_rewrite(&rule_results, &expression) {
         // If a rule is applied, mark the expression as dirty
-        log_rule_application(&result, &expression);
+        log_rule_application(&result, &expression, model);
         return Some(result.reduction);
     }
 

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -78,7 +78,7 @@ pub fn rewrite_naive<'a>(
             [(result, _priority, expr, ctx), ..] => {
                 // Extract the single applicable rule and apply it
 
-                log_rule_application(result, expr);
+                log_rule_application(result, expr, &model);
 
                 // Replace expr with new_expression
                 model.set_constraints(ctx(result.reduction.new_expression.clone()));

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -1,6 +1,6 @@
 use super::{RewriteError, RuleSet};
 use crate::{
-    ast::{pretty::pretty_vec, Expression as Expr},
+    ast::Expression as Expr,
     bug,
     rule_engine::{
         get_rule_priorities,
@@ -75,16 +75,8 @@ pub fn rewrite_naive<'a>(
 
         match results.as_slice() {
             [] => break, // Exit if no rules are applicable.
-            [(result, priority, expr, ctx), ..] => {
+            [(result, _priority, expr, ctx), ..] => {
                 // Extract the single applicable rule and apply it
-                tracing::info!(
-                    new_top = %pretty_vec(&result.reduction.new_top),
-                    "Applying rule: {} (priority {}), to expression: {}, resulting in: {}",
-                    result.rule.name,
-                    priority,
-                    expr,
-                    result.reduction.new_expression
-                );
 
                 log_rule_application(result, expr);
 

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -21,7 +21,7 @@ pub fn log_rule_application(result: &RuleResult, initial_expression: &Expression
 
     info!(
         %new_top_string,
-        "Rule applicable: {} ({:?}), to expression: {}, resulting in: {}",
+        "Applying rule: {} ({:?}), to expression: {}, resulting in: {}",
         rule.name,
         rule.rule_sets,
         initial_expression,

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -1,8 +1,15 @@
 //! Common utilities and types for rewriters.
 
 use super::{resolve_rules::ResolveRulesError, Reduction, Rule};
-use crate::ast::{pretty::pretty_vec, Expression};
+use crate::{
+    ast::{
+        pretty::{pretty_variable_declaration, pretty_vec},
+        Expression,
+    },
+    Model,
+};
 
+use itertools::Itertools;
 use thiserror::Error;
 use tracing::{info, trace};
 
@@ -14,7 +21,11 @@ pub struct RuleResult<'a> {
 
 /// Logs, to the main log, and the human readable traces used by the integration tester, that the
 /// rule has been applied to the expression
-pub fn log_rule_application(result: &RuleResult, initial_expression: &Expression) {
+pub fn log_rule_application(
+    result: &RuleResult,
+    initial_expression: &Expression,
+    initial_model: &Model,
+) {
     let red = &result.reduction;
     let rule = result.rule;
     let new_top_string = pretty_vec(&red.new_top);
@@ -28,13 +39,73 @@ pub fn log_rule_application(result: &RuleResult, initial_expression: &Expression
         red.new_expression
     );
 
+    // empty if no top level constraints
+    let top_level_str = if !red.new_top.is_empty() {
+        let mut exprs: Vec<String> = vec![];
+
+        for expr in &red.new_top {
+            exprs.push(format!("  {}", expr));
+        }
+
+        let exprs = exprs.iter().join("\n");
+
+        format!("with new top level expressions:\n{}\n", exprs)
+    } else {
+        String::new()
+    };
+
+    let mut symbol_changes: Vec<String> = vec![];
+
+    // show symbol changes in diff-like format
+    //
+    // + some added decl
+    // - some removed decl
+    //
+    // [old] x: someDomain
+    // [new] x: someNewDomain
+
+    // TODO: when we support them, print removed declarations with a - in-front of them.
+
+    for var_name in red.added_symbols(&initial_model.variables) {
+        #[allow(clippy::unwrap_used)]
+        symbol_changes.push(format!(
+            "  + {}",
+            pretty_variable_declaration(&red.symbols, &var_name).unwrap()
+        ));
+    }
+
+    for (var_name, _, _) in red.changed_symbols(&initial_model.variables) {
+        #[allow(clippy::unwrap_used)]
+        symbol_changes.push(format!(
+            "  [old] {}",
+            pretty_variable_declaration(&initial_model.variables, &var_name).unwrap()
+        ));
+
+        #[allow(clippy::unwrap_used)]
+        symbol_changes.push(format!(
+            "  [new] {}",
+            pretty_variable_declaration(&red.symbols, &var_name).unwrap()
+        ));
+    }
+
+    let symbol_changes_str = if symbol_changes.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "with changed declarations:\n{}\n",
+            symbol_changes.join("\n")
+        )
+    };
+
     trace!(
         target: "rule_engine_human",
-        "{}, \n   ~~> {} ({:?}) \n{} \n\n--\n",
+        "{}, \n   ~~> {} ({:?}) \n{} \n{}\n{}--\n",
         initial_expression,
         rule.name,
         rule.rule_sets,
         red.new_expression,
+        top_level_str,
+        symbol_changes_str
     );
 }
 

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -9,7 +9,6 @@ use crate::{
     Model,
 };
 
-use clap::builder::Str;
 use itertools::Itertools;
 use thiserror::Error;
 use tracing::{info, trace};


### PR DESCRIPTION
- **fix(rewrite_naive): remove duplicate log print for rule application**
- **rewriter: log new top level vars to human rule trace**