### PR TITLE
CI: add debugging info for macos-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,12 @@ jobs:
           echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
           echo RUSTDOCFLAGS=${RUSTDOCFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
         if: matrix.rust_release == 'nightly'
-        
+
+      - name: Print mac ulimit to debug issue 516
+        run: ulimit -a
+        if: matrix.os == 'macos-latest'
+
+
       - name: Print files and modification dates before test run to debug issue 516
         run: |
          brew install tree

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,13 @@ jobs:
           echo RUSTFLAGS=${RUSTFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
           echo RUSTDOCFLAGS=${RUSTDOCFLAGS}\ -Zlinker-features=-lld >> $GITHUB_ENV
         if: matrix.rust_release == 'nightly'
-
+        
+      - name: Print files and modification dates before test run to debug issue 516
+        run: |
+         brew install tree
+         tree -D .
+        if: matrix.os == 'macos-latest'
+        
       - run: rustup update ${{ matrix.rust_release }} && rustup default ${{ matrix.rust_release }}
 
       - run: cargo build -vv --workspace
@@ -73,7 +79,11 @@ jobs:
           version: ${{ matrix.conjure_version }}
 
       - run: cargo test --workspace
-
+      
+      - name: Print files and modification dates after test run to debug issue 516
+        run: tree -D .
+        if: matrix.os == 'macos-latest'
+       
   examples:
     name: "Examples"
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       
       - name: Print files and modification dates after test run to debug issue 516
         run: tree -D .
-        if: matrix.os == 'macos-latest'
+        if: (success() || failure()) && matrix.os == 'macos-latest'
        
   examples:
     name: "Examples"


### PR DESCRIPTION
Print file info and modification dates to help debug #516 when it occurs again.

My best guess is that theres some junk files / old files in there that shouldn't be, this should give us info of what is on the action runner and the impact of running the tests.