### PR TITLE
Remove SumEq expression

### DIFF
--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
@@ -14,14 +14,20 @@ MinusEq(__0,y)
 --
 
 (x = Sum([__0, z])), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([__0, z], x) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([__0, z]) <= x), (Sum([__0, z]) >= x)]) 
 
 --
 
-SumEq([__0, z], x), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([__0, z], x), SumGeq([__0, z], x)]) 
+(Sum([__0, z]) <= x), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([__0, z], x) 
+
+--
+
+(Sum([__0, z]) >= x), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([__0, z], x) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
@@ -64,14 +64,20 @@ MinusEq(__1,z)
 --
 
 (x = Sum([__0, __1, -1, a, b])), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([__0, __1, -1, a, b], x) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([__0, __1, -1, a, b]) <= x), (Sum([__0, __1, -1, a, b]) >= x)]) 
 
 --
 
-SumEq([__0, __1, -1, a, b], x), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([__0, __1, -1, a, b], x), SumGeq([__0, __1, -1, a, b], x)]) 
+(Sum([__0, __1, -1, a, b]) <= x), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([__0, __1, -1, a, b], x) 
+
+--
+
+(Sum([__0, __1, -1, a, b]) >= x), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([__0, __1, -1, a, b], x) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input-expected-rule-trace-human.txt
@@ -5,14 +5,20 @@ Sum([a, b, c, d, e])
 --
 
 (Sum([a, b, c, d, e]) = 5), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([a, b, c, d, e], 5) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([a, b, c, d, e]) <= 5), (Sum([a, b, c, d, e]) >= 5)]) 
 
 --
 
-SumEq([a, b, c, d, e], 5), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([a, b, c, d, e], 5), SumGeq([a, b, c, d, e], 5)]) 
+(Sum([a, b, c, d, e]) <= 5), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([a, b, c, d, e], 5) 
+
+--
+
+(Sum([a, b, c, d, e]) >= 5), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([a, b, c, d, e], 5) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
@@ -44,14 +44,20 @@ DivEq(__0, a, 3)
 --
 
 __0 =aux Sum([x, y, z]), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([x, y, z], __0) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([x, y, z]) <= __0), (Sum([x, y, z]) >= __0)]) 
 
 --
 
-SumEq([x, y, z], __0), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([x, y, z], __0), SumGeq([x, y, z], __0)]) 
+(Sum([x, y, z]) <= __0), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([x, y, z], __0) 
+
+--
+
+(Sum([x, y, z]) >= __0), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([x, y, z], __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple/input-expected-rule-trace-human.txt
@@ -18,18 +18,6 @@ new constraints:
   __2 =aux Product([3, y])
 --
 
-__0 =aux Sum([__1, __2]), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([__1, __2], __0) 
-
---
-
-SumEq([__1, __2], __0), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([__1, __2], __0), SumGeq([__1, __2], __0)]) 
-
---
-
 __1 =aux Product([2, x]), 
    ~~> introduce_producteq ([("Minion", 4200)]) 
 FlatProductEq(x,2,__1) 
@@ -45,6 +33,24 @@ FlatProductEq(y,3,__2)
 (__0 < 12), 
    ~~> lt_to_ineq ([("Minion", 4100)]) 
 Ineq(__0, 12, -1) 
+
+--
+
+__0 =aux Sum([__1, __2]), 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([__1, __2]) <= __0), (Sum([__1, __2]) >= __0)]) 
+
+--
+
+(Sum([__1, __2]) <= __0), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([__1, __2], __0) 
+
+--
+
+(Sum([__1, __2]) >= __0), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([__1, __2], __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/02-needs-normalising/input-expected-rule-trace-human.txt
@@ -66,18 +66,6 @@ new constraints:
   __5 =aux Product([-5, y])
 --
 
-__0 =aux Sum([__1, __2, __3, __4, __5]), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([__1, __2, __3, __4, __5], __0) 
-
---
-
-SumEq([__1, __2, __3, __4, __5], __0), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([__1, __2, __3, __4, __5], __0), SumGeq([__1, __2, __3, __4, __5], __0)]) 
-
---
-
 __1 =aux Product([5, x]), 
    ~~> introduce_producteq ([("Minion", 4200)]) 
 FlatProductEq(x,5,__1) 
@@ -120,6 +108,24 @@ FlatProductEq(x,3,__6)
 (__0 < 10), 
    ~~> lt_to_ineq ([("Minion", 4100)]) 
 Ineq(__0, 10, -1) 
+
+--
+
+__0 =aux Sum([__1, __2, __3, __4, __5]), 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([__1, __2, __3, __4, __5]) <= __0), (Sum([__1, __2, __3, __4, __5]) >= __0)]) 
+
+--
+
+(Sum([__1, __2, __3, __4, __5]) <= __0), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([__1, __2, __3, __4, __5], __0) 
+
+--
+
+(Sum([__1, __2, __3, __4, __5]) >= __0), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([__1, __2, __3, __4, __5], __0) 
 
 --
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
@@ -11,20 +11,20 @@ Sum([x, y, 35])
 --
 
 (Sum([x, y, 35]) = 100), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([x, y, 35], 100) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([x, y, 35]) <= 100), (Sum([x, y, 35]) >= 100)]) 
 
 --
 
-SumEq([x, y, 35], 100), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-SumEq([x, y], 65) 
+(Sum([x, y, 35]) <= 100), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([x, y, 35], 100) 
 
 --
 
-SumEq([x, y], 65), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([x, y], 65), SumGeq([x, y], 65)]) 
+(Sum([x, y, 35]) >= 100), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([x, y, 35], 100) 
 
 --
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
@@ -23,11 +23,16 @@
                   "Reference": {
                     "UserName": "y"
                   }
+                },
+                {
+                  "Literal": {
+                    "Int": 35
+                  }
                 }
               ],
               {
                 "Literal": {
-                  "Int": 65
+                  "Int": 100
                 }
               }
             ]
@@ -48,11 +53,16 @@
                   "Reference": {
                     "UserName": "y"
                   }
+                },
+                {
+                  "Literal": {
+                    "Int": 35
+                  }
                 }
               ],
               {
                 "Literal": {
-                  "Int": 65
+                  "Int": 100
                 }
               }
             ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
@@ -11,20 +11,20 @@ Sum([x, y, 35])
 --
 
 (Sum([x, y, 35]) = 100), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([x, y, 35], 100) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([x, y, 35]) <= 100), (Sum([x, y, 35]) >= 100)]) 
 
 --
 
-SumEq([x, y, 35], 100), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-SumEq([x, y], 65) 
+(Sum([x, y, 35]) <= 100), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([x, y, 35], 100) 
 
 --
 
-SumEq([x, y], 65), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([x, y], 65), SumGeq([x, y], 65)]) 
+(Sum([x, y, 35]) >= 100), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([x, y, 35], 100) 
 
 --
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
@@ -23,11 +23,16 @@
                   "Reference": {
                     "UserName": "y"
                   }
+                },
+                {
+                  "Literal": {
+                    "Int": 35
+                  }
                 }
               ],
               {
                 "Literal": {
-                  "Int": 65
+                  "Int": 100
                 }
               }
             ]
@@ -48,11 +53,16 @@
                   "Reference": {
                     "UserName": "y"
                   }
+                },
+                {
+                  "Literal": {
+                    "Int": 35
+                  }
                 }
               ],
               {
                 "Literal": {
-                  "Int": 65
+                  "Int": 100
                 }
               }
             ]

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input-expected-rule-trace-human.txt
@@ -5,14 +5,20 @@ Sum([a, b, c])
 --
 
 (Sum([a, b, c]) = 4), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([a, b, c], 4) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([a, b, c]) <= 4), (Sum([a, b, c]) >= 4)]) 
 
 --
 
-SumEq([a, b, c], 4), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]) 
+(Sum([a, b, c]) <= 4), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([a, b, c], 4) 
+
+--
+
+(Sum([a, b, c]) >= 4), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([a, b, c], 4) 
 
 --
 

--- a/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
@@ -20,21 +20,27 @@ new constraints:
   Or([(__1 = a), (__1 = b)])
 --
 
-(x = Sum([__1, 1])), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([__1, 1], x) 
-
---
-
-SumEq([__1, 1], x), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([__1, 1], x), SumGeq([__1, 1], x)]) 
-
---
-
 (__0 >= 2), 
    ~~> geq_to_ineq ([("Minion", 4100)]) 
 Ineq(2, __0, 0) 
+
+--
+
+(x = Sum([__1, 1])), 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([__1, 1]) <= x), (Sum([__1, 1]) >= x)]) 
+
+--
+
+(Sum([__1, 1]) <= x), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([__1, 1], x) 
+
+--
+
+(Sum([__1, 1]) >= x), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([__1, 1], x) 
 
 --
 

--- a/conjure_oxide/tests/integration/xyz/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/xyz/input-expected-rule-trace-human.txt
@@ -5,14 +5,20 @@ Sum([a, b, c])
 --
 
 (Sum([a, b, c]) = 4), 
-   ~~> sum_eq_to_sumeq ([("Minion", 4200)]) 
-SumEq([a, b, c], 4) 
+   ~~> sum_eq_to_inequalities ([("Minion", 4100)]) 
+And([(Sum([a, b, c]) <= 4), (Sum([a, b, c]) >= 4)]) 
 
 --
 
-SumEq([a, b, c], 4), 
-   ~~> sumeq_to_minion ([("Minion", 4400)]) 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]) 
+(Sum([a, b, c]) <= 4), 
+   ~~> introduce_sumleq ([("Minion", 4400)]) 
+SumLeq([a, b, c], 4) 
+
+--
+
+(Sum([a, b, c]) >= 4), 
+   ~~> introduce_sumgeq ([("Minion", 4400)]) 
+SumGeq([a, b, c], 4) 
 
 --
 

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -101,15 +101,6 @@ pub enum Expression {
     #[compatible(JsonInput)]
     Minus(Metadata, Box<Expression>, Box<Expression>),
 
-    /* Flattened SumEq.
-     *
-     * Note: this is an intermediary step that's used in the process of converting from conjure model to minion.
-     * This is NOT a valid expression in either Essence or minion.
-     *
-     * ToDo: This is a stop gap solution. Eventually it may be better to have multiple constraints instead? (gs248)
-     */
-    SumEq(Metadata, Vec<Expression>, Box<Expression>),
-
     /// Ensures that sum(vec) >= x.
     ///
     /// Low-level Minion constraint.
@@ -323,7 +314,6 @@ impl Expression {
             Expression::Leq(_, _, _) => Some(Domain::BoolDomain),
             Expression::Gt(_, _, _) => Some(Domain::BoolDomain),
             Expression::Lt(_, _, _) => Some(Domain::BoolDomain),
-            Expression::SumEq(_, _, _) => Some(Domain::BoolDomain),
             Expression::FlatSumGeq(_, _, _) => Some(Domain::BoolDomain),
             Expression::FlatSumLeq(_, _, _) => Some(Domain::BoolDomain),
             Expression::MinionDivEqUndefZero(_, _, _, _) => Some(Domain::BoolDomain),
@@ -413,7 +403,6 @@ impl Expression {
             Expression::Lt(_, _, _) => Some(ReturnType::Bool),
             Expression::SafeDiv(_, _, _) => Some(ReturnType::Int),
             Expression::UnsafeDiv(_, _, _) => Some(ReturnType::Int),
-            Expression::SumEq(_, _, _) => Some(ReturnType::Bool),
             Expression::FlatSumGeq(_, _, _) => Some(ReturnType::Bool),
             Expression::FlatSumLeq(_, _, _) => Some(ReturnType::Bool),
             Expression::MinionDivEqUndefZero(_, _, _, _) => Some(ReturnType::Bool),
@@ -516,14 +505,6 @@ impl Display for Expression {
             }
             Expression::Lt(_, box1, box2) => {
                 write!(f, "({} < {})", box1.clone(), box2.clone())
-            }
-            Expression::SumEq(_, expressions, expr_box) => {
-                write!(
-                    f,
-                    "SumEq({}, {})",
-                    pretty_vec(expressions),
-                    expr_box.clone()
-                )
             }
             Expression::FlatSumGeq(_, box1, box2) => {
                 write!(f, "SumGeq({}, {})", pretty_vec(box1), box2.clone())

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -114,9 +114,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(b == result))
         }
-        Expr::SumEq(_, exprs, a) => {
-            flat_op::<i32, bool>(|e, a| e.iter().sum::<i32>() == a, exprs, a).map(Lit::Bool)
-        }
         Expr::MinionModuloEqUndefZero(_, a, b, c) => {
             // From Savile Row. Same semantics as division.
             //
@@ -176,6 +173,7 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             let b: i32 = b.try_into().ok()?;
             let c: i32 = c.try_into().ok()?;
             Some(Lit::Bool(a * b == c))
+        }
     }
 }
 
@@ -223,6 +221,7 @@ where
     f(a)
 }
 
+#[allow(dead_code)]
 fn flat_op<T, A>(f: fn(Vec<T>, T) -> A, a: &[Expr], b: &Expr) -> Option<A>
 where
     T: TryFrom<Lit>,

--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -199,41 +199,6 @@ fn partial_evaluator(expr: &Expr, _: &Model) -> ApplicationResult {
         Lt(_, _, _) => Err(RuleNotApplicable),
         SafeDiv(_, _, _) => Err(RuleNotApplicable),
         UnsafeDiv(_, _, _) => Err(RuleNotApplicable),
-        SumEq(m, vec, eq) => {
-            let mut acc = 0;
-            let mut new_vec: Vec<Expr> = Vec::new();
-            let mut n_consts = 0;
-            for expr in vec {
-                if let Expr::Atomic(_, Atom::Literal(Int(x))) = expr {
-                    n_consts += 1;
-                    acc += x;
-                } else {
-                    new_vec.push(expr);
-                }
-            }
-
-            if let Expr::Atomic(_, Atom::Literal(Int(x))) = *eq {
-                if acc != 0 {
-                    // when rhs is a constant, move lhs constants to rhs
-                    return Ok(Reduction::pure(SumEq(
-                        m,
-                        new_vec,
-                        Box::new(Expr::Atomic(
-                            Default::default(),
-                            Atom::Literal(Int(x - acc)),
-                        )),
-                    )));
-                }
-            } else if acc != 0 {
-                new_vec.push(Expr::Atomic(Default::default(), Atom::Literal(Int(acc))));
-            }
-
-            if n_consts <= 1 {
-                Err(RuleNotApplicable)
-            } else {
-                Ok(Reduction::pure(SumEq(m, new_vec, eq)))
-            }
-        }
         AllDiff(m, vec) => {
             let mut consts: HashSet<i32> = HashSet::new();
 


### PR DESCRIPTION
**Closes: #515**

SumEq was used as an intermediate representation when rewriting `sum(...) = e2` into flat sumgeq / sumleq constraints.

Instead, decompose `sum(...) = e2` into `sum(...) <= e2 /\ sum(...) >= e2` and let the normal Minion process for flattening these convert these to Minion.

---

<!-- start git-machete generated -->

# Based on PR #570

## Chain of upstream PRs as of 2025-01-08

* PR #570:
  `main` ← `nik/pr/add-mul/minion-conversion`

  * **PR #571 (THIS ONE)**:
    `nik/pr/add-mul/minion-conversion` ← `nik/pr/add-mul/remove-sum-eq`

<!-- end git-machete generated -->