### PR TITLE
minor refactor: Remove RuleSet order

### DIFF
--- a/crates/conjure_core/src/rule_engine/mod.rs
+++ b/crates/conjure_core/src/rule_engine/mod.rs
@@ -51,7 +51,7 @@ pub use conjure_macros::register_rule;
 /// This macro uses the following syntax:
 ///
 /// ```text
-/// register_rule_set!(<RuleSet name>, <RuleSet order>, (<DependencyRuleSet1>, <DependencyRuleSet2>, ...));
+/// register_rule_set!(<RuleSet name>, (<DependencyRuleSet1>, <DependencyRuleSet2>, ...));
 /// ```
 ///
 /// # Example
@@ -59,7 +59,7 @@ pub use conjure_macros::register_rule;
 /// ```rust
 /// use conjure_core::rule_engine::register_rule_set;
 ///
-/// register_rule_set!("MyRuleSet", 10, ("DependencyRuleSet", "AnotherRuleSet"));
+/// register_rule_set!("MyRuleSet", ("DependencyRuleSet", "AnotherRuleSet"));
 /// ```
 #[doc(inline)]
 pub use conjure_macros::register_rule_set;
@@ -159,8 +159,8 @@ pub fn get_rule_by_name(name: &str) -> Option<&'static Rule<'static>> {
 /// use conjure_core::rule_engine::register_rule_set;
 /// use conjure_core::rule_engine::get_rule_sets;
 ///
-/// register_rule_set!("MyRuleSet", 10, ("AnotherRuleSet"));
-/// register_rule_set!("AnotherRuleSet", 5, ());
+/// register_rule_set!("MyRuleSet", ("AnotherRuleSet"));
+/// register_rule_set!("AnotherRuleSet", ());
 ///
 /// println!("Rule sets: {:?}", get_rule_sets());
 /// ```
@@ -168,8 +168,8 @@ pub fn get_rule_by_name(name: &str) -> Option<&'static Rule<'static>> {
 /// This will print (if no other rule sets are registered):
 /// ```text
 /// Rule sets: [
-///   RuleSet { name: "MyRuleSet", order: 10, rules: OnceLock { state: Uninitialized }, dependencies: ["AnotherRuleSet"] },
-///   RuleSet { name: "AnotherRuleSet", order: 5, rules: OnceLock { state: Uninitialized }, dependencies: [] }
+///   RuleSet { name: "MyRuleSet", rules: OnceLock { state: Uninitialized }, dependencies: ["AnotherRuleSet"] },
+///   RuleSet { name: "AnotherRuleSet", rules: OnceLock { state: Uninitialized }, dependencies: [] }
 /// ]
 /// ```
 ///
@@ -185,14 +185,14 @@ pub fn get_rule_sets() -> Vec<&'static RuleSet<'static>> {
 /// use conjure_core::rule_engine::register_rule_set;
 /// use conjure_core::rule_engine::get_rule_set_by_name;
 ///
-/// register_rule_set!("MyRuleSet", 10, ("DependencyRuleSet", "AnotherRuleSet"));
+/// register_rule_set!("MyRuleSet", ("DependencyRuleSet", "AnotherRuleSet"));
 ///
 /// println!("Rule set: {:?}", get_rule_set_by_name("MyRuleSet"));
 /// ```
 ///
 /// This will print:
 /// ```text
-/// Rule set: Some(RuleSet { name: "MyRuleSet", order: 10, rules: OnceLock { state: Uninitialized }, dependencies: ["DependencyRuleSet", "AnotherRuleSet"] })
+/// Rule set: Some(RuleSet { name: "MyRuleSet", rules: OnceLock { state: Uninitialized }, dependencies: ["DependencyRuleSet", "AnotherRuleSet"] })
 /// ```
 pub fn get_rule_set_by_name(name: &str) -> Option<&'static RuleSet<'static>> {
     get_rule_sets()

--- a/crates/conjure_core/src/rule_engine/resolve_rules.rs
+++ b/crates/conjure_core/src/rule_engine/resolve_rules.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 
+use log::warn;
 use thiserror::Error;
 
 use crate::rule_engine::{get_rule_set_by_name, get_rule_sets_for_solver_family, Rule, RuleSet};
@@ -94,10 +95,8 @@ pub fn get_rule_priorities<'a>(
 
     for rs in rule_sets {
         for (rule, priority) in rs.get_rules() {
-            if let Some((old_rs, _)) = rule_priorities.get(rule) {
-                if rs.order >= old_rs.order {
-                    rule_priorities.insert(rule, (rs, *priority));
-                }
+            if rule_priorities.contains_key(rule) {
+                warn!("Rule {} is defined in multiple rule sets.", rule.name);
             } else {
                 rule_priorities.insert(rule, (rs, *priority));
             }

--- a/crates/conjure_core/src/rule_engine/rule_set.rs
+++ b/crates/conjure_core/src/rule_engine/rule_set.rs
@@ -31,9 +31,6 @@ use crate::solver::SolverFamily;
 pub struct RuleSet<'a> {
     /// The name of the rule set.
     pub name: &'a str,
-    /// Order of the RuleSet. Used to establish a consistent order of operations when resolving rules.
-    /// If two RuleSets overlap (contain the same rule but with different priorities), the RuleSet with the higher order will be used as the source of truth.
-    pub order: u16,
     /// A map of rules to their priorities. This will be lazily initialized at runtime.
     rules: OnceLock<HashMap<&'a Rule<'a>, u16>>,
     /// The names of the rule sets that this rule set depends on.
@@ -46,13 +43,11 @@ pub struct RuleSet<'a> {
 impl<'a> RuleSet<'a> {
     pub const fn new(
         name: &'a str,
-        order: u16,
         dependencies: &'a [&'a str],
         solver_families: &'a [SolverFamily],
     ) -> Self {
         Self {
             name,
-            order,
             dependency_rs_names: dependencies,
             solver_families,
             rules: OnceLock::new(),
@@ -181,11 +176,10 @@ impl Display for RuleSet<'_> {
             f,
             "RuleSet {{\n\
             \tname: {}\n\
-            \torder: {}\n\
             \trules: {}\n\
             \tsolver_families: {:?}\n\
         }}",
-            self.name, self.order, n_rules, solver_families
+            self.name, n_rules, solver_families
         )
     }
 }

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -10,7 +10,7 @@ use Atom::*;
 use Expr::*;
 use Lit::*;
 
-register_rule_set!("Base", 100, ());
+register_rule_set!("Base", ());
 
 /// This rule simplifies expressions where the operator is applied to an empty set of sub-expressions.
 ///

--- a/crates/conjure_core/src/rules/bubble.rs
+++ b/crates/conjure_core/src/rules/bubble.rs
@@ -11,7 +11,7 @@ use crate::ast::{Atom, Literal};
 
 use super::utils::is_all_constant;
 
-register_rule_set!("Bubble", 100, ("Base"));
+register_rule_set!("Bubble", ("Base"));
 
 // Bubble reduction rules
 

--- a/crates/conjure_core/src/rules/cnf.rs
+++ b/crates/conjure_core/src/rules/cnf.rs
@@ -5,4 +5,4 @@
 use conjure_core::rule_engine::register_rule_set;
 use conjure_core::solver::SolverFamily;
 
-register_rule_set!("CNF", 100, ("Base"), (SolverFamily::SAT));
+register_rule_set!("CNF", ("Base"), (SolverFamily::SAT));

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -8,7 +8,7 @@ use conjure_core::rule_engine::{
 use conjure_core::Model;
 use itertools::izip;
 
-register_rule_set!("Constant", 100, ());
+register_rule_set!("Constant", ());
 
 #[register_rule(("Constant", 9001))]
 fn apply_eval_constant(expr: &Expr, _: &Model) -> ApplicationResult {

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -19,7 +19,7 @@ use ApplicationError::*;
 
 use super::utils::{is_flat, to_aux_var};
 
-register_rule_set!("Minion", 100, ("Base"), (SolverFamily::Minion));
+register_rule_set!("Minion", ("Base"), (SolverFamily::Minion));
 
 #[register_rule(("Minion", 4200))]
 fn introduce_producteq(expr: &Expr, model: &Model) -> ApplicationResult {


### PR DESCRIPTION
As discussed with Oz, RuleSet order is only ever used as a tie breaker in very specific circumstances. 
It's unnecessary and confusing for the user, so I suggest we remove it.

See this link for the original reasoning behind adding it:

https://github.com/conjure-cp/conjure-oxide/wiki/Expression-rewriting%2C-Rules-and-RuleSets#ruleset-ordering

(This doc will need to be updated to avoid confusion)