### PR TITLE
Treemorph dirty clean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
 name = "tree-morph"
 version = "0.1.0"
 dependencies = [
+ "im",
  "multipeek",
  "rand",
  "uniplate",

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 multipeek = "0.1.2"
 rand = "0.8.5"
-uniplate = { version = "0.1.0" }
+uniplate = "0.1.5"
 
 
 [lints]

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -9,6 +9,8 @@ multipeek = "0.1.2"
 rand = "0.8.5"
 uniplate = "0.1.5"
 
-
 [lints]
 workspace = true
+
+[features]
+examples = []

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+im = "15.1.0"
 multipeek = "0.1.2"
 rand = "0.8.5"
 uniplate = "0.1.5"

--- a/crates/tree_morph/src/examples.rs
+++ b/crates/tree_morph/src/examples.rs
@@ -1,0 +1,13 @@
+use uniplate::derive::Uniplate;
+
+#[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
+pub enum Expr {
+    Nothing,
+    Add(Box<Expr>, Box<Expr>),
+    Sub(Box<Expr>, Box<Expr>),
+    Mul(Box<Expr>, Box<Expr>),
+    Div(Box<Expr>, Box<Expr>),
+    Val(i32),
+    Var(String),
+    Neg(Box<Expr>),
+}

--- a/crates/tree_morph/src/helpers.rs
+++ b/crates/tree_morph/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, io::Write, sync::Arc};
 
-use crate::{Reduction, Rule};
+use crate::prelude::*;
 use multipeek::multipeek;
 use uniplate::Uniplate;
 
@@ -19,6 +19,14 @@ where
         return rs.next().map(|(_, r)| r);
     }
     select(t, &mut rs)
+}
+
+/// Returns the number of nodes in the given tree.
+pub(crate) fn tree_size<T>(tree: T) -> usize
+where
+    T: Uniplate,
+{
+    tree.cata(Arc::new(|_, sizes| sizes.iter().sum::<usize>() + 1))
 }
 
 /// Returns the first available `Reduction` if there is one, otherwise returns `None`.

--- a/crates/tree_morph/src/helpers.rs
+++ b/crates/tree_morph/src/helpers.rs
@@ -22,7 +22,7 @@ where
 }
 
 /// Returns the number of nodes in the given tree.
-pub(crate) fn tree_size<T>(tree: T) -> usize
+pub(crate) fn tree_size<T>(tree: &T) -> usize
 where
     T: Uniplate,
 {

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -14,7 +14,7 @@
 //# TODO (Felix): choose a more concise example
 //!
 //! ```rust
-//! use tree_morph::*;
+//! use tree_morph::prelude::*;
 //! use uniplate::derive::Uniplate;
 //!
 //! #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
@@ -133,7 +133,7 @@
 //!     // Ordering is important here: we evaluate first (1), then reduce (2..6), then change form (7)
 //!     let rules = [Eval, AddZero, AddSame, MulOne, MulZero, DoubleNeg, Associativity];
 //!
-//!     let (expr, _) = reduce_with_rules(&rules, helpers::select_first, expr, ());
+//!     let (expr, _) = reduce_with_rules(&rules, select_first, expr, ());
 //!     assert_eq!(expr, Mul(bx(Val(4)), bx(Var("x".to_string()))));
 //! }
 //!

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -154,6 +154,7 @@ pub mod helpers;
 mod reduce;
 mod reduction;
 mod rule;
+mod skel;
 
 pub use commands::Commands;
 pub use reduce::{reduce, reduce_with_rule_groups, reduce_with_rules};

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -156,6 +156,6 @@ mod reduction;
 mod rule;
 
 pub use commands::Commands;
-pub use reduce::{reduce, reduce_with_rules};
+pub use reduce::{reduce, reduce_with_rule_groups, reduce_with_rules};
 pub use reduction::Reduction;
 pub use rule::Rule;

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -149,14 +149,22 @@
 //! These functions can then be defined elsewhere for better organization.
 //!
 
-mod commands;
+pub mod commands;
 pub mod helpers;
-mod reduce;
-mod reduction;
-mod rule;
-mod skel;
+pub mod reduce;
+pub mod reduction;
+pub mod rule;
+pub mod zipper;
 
-pub use commands::Commands;
-pub use reduce::{reduce, reduce_with_rule_groups, reduce_with_rules};
-pub use reduction::Reduction;
-pub use rule::Rule;
+pub mod prelude {
+    use super::*;
+
+    pub use commands::Commands;
+    pub use helpers::select_first;
+    pub use reduce::{reduce, reduce_with_rule_groups, reduce_with_rules};
+    pub use reduction::Reduction;
+    pub use rule::Rule;
+}
+
+#[cfg(any(test, feature = "examples"))]
+pub mod examples;

--- a/crates/tree_morph/src/reduce.rs
+++ b/crates/tree_morph/src/reduce.rs
@@ -1,4 +1,4 @@
-use crate::{helpers::one_or_select, Commands, Reduction, Rule};
+use crate::{helpers::one_or_select, prelude::*};
 use uniplate::Uniplate;
 
 // TODO: (Felix) dirty/clean optimisation: replace tree with a custom tree structure,

--- a/crates/tree_morph/src/reduction.rs
+++ b/crates/tree_morph/src/reduction.rs
@@ -1,4 +1,4 @@
-use crate::Commands;
+use crate::commands::Commands;
 use uniplate::Uniplate;
 
 pub struct Reduction<T, M>

--- a/crates/tree_morph/src/rule.rs
+++ b/crates/tree_morph/src/rule.rs
@@ -1,4 +1,4 @@
-use crate::Commands;
+use crate::commands::Commands;
 use uniplate::Uniplate;
 
 pub trait Rule<T, M>

--- a/crates/tree_morph/src/skel.rs
+++ b/crates/tree_morph/src/skel.rs
@@ -1,0 +1,121 @@
+use std::rc::Rc;
+
+use uniplate::{Tree, Uniplate};
+
+/// Additional metadata associated with each tree node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Meta {
+    /// Transforms at and after this index should be applied.
+    /// Those before it have already been tried with no change.
+    clean_before: usize,
+}
+
+impl Meta {
+    fn new() -> Self {
+        Self { clean_before: 0 }
+    }
+}
+
+/// Wraps around a tree and associates additional metadata with each node for rewriter optimisations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Skel<T>
+where
+    T: Uniplate,
+{
+    pub node: Rc<T>,
+    pub meta: Meta,
+    pub children: Vec<Skel<T>>,
+}
+
+impl<T> Skel<T>
+where
+    T: Uniplate,
+{
+    /// Construct a new `Skel` wrapper around an entire tree.
+    pub fn new(node: T) -> Self {
+        Self::_new(Rc::new(node))
+    }
+
+    fn _new(node: Rc<T>) -> Self {
+        Self {
+            node: Rc::clone(&node),
+            meta: Meta::new(),
+            children: node
+                .children()
+                .into_iter()
+                .map(|child| Skel::_new(Rc::new(child)))
+                .collect(),
+        }
+    }
+}
+
+impl<T> Uniplate for Skel<T>
+where
+    T: Uniplate,
+{
+    // Implemented here as Uniplate doesn't yet support this struct
+    fn uniplate(&self) -> (Tree<Self>, Box<dyn Fn(Tree<Self>) -> Self>) {
+        let node = Rc::clone(&self.node);
+        let meta = self.meta.clone();
+
+        let tree = Tree::Many(im::Vector::from_iter(
+            self.children.clone().into_iter().map(Tree::One),
+        ));
+
+        let ctx = Box::new(move |tr| {
+            let Tree::Many(trs) = tr else { panic!() };
+            let children = trs
+                .into_iter()
+                .map(|ch| {
+                    let Tree::One(sk) = ch else { panic!() };
+                    sk
+                })
+                .collect();
+            Skel {
+                node: node.clone(),
+                meta: meta.clone(),
+                children,
+            }
+        });
+
+        (tree, ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    use im::Vector;
+    use uniplate::derive::Uniplate;
+    use uniplate::Uniplate;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
+    enum Expr {
+        A,
+        B,
+        P(Box<Expr>, Box<Expr>),
+    }
+
+    #[test]
+    fn test_skel_reconstruct() {
+        let tree = Expr::P(
+            Box::new(Expr::P(
+                Box::new(Expr::P(Box::new(Expr::A), Box::new(Expr::A))),
+                Box::new(Expr::B),
+            )),
+            Box::new(Expr::B),
+        );
+
+        let skel = Skel::new(tree.clone());
+        let reconstructed = skel.cata(Arc::new(|sk: Skel<Expr>, chs| {
+            sk.node.with_children(Vector::from(chs))
+        }));
+
+        // println!("Tree: {:?}", tree);
+        // println!("Skel: {:?}", skel);
+        assert_eq!(tree, reconstructed);
+    }
+}

--- a/crates/tree_morph/src/zipper.rs
+++ b/crates/tree_morph/src/zipper.rs
@@ -1,0 +1,191 @@
+// Copied and adapted from https://github.com/conjure-cp/uniplate/blob/nik/zippers/uniplate/src/zipper.rs
+
+use std::sync::Arc;
+
+use im::Vector;
+use uniplate::{Tree, Uniplate};
+
+use crate::helpers::tree_size;
+
+/// Additional metadata associated with each tree node.
+///
+/// This lets us cache info about nodes of user-defined types,
+/// and is used for engine optimisations.
+#[derive(Debug, Clone)]
+pub struct Meta {
+    /// Transforms at and after this index should be applied.
+    /// Those before it have already been tried with no change.
+    clean_before: usize,
+
+    /// The number of nodes in the associated subtree, including the root.
+    subtree_size: usize,
+}
+
+impl Meta {
+    /// Returns whether the associated node is clean up to the given transform index.
+    ///
+    /// A node is clean up to a given index iff all transforms before the index have
+    /// been applied to all nodes in the subtree with no changes.
+    pub fn is_clean(&self, index: usize) -> bool {
+        index < self.clean_before
+    }
+}
+
+/// A Zipper over `Uniplate` types, holding additional metadata information for each node.
+#[derive(Clone)]
+pub struct Zipper<T>
+where
+    T: Uniplate,
+{
+    /// The current node.
+    focus: T,
+
+    /// The path back to the top, immediate parent last.
+    ///
+    /// If empty, the focus is the top level node.
+    path: Vec<PathSegment<T>>,
+
+    /// A list of `Meta` objects in preorder traversal order.
+    meta_list: Vec<Meta>,
+
+    /// Points to the value in `meta_list` associated with the current focus.
+    meta_index: usize,
+}
+
+#[derive(Clone)]
+struct PathSegment<T>
+where
+    T: Uniplate,
+{
+    /// Left siblings of the node, eldest last.
+    left: Vector<T>,
+
+    /// Right siblings of the node, eldest first.
+    right: Vector<T>,
+
+    /// Function to convert this layer back into a tree given a full list of children
+    rebuild_tree: Arc<dyn Fn(Vector<T>) -> Tree<T>>,
+
+    // Function to create the parent node, given its children as a tree
+    ctx: Arc<dyn Fn(Tree<T>) -> T>,
+}
+
+impl<T> Zipper<T>
+where
+    T: Uniplate,
+{
+    /// Creates a new [`Zipper`] with `root` as the root node.
+    ///
+    /// The focus is initially the root node.
+    pub fn new(root: T) -> Self {
+        // TODO: This could be done slightly better, without re-calculating the size of every subtree
+        // Maybe transform into a tree of the same shape holding metas at each node and flatten?
+        let mut meta_list = vec![];
+        for node in root.universe() {
+            meta_list.push(Meta {
+                clean_before: 0,
+                subtree_size: tree_size(node),
+            })
+        }
+
+        Zipper {
+            focus: root,
+            path: Vec::new(),
+            meta_list,
+            meta_index: 0,
+        }
+    }
+
+    /// Borrows the current focus of the [Zipper].
+    pub fn focus(&self) -> &T {
+        &self.focus
+    }
+
+    /// Mutably borrows the current focus of the [Zipper].
+    pub fn focus_mut(&mut self) -> &T {
+        &mut self.focus
+    }
+
+    /// Borrows the `Meta` object for the current focus.
+    pub fn meta(&self) -> &Meta {
+        &self
+            .meta_list
+            .get(self.meta_index)
+            .expect("Meta index out of bounds")
+    }
+
+    /// Mutably borrows the `Meta` object for the current focus.
+    pub fn meta_mut(&mut self) -> &Meta {
+        &mut self
+            .meta_list
+            .get(self.meta_index)
+            .expect("Meta index out of bounds")
+    }
+
+    /// Replaces the focus of the [Zipper], returning the old focus.
+    pub fn replace_focus(&mut self, new_focus: T) -> T {
+        // TODO: splice meta_list
+        std::mem::replace(&mut self.focus, new_focus)
+    }
+
+    /// Rebuilds the root node from the Zipper.
+    pub fn rebuild_root(mut self) -> T {
+        while self.go_up().is_some() {}
+        self.focus
+    }
+
+    /// Returns the depth of the focus from the root.
+    pub fn depth(&self) -> usize {
+        self.path.len()
+    }
+
+    /// Sets the focus to the parent of the focus (if it exists).
+    pub fn go_up(&mut self) -> Option<()> {
+        let mut path_seg = self.path.pop()?;
+
+        // TODO: get rid of the clone if possible
+        path_seg.left.push_back(self.focus.clone());
+        path_seg.left.append(path_seg.right);
+
+        let tree = (path_seg.rebuild_tree)(path_seg.left);
+
+        self.focus = (path_seg.ctx)(tree);
+
+        Some(())
+    }
+
+    /// Sets the focus to the left-most child of the focus (if it exists).
+    pub fn go_down(&mut self) -> Option<()> {
+        let (children, ctx) = self.focus.uniplate();
+        let (mut siblings, rebuild_tree) = children.list();
+        let new_focus = siblings.pop_front()?;
+        let new_segment = PathSegment {
+            left: Vector::new(),
+            right: siblings,
+            rebuild_tree: rebuild_tree.into(),
+            ctx: ctx.into(),
+        };
+
+        self.path.push(new_segment);
+        self.focus = new_focus;
+        Some(())
+    }
+
+    /// Sets the focus to the left sibling of the focus (if it exists).
+    pub fn go_left(&mut self) -> Option<()> {
+        let path_segment = self.path.last_mut()?;
+        let new_focus = path_segment.left.pop_front()?;
+        let old_focus = std::mem::replace(&mut self.focus, new_focus);
+        path_segment.right.push_back(old_focus);
+        Some(())
+    }
+
+    /// Sets the focus to the right sibling of the focus (if it exists).
+    pub fn go_right(&mut self) -> Option<()> {
+        let path_segment = self.path.last_mut()?;
+        let new_focus = path_segment.right.pop_front()?;
+        let old_focus = std::mem::replace(&mut self.focus, new_focus);
+        path_segment.left.push_back(old_focus);
+        Some(())
+    }
+}

--- a/crates/tree_morph/tests/add_mul.rs
+++ b/crates/tree_morph/tests/add_mul.rs
@@ -1,6 +1,6 @@
 //! These tests use a simple constant expression tree to demonstrate the use of the `gen_reduce` crate.
 
-use tree_morph::{helpers::select_first, *};
+use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]

--- a/crates/tree_morph/tests/depend_meta.rs
+++ b/crates/tree_morph/tests/depend_meta.rs
@@ -3,7 +3,7 @@
 
 // TODO (Felix) how might we fix this, in the engine or by blocking this use case?
 
-use tree_morph::*;
+use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]

--- a/crates/tree_morph/tests/depend_meta.rs
+++ b/crates/tree_morph/tests/depend_meta.rs
@@ -1,6 +1,8 @@
 //! Here we test an interesting side-effect case, with rules which return a reduction based on a metadata field.
 //! These rules will not be run a second time if no other rule applies to the same node, which might be unexpected.
 
+// TODO (Felix) how might we fix this, in the engine or by blocking this use case?
+
 use tree_morph::*;
 use uniplate::derive::Uniplate;
 
@@ -22,10 +24,11 @@ fn transform(cmd: &mut Commands<Expr, bool>, expr: &Expr, meta: &bool) -> Option
     None
 }
 
-// #[test] // TODO (Felix) how might we fix this, in the engine or by blocking this use case?
+#[test]
+#[ignore = "this will fail until we fix it"]
 fn test_meta_branching_side_effect() {
     let expr = Expr::One;
-    let (expr, meta) = reduce(transform, expr, false);
+    let (expr, meta) = reduce(&[transform], expr, false);
     assert_eq!(expr, Expr::Two);
     assert_eq!(meta, true);
 }

--- a/crates/tree_morph/tests/lambda_calc.rs
+++ b/crates/tree_morph/tests/lambda_calc.rs
@@ -2,7 +2,7 @@
 //! The beta-reduction rule has the side effect of increasing a counter in the metadata.
 
 use std::collections::HashSet;
-use tree_morph::*;
+use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]

--- a/crates/tree_morph/tests/lambda_calc.rs
+++ b/crates/tree_morph/tests/lambda_calc.rs
@@ -114,7 +114,7 @@ fn test_simple_application() {
         Box::new(Expr::Abs(0, Box::new(Expr::Var(0)))),
         Box::new(Expr::Var(1)),
     );
-    let (result, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(result, Expr::Var(1));
     assert_eq!(meta, 1);
 }
@@ -129,7 +129,7 @@ fn test_nested_application() {
         )),
         Box::new(Expr::Var(2)),
     );
-    let (result, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(result, Expr::Var(2));
     assert_eq!(meta, 2);
 }
@@ -141,7 +141,7 @@ fn test_capture_avoiding_substitution() {
         Box::new(Expr::Abs(0, Box::new(Expr::Abs(1, Box::new(Expr::Var(0)))))),
         Box::new(Expr::Var(1)),
     );
-    let (result, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(result, Expr::Abs(2, Box::new(Expr::Var(1))));
     assert_eq!(meta, 1);
 }
@@ -153,7 +153,7 @@ fn test_double_reduction() {
         Box::new(Expr::Abs(0, Box::new(Expr::Abs(1, Box::new(Expr::Var(1)))))),
         Box::new(Expr::Var(2)),
     );
-    let (result, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(result, Expr::Abs(1, Box::new(Expr::Var(1))));
     assert_eq!(meta, 1);
 }
@@ -162,7 +162,7 @@ fn test_double_reduction() {
 fn test_id() {
     // (\x. x) -> (\x. x)
     let expr = Expr::Abs(0, Box::new(Expr::Var(0)));
-    let (expr, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (expr, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(expr, Expr::Abs(0, Box::new(Expr::Var(0))));
     assert_eq!(meta, 0);
 }
@@ -171,7 +171,7 @@ fn test_id() {
 fn test_no_reduction() {
     // x -> x
     let expr = Expr::Var(1);
-    let (result, meta) = reduce(transform_beta_reduce, expr.clone(), 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr.clone(), 0);
     assert_eq!(result, expr);
     assert_eq!(meta, 0);
 }
@@ -192,7 +192,7 @@ fn test_complex_expression() {
         )),
         Box::new(Expr::Abs(3, Box::new(Expr::Var(3)))),
     );
-    let (result, meta) = reduce(transform_beta_reduce, expr, 0);
+    let (result, meta) = reduce(&[transform_beta_reduce], expr, 0);
     assert_eq!(result, Expr::Abs(3, Box::new(Expr::Var(3))));
     assert_eq!(meta, 3);
 }

--- a/crates/tree_morph/tests/rule_groups.rs
+++ b/crates/tree_morph/tests/rule_groups.rs
@@ -5,7 +5,7 @@
 //! This lets us make powerful "evaluation" rules which greedily reduce the tree as much as possible, before other
 //! "rewriting" rules are applied.
 
-use tree_morph::{helpers::select_first, *};
+use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 
 /// A simple language of two literals and a wrapper

--- a/crates/tree_morph/tests/rule_groups.rs
+++ b/crates/tree_morph/tests/rule_groups.rs
@@ -21,7 +21,7 @@ enum Expr {
 struct Rl(fn(&Expr) -> Option<Expr>);
 
 impl Rule<Expr, ()> for Rl {
-    fn apply(&self, cmd: &mut Commands<Expr, ()>, expr: &Expr, _: &()) -> Option<Expr> {
+    fn apply(&self, _: &mut Commands<Expr, ()>, expr: &Expr, _: &()) -> Option<Expr> {
         self.0(expr)
     }
 }

--- a/crates/tree_morph/tests/rule_groups.rs
+++ b/crates/tree_morph/tests/rule_groups.rs
@@ -1,0 +1,85 @@
+//! Here we test the `reduce_with_rule_groups` function.
+//! Each rule group is applied to the whole tree as with `reduce_with_rules`, before the next group is tried.
+//! Every time a change is made, the algorithm starts again with the first group.
+//!
+//! This lets us make powerful "evaluation" rules which greedily reduce the tree as much as possible, before other
+//! "rewriting" rules are applied.
+
+use tree_morph::{helpers::select_first, *};
+use uniplate::derive::Uniplate;
+
+/// A simple language of two literals and a wrapper
+#[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
+#[uniplate()]
+enum Expr {
+    A,               // a
+    B,               // b
+    Wrap(Box<Expr>), // [E]
+}
+
+/// Rule container: holds a primitive function and implements the Rule trait
+struct Rl(fn(&Expr) -> Option<Expr>);
+
+impl Rule<Expr, ()> for Rl {
+    fn apply(&self, cmd: &mut Commands<Expr, ()>, expr: &Expr, _: &()) -> Option<Expr> {
+        self.0(expr)
+    }
+}
+
+mod rules {
+    use super::*;
+
+    /// [a] ~> a
+    pub fn unwrap_a(expr: &Expr) -> Option<Expr> {
+        if let Expr::Wrap(inner) = expr {
+            if let Expr::A = **inner {
+                return Some(Expr::A);
+            }
+        }
+        None
+    }
+
+    /// a ~> b
+    pub fn a_to_b(expr: &Expr) -> Option<Expr> {
+        if let Expr::A = expr {
+            return Some(Expr::B);
+        }
+        None
+    }
+}
+
+#[test]
+fn test_same_group() {
+    // If the rules are in the same group, unwrap_a will apply higher in the tree
+
+    // [a]
+    let expr = Expr::Wrap(Box::new(Expr::A));
+
+    let (expr, _) = reduce_with_rule_groups(
+        &[&[Rl(rules::unwrap_a), Rl(rules::a_to_b)]],
+        select_first,
+        expr,
+        (),
+    );
+
+    // [a] ~> a ~> b
+    assert_eq!(expr, Expr::B);
+}
+
+#[test]
+fn test_a_to_b_first() {
+    // a_to_b is in a higher group than unwrap_a, so it will be applied first to the lower expression
+
+    // [a]
+    let expr = Expr::Wrap(Box::new(Expr::A));
+
+    let (expr, _) = reduce_with_rule_groups(
+        &[&[Rl(rules::a_to_b)], &[Rl(rules::unwrap_a)]],
+        select_first,
+        expr,
+        (),
+    );
+
+    // [a] ~> [b]
+    assert_eq!(expr, Expr::Wrap(Box::new(Expr::B)));
+}


### PR DESCRIPTION
Since we can't depend on the user-given structure to hold dirty/clean data, ~~I use a wrapper struct `Skel` which holds some metadata and maps directly onto the original structure via pointers. A custom Uniplate implementation may be necessary to maintain the one-to-one mapping upon reconstruction with Uniplate contexts.~~

...some way of associating engine metadata with positions in the tree has to be created. This store must be updated when subtrees are inserted, and must be fully accessible during tree traversal to facilitate dirty-clean optimisation (to not needlessly traverse into clean subtrees).

The first approach explored here, using a "skeleton" tree structure which contains references to the user defined tree's nodes and shares its shape, makes reconstructing the tree difficult due to ownership rules.

The current approach is to use a zipper type similar to that released with Uniplate v0.2.0, which updates an index into a contiguous list of metadata values as it moves around the tree.

Based on #586.