### PR TITLE
Enable `prop_multiple_equally_applicable` by default in integration tests

### DIFF
--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -208,7 +208,7 @@ fn integration_test_inner(
         "Model before rewriting:\n\n{}\n--\n",
         model
     );
-    let model = rewrite_naive(&model, &rule_sets, false)?;
+    let model = rewrite_naive(&model, &rule_sets, true)?;
 
     tracing::trace!(
         target: "rule_engine_human",


### PR DESCRIPTION
- **bug(rewriter): only panic when there are multiple _equally_ applicable rules**
  Fix the naive rewriter's `prop_multiple_equally_applicable` check so
  that it panics when there are multiple equally applicable rules (i.e.
  they have the same priority) instead of panicing any time there are
  multiple applicable rules of any priority.
  

- **tester: enable `prop_multiple_equally_applicable` rewriter check**
  Enable the `prop_multiple_equally_applicable` rewriter assertion in the
  integration tester. This check panics if a given expression has two
  rules of the same priority applicable to it.
  
  All tests pass with this enabled.
  
  For performance reasons, I think it is best to keep this disabled by
  default in the CLI.
  
  Issue: #552
  