### PR TITLE
fix(ci): trigger code-coverage-deploy again

### DIFF
--- a/.github/workflows/code-coverage-deploy.yml
+++ b/.github/workflows/code-coverage-deploy.yml
@@ -3,7 +3,7 @@ name: "Code and Documentation Coverage (Deploy)"
 
 on:
   workflow_run:
-    workflows: ["Code and Documentation Coverage (PR)"]
+    workflows: ["Coverage (PR)"]
     types:
       - completed
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,4 +1,4 @@
-name: "Coverage"
+name: "Coverage (PR)"
 
 on:
   pull_request:


### PR DESCRIPTION
A previous renaming of actions made code-coverage-deploy no longer
trigger, breaking code coverage comments and report publishing.

Fixes: #607
