### PR TITLE
perf: only log rule not applicable in debug mode

### DIFF
--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -57,6 +57,8 @@ pub fn rewrite_naive<'a>(
                             ));
                         }
                         Err(_) => {
+                            // when called a lot, this becomes very expensive!
+                            #[cfg(debug_assertions)]
                             tracing::trace!(
                                 "Rule attempted but not applied: {} (priority {}), to expression: {}",
                                 rule.name,


### PR DESCRIPTION
Only run the "rule not applicable" trace when Conjure Oxide is built in debug mode. 

For the test file `optimisations/implies-tautologies-cse/input.eprime`, this reduces execution time from 5.42s to 1.281s, a 75% improvement.

As this is only printed at the trace debug level, it is unlikely to be needed in a release build anyways.

DETAILS

Measurements were taken using `hyperfine`, building the project in release mode. Conjure oxide was ran using the `--no-run-solver` flag to mimic default Savile Row behaviour.

Profiling (using `samply`) revealed that 75% of our execution time was spent in this `trace`, even if we never print it.

For comparison, `savilerow -O0` takes 0.136s +- 0.004. Note that part of this may be due to us having no implication simplification rules, meaning that we would have to do more rewrites than Savile Row.

Another expensive function is `Uniplate::contexts`. A rewrite for this is in progress.
