### PR TITLE
Add CLI flags: `--[no]-check-equally-applicable-rules`, `--no-run-solver`

### DIFF
--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -70,20 +70,37 @@ struct Cli {
 
     #[arg(
         long,
-        short = 'o',
-        help = "Save solutions to a JSON file (prints to stdin by default)"
-    )]
-    #[arg(
-        long,
         help = "use the, in development, dirty-clean optimising rewriter",
         default_value_t = false
     )]
     use_optimising_rewriter: bool,
 
+    #[arg(
+        long,
+        short = 'o',
+        help = "Save solutions to a JSON file (prints to stdout by default)"
+    )]
     output: Option<PathBuf>,
 
     #[arg(long, short = 'v', help = "Log verbosely to sterr")]
     verbose: bool,
+
+    // --no-x flag disables --x flag : https://jwodder.github.io/kbits/posts/clap-bool-negate/
+    /// Check for multiple equally applicable rules, exiting if any are found.
+    ///
+    /// Only compatible with the default rewriter.
+    #[arg(
+        long,
+        overrides_with = "_no_check_equally_applicable_rules",
+        default_value_t = false
+    )]
+    check_equally_applicable_rules: bool,
+
+    /// Do not check for multiple equally applicable rules [default].
+    ///
+    /// Only compatible with the default rewriter.
+    #[arg(long)]
+    _no_check_equally_applicable_rules: bool,
 }
 
 #[allow(clippy::unwrap_used)]
@@ -266,7 +283,7 @@ pub fn main() -> AnyhowResult<()> {
         model = rewrite_model(&model, &rule_sets)?;
     } else {
         tracing::info!("Rewriting model...");
-        model = rewrite_naive(&model, &rule_sets, false)?;
+        model = rewrite_naive(&model, &rule_sets, cli.check_equally_applicable_rules)?;
     }
 
     tracing::info!("Rewritten model: \n{}\n", model);


### PR DESCRIPTION
**Related issue: #552**

Add the `--[no]-check-equally-applicable-rules` and `--no-run-solver` command
line flags to enable/disable the rewriter's multiple equally applicable rules
assertion, and disable running the solver (e.g. for benchmarking)
# Changelog

**cli: add --check-equally-applicable-rules flag**

Add --check-equally-applicable-rules and
--no-check-equally-applicable-rules flags to enable / disable the naive
rewriters multiple equally applicable rules assertion via the
command line.

As before, this assertion is disabled by default.


---

**cli: add --no-run-solver flag**

Add --no-run-solver flag to disable the running of the solver. This
prints the rewritten model as output.

The motivation for this flag is comparing execution time against Savile
Row. In the future we may benchmark more rigorously with the reported
rewrite times output by both. However, this flag would still be useful for
doing ad-hoc performance comparisons during development (e.g. using `time` or
`hyperfine`).

It could also be useful for debugging the rewriting of larger models.

The model output is not necessarily valid Essence that we can parse
(as it can contain Minion constraints), so might not be too useful
outside of these use-cases.

