### PR TITLE
fix(tester): make human rule trace writer blocking

### DIFF
--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -99,7 +99,7 @@ fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(
     // run tests in sequence not parallel when verbose logging, to ensure the logs are ordered
     // correctly
 
-    let (subscriber, _guard) = create_scoped_subscriber(path, essence_base);
+    let subscriber = create_scoped_subscriber(path, essence_base);
 
     // set the subscriber as default
     tracing::subscriber::with_default(subscriber, || {
@@ -376,12 +376,9 @@ fn assert_constants_leq_one(parent_expr: &Expression, exprs: &[Expression]) {
 pub fn create_scoped_subscriber(
     path: &str,
     test_name: &str,
-) -> (
-    impl tracing::Subscriber + Send + Sync,
-    Vec<tracing_appender::non_blocking::WorkerGuard>,
-) {
+) -> (impl tracing::Subscriber + Send + Sync) {
     //let (target1_layer, guard1) = create_file_layer_json(path, test_name);
-    let (target2_layer, guard2) = create_file_layer_human(path, test_name);
+    let target2_layer = create_file_layer_human(path, test_name);
     let layered = target2_layer;
 
     let subscriber = Arc::new(tracing_subscriber::registry().with(layered))
@@ -389,7 +386,7 @@ pub fn create_scoped_subscriber(
     // setting this subscriber as the default
     let _default = tracing::subscriber::set_default(subscriber.clone());
 
-    (subscriber, vec![guard2])
+    subscriber
 }
 
 fn create_file_layer_json(
@@ -412,23 +409,19 @@ fn create_file_layer_json(
     (layer1, guard1)
 }
 
-fn create_file_layer_human(
-    path: &str,
-    test_name: &str,
-) -> (impl Layer<Registry> + Send + Sync, WorkerGuard) {
+fn create_file_layer_human(path: &str, test_name: &str) -> (impl Layer<Registry> + Send + Sync) {
     let file = File::create(format!("{path}/{test_name}-generated-rule-trace-human.txt"))
         .expect("Unable to create log file");
-    let (non_blocking, guard2) = tracing_appender::non_blocking(file);
 
     let layer2 = fmt::layer()
-        .with_writer(non_blocking)
+        .with_writer(file)
         .with_level(false)
         .without_time()
         .with_target(false)
         .with_filter(EnvFilter::new("rule_engine_human=trace"))
         .with_filter(FilterFn::new(|meta| meta.target() == "rule_engine_human"));
 
-    (layer2, guard2)
+    layer2
 }
 
 #[test]

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::env;
 use std::process::exit;
 
 use conjure_core::rules::eval_constant;
@@ -9,7 +8,6 @@ use conjure_oxide::{
     get_rule_by_name, get_rules,
     rule_engine::{resolve_rule_sets, rewrite_model},
     solver::{adaptors, Solver},
-    utils::testing::save_stats_json,
     Metadata, Model, Rule,
 };
 use uniplate::{Biplate, Uniplate};


### PR DESCRIPTION
Make human rule trace use a blocking writer.

I hope that this will fix our issues with macos CI in #516.

The failure is that, in some tests, the generated rule trace has some
lines missing from the end of the file compared to the expected rule
trace. Because of this, I suspect that the generated file is being read
before it has fully been written to. If this is the issue, blocking on
write would fix this.