### PR TITLE
refactor(ast)!: add top level expression type `Expr::Root`

### DIFF
--- a/conjure_oxide/examples/solver-hello-minion.rs
+++ b/conjure_oxide/examples/solver-hello-minion.rs
@@ -27,7 +27,7 @@ pub fn main() {
     let model = get_example_model("div-05").unwrap();
     println!(
         "Input model: \n {} \n",
-        pretty_expressions_as_top_level(&model.constraints)
+        pretty_expressions_as_top_level(&model.get_constraints_vec())
     );
 
     // TODO: We will have a nicer way to do this in the future
@@ -36,7 +36,7 @@ pub fn main() {
     let model = rewrite_model(&model, &rule_sets).unwrap();
     println!(
         "Rewritten model: \n {} \n",
-        pretty_expressions_as_top_level(&model.constraints)
+        pretty_expressions_as_top_level(&model.get_constraints_vec())
     );
 
     // To tell the `Solver` type what solver to use, you pass it a `SolverAdaptor`.

--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -39,7 +39,7 @@ pub fn parse_essence_file_native(
                         constraint_vec.push(parse_constraint(constraint, &source_code));
                     }
                 }
-                model.constraints.extend(constraint_vec);
+                model.add_constraints(constraint_vec);
             }
             "e_prime_label" => {}
             _ => {

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -357,7 +357,7 @@ fn check_solutions_stage(
 }
 
 fn assert_vector_operators_have_partially_evaluated(model: &conjure_core::Model) {
-    for node in model.constraints.universe_bi() {
+    for node in model.universe_bi() {
         use conjure_core::ast::Expression::*;
         match node {
             Sum(_, ref vec) => assert_constants_leq_one(&node, vec),

--- a/conjure_oxide/tests/integration/basic/abs/0-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/0-simple/input.expected-parse.serialised.json
@@ -1,16 +1,37 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Abs": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
+            },
+            {
+              "Abs": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "Atomic": [
@@ -19,30 +40,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
+                  "Literal": {
+                    "Int": 1
                   }
                 }
               ]
             }
           ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/0-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/0-simple/input.expected-rewrite.serialised.json
@@ -1,24 +1,32 @@
 {
-  "constraints": [
-    {
-      "FlatAbsEq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Int": 1
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 1
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-parse.serialised.json
@@ -1,79 +1,87 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Abs": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "x"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Abs": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "y"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Abs": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Abs": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-rewrite.serialised.json
@@ -1,102 +1,110 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 10
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 10
-                }
+          ]
+        },
+        {
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-parse.serialised.json
@@ -1,95 +1,103 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Abs": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Neg": [
+                    "Abs": [
                       {
                         "clean": false,
                         "etype": null
                       },
                       {
-                        "Atomic": [
+                        "Neg": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "x"
-                            }
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "x"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Abs": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Neg": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
                           }
                         ]
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "Abs": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Neg": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "y"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-rewrite.serialised.json
@@ -1,102 +1,110 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 10
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 10
-                }
+          ]
+        },
+        {
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-parse.serialised.json
@@ -1,42 +1,76 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Abs": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Minus": [
+                    "Abs": [
                       {
                         "clean": false,
                         "etype": null
                       },
                       {
-                        "Sum": [
+                        "Minus": [
                           {
                             "clean": false,
                             "etype": null
                           },
-                          [
-                            {
-                              "UnsafeDiv": [
+                          {
+                            "Sum": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
                                 {
-                                  "clean": false,
-                                  "etype": null
+                                  "UnsafeDiv": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "x"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 2
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
                                 },
                                 {
                                   "Atomic": [
@@ -46,40 +80,56 @@
                                     },
                                     {
                                       "Reference": {
-                                        "UserName": "x"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "Atomic": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    {
-                                      "Literal": {
-                                        "Int": 2
+                                        "UserName": "y"
                                       }
                                     }
                                   ]
                                 }
                               ]
-                            },
-                            {
-                              "Atomic": [
-                                {
-                                  "clean": false,
-                                  "etype": null
-                                },
-                                {
-                                  "Reference": {
-                                    "UserName": "y"
-                                  }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
                                 }
-                              ]
-                            }
-                          ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "UnsafeDiv": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Abs": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
+                          }
                         ]
                       },
                       {
@@ -89,8 +139,8 @@
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "z"
+                            "Literal": {
+                              "Int": 2
                             }
                           }
                         ]
@@ -98,68 +148,26 @@
                     ]
                   }
                 ]
-              },
-              {
-                "UnsafeDiv": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Abs": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "y"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-rewrite.serialised.json
@@ -1,240 +1,248 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 10
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 10
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
+          ]
+        },
+        {
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 2
+              }
+            }
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 4
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatWeightedSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": -1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 3
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 2
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 10
-                }
+                "FlatWeightedSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": -1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 3
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 2
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 2
-          }
-        }
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 4
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWeightedSumLeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": -1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "MachineName": 3
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 2
-                }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
               }
-            ]
-          },
-          {
-            "FlatWeightedSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": -1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "MachineName": 3
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 2
-                }
+            },
+            {
+              "Literal": {
+                "Int": 2
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 3
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 3
-          }
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 4
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 4
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 5,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/04-bounds/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/04-bounds/input.expected-parse.serialised.json
@@ -1,37 +1,24 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Product": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              },
-              {
-                "Abs": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
+            {
+              "Product": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
                     "Atomic": [
                       {
@@ -40,32 +27,53 @@
                       },
                       {
                         "Reference": {
-                          "UserName": "x"
+                          "UserName": "y"
                         }
+                      }
+                    ]
+                  },
+                  {
+                    "Abs": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
                       }
                     ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 2
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/abs/04-bounds/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/04-bounds/input.expected-rewrite.serialised.json
@@ -1,47 +1,55 @@
 {
-  "constraints": [
-    {
-      "FlatProductEq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatProductEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
+          "FlatAbsEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatAbsEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01-expected-rule-trace-human.txt
@@ -8,11 +8,17 @@ such that
 
 --
 
+, 
+   ~~> eval_root ([("Constant", 9001)]) 
+true 
+
+--
+
 Final model:
 
 find x: bool
 
 such that
 
-
+true
 

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01-expected-rule-trace.json
@@ -1,3 +1,44 @@
-{
-  "Number of rules applied": 0
-}
+[
+  {
+    "initial_expression": {
+      "Root": [
+        [],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "eval_root",
+    "rule_priority": 9001,
+    "rule_set": {
+      "name": "Constant"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "Number of rules applied": 1
+  }
+]

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-parse.serialised.json
@@ -1,5 +1,13 @@
 {
-  "constraints": [],
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      []
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/01/bool-01.expected-rewrite.serialised.json
@@ -1,5 +1,27 @@
 {
-  "constraints": [],
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
+        }
+      ]
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02-expected-rule-trace-human.txt
@@ -9,6 +9,12 @@ such that
 
 --
 
+, 
+   ~~> eval_root ([("Constant", 9001)]) 
+true 
+
+--
+
 Final model:
 
 find x: bool
@@ -16,5 +22,5 @@ find y: bool
 
 such that
 
-
+true
 

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02-expected-rule-trace.json
@@ -1,3 +1,44 @@
-{
-  "Number of rules applied": 0
-}
+[
+  {
+    "initial_expression": {
+      "Root": [
+        [],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "eval_root",
+    "rule_priority": 9001,
+    "rule_set": {
+      "name": "Constant"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "Number of rules applied": 1
+  }
+]

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-parse.serialised.json
@@ -1,5 +1,13 @@
 {
-  "constraints": [],
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      []
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/02/bool-02.expected-rewrite.serialised.json
@@ -1,5 +1,27 @@
 {
-  "constraints": [],
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
+        }
+      ]
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/03/bool-03.expected-rewrite.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-parse.serialised.json
@@ -1,74 +1,82 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Bool": true
+                  }
+                }
+              ]
             }
           ]
         },
         {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Bool": true
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Bool": false
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    },
-    {
-      "Neq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "y"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Bool": false
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/bool/04/bool-04.expected-rewrite.serialised.json
@@ -1,66 +1,74 @@
 {
-  "constraints": [
-    {
-      "MinionReify": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Bool": true
-              }
-            }
-          ]
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        }
-      ]
-    },
-    {
-      "Neq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Bool": true
+                  }
+                }
+              ]
             },
             {
               "Reference": {
-                "UserName": "y"
+                "UserName": "x"
               }
             }
           ]
         },
         {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Bool": false
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Bool": false
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/01/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/01/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "a"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "b"
+                  "Literal": {
+                    "Int": 1
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/01/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 1
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "a"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "b"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/02/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
@@ -32,30 +19,51 @@
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 4
+                  "Reference": {
+                    "UserName": "a"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 2
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 4
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/02/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/03/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/03/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Literal": {
-                    "Int": 8
+                    "Int": 2
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "a"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 8
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/03/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 8
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 2
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Literal": {
-                      "Int": 0
+                      "Int": 8
                     }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 2
+                    }
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/04/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/04/input.expected-parse.serialised.json
@@ -1,32 +1,19 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                }
-              ]
-            },
-            {
-              "UnsafeDiv": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
@@ -39,21 +26,42 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "b"
+                        "UserName": "a"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -62,8 +70,8 @@
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/04/input.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/05/div-05.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "b"
+                    "UserName": "a"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "c"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/05/div-05.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/06/div-06.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06.expected-parse.serialised.json
@@ -1,32 +1,19 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                }
-              ]
-            },
-            {
-              "UnsafeDiv": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
@@ -39,21 +26,42 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "b"
+                        "UserName": "a"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -62,8 +70,8 @@
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/06/div-06.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/01-basic/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/01-basic/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/01-basic/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/01-basic/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-parse.serialised.json
@@ -1,204 +1,212 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Lt": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "Lt": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             },
             {
-              "Atomic": [
+              "Geq": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 3
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 5
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         },
         {
-          "Geq": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
-                  }
+                  "Sum": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 8
+                      }
+                    }
+                  ]
                 }
               ]
             },
             {
-              "Atomic": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 5
-                  }
+                  "Sum": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    },
-    {
-      "Imply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Sum": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "y"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 8
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Eq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Sum": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "x"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
-                        }
-                      }
-                    ]
-                  }
-                ]
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-rewrite.serialised.json
@@ -1,220 +1,228 @@
 {
-  "constraints": [
-    {
-      "MinionReifyImply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReifyImply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 5
-              }
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
             },
             {
               "Reference": {
-                "UserName": "y"
+                "MachineName": 0
               }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "MinionReifyImply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "And": [
+          "MinionReifyImply": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
             {
-              "clean": false,
-              "etype": null
+              "And": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "FlatSumLeq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Reference": {
+                            "UserName": "x"
+                          }
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ],
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "FlatSumGeq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Reference": {
+                            "UserName": "x"
+                          }
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ],
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
             },
             {
               "Reference": {
-                "UserName": "x"
+                "MachineName": 1
               }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "And": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 8
-                    }
+            {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
                   }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 8
-                    }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
                   }
-                ]
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 0
               }
-            ]
+            }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "And": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "FlatSumLeq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ],
+                      {
+                        "Literal": {
+                          "Int": 8
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "FlatSumGeq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ],
+                      {
+                        "Literal": {
+                          "Int": 8
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace-human.txt
@@ -21,9 +21,25 @@ true
 
 --
 
+true,
+Or([(a) -> (z), (z) -> (a)]),
+Or([(b) -> (c), (b) -> (Not(c))]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([(a) -> (z), (z) -> (a)]),
+Or([(b) -> (c), (b) -> (Not(c))]) 
+
+--
+
 Or([(a) -> (z), (z) -> (a)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 true 
+
+--
+
+true,
+Or([(b) -> (c), (b) -> (Not(c))]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([(b) -> (c), (b) -> (Not(c))]) 
 
 --
 
@@ -44,7 +60,5 @@ find z: bool
 
 such that
 
-true,
-true,
 true
 

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace.json
@@ -55,6 +55,374 @@
   },
   {
     "initial_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
       "Or": [
         [
           {
@@ -144,6 +512,218 @@
             "Bool": true
           }
         },
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
@@ -258,6 +838,6 @@
     }
   },
   {
-    "Number of rules applied": 3
+    "Number of rules applied": 5
   }
 ]

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-parse.serialised.json
@@ -1,182 +1,148 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             }
           ]
         },
         {
-          "Atomic": [
+          "Or": [
             {
               "clean": false,
               "etype": null
             },
-            {
-              "Reference": {
-                "UserName": "x"
+            [
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
-            }
+            ]
           ]
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
         },
-        [
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Imply": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "Not": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   },
                   {
                     "Atomic": [
@@ -192,13 +158,55 @@
                     ]
                   }
                 ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Not": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-rewrite.serialised.json
@@ -1,45 +1,27 @@
 {
-  "constraints": [
-    {
-      "Atomic": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-parse.serialised.json
@@ -1,10 +1,68 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "Not": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Imply": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Not": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "x"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Not": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "Imply": [
@@ -26,7 +84,7 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "x"
+                        "UserName": "a"
                       }
                     }
                   ]
@@ -47,7 +105,138 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "y"
+                        "UserName": "b"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Imply": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "c"
+                  }
+                }
+              ]
+            },
+            {
+              "Imply": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "d"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "e"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Imply": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Imply": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "h"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "f"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Imply": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "h"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "g"
                       }
                     }
                   ]
@@ -57,189 +246,8 @@
           ]
         }
       ]
-    },
-    {
-      "Imply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Not": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Not": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Imply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "c"
-              }
-            }
-          ]
-        },
-        {
-          "Imply": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "d"
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "e"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Imply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Imply": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "h"
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "f"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Imply": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "h"
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "g"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-rewrite.serialised.json
@@ -1,111 +1,11 @@
 {
-  "constraints": [
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWatchedLiteral": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "UserName": "x"
-              },
-              {
-                "Bool": false
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "e"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "g"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
           "And": [
             {
@@ -114,15 +14,16 @@
             },
             [
               {
-                "Atomic": [
+                "FlatWatchedLiteral": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "c"
-                    }
+                    "UserName": "x"
+                  },
+                  {
+                    "Bool": false
                   }
                 ]
               },
@@ -134,7 +35,7 @@
                   },
                   {
                     "Reference": {
-                      "UserName": "d"
+                      "UserName": "y"
                     }
                   }
                 ]
@@ -143,62 +44,169 @@
           ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "And": [
+          "FlatIneq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "h"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "f"
-                    }
-                  }
-                ]
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "e"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "g"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "And": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "d"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "And": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "h"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "f"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "A"
-              }
-            }
-          ]
-        },
-        {
-          "Lt": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "b"
+                    "UserName": "A"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "Lt": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 3
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/02-value-int/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/02-value-int/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Lt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Lt": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "b"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "A"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "A"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/02-value-int/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/02-value-int/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "NotA"
-              }
-            }
-          ]
-        },
-        {
-          "Lt": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "b"
+                    "UserName": "NotA"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "Lt": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 3
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/04-domain/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/basic/lettings/04-domain/input-expected-rule-trace.json
@@ -155,54 +155,64 @@
   },
   {
     "initial_expression": {
-      "Imply": [
-        {
-          "Atomic": [
-            {
-              "Reference": {
-                "UserName": "x"
+      "Root": [
+        [
+          {
+            "Imply": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Leq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "Leq": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
@@ -215,54 +225,64 @@
       "name": "Base"
     },
     "transformed_expression": {
-      "Imply": [
-        {
-          "Atomic": [
-            {
-              "Reference": {
-                "UserName": "x"
+      "Root": [
+        [
+          {
+            "Imply": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Leq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "Leq": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null

--- a/conjure_oxide/tests/integration/basic/lettings/04-domain/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/04-domain/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Lt": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "x"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "Lt": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 3
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/lettings/04-domain/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/lettings/04-domain/input.expected-rewrite.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "MinionReifyImply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReifyImply": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "y"
+                "UserName": "x"
               }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Int": 0
             }
           ]
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Max": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 2
-              }
+              "Max": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 2
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Min": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 3
-              }
+              "Min": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 3
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 3
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 3
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Min": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 2
-              }
+              "Min": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Min": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 2
-              }
+              "Min": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Min": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 3
-              }
+              "Min": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 3
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 3
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 3
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Min": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 2
-              }
+              "Min": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
@@ -1,147 +1,155 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/01/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/01/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "a"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "b"
+                  "Literal": {
+                    "Int": 1
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/01/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionModuloEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 1
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "a"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "b"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/02/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
@@ -32,30 +19,51 @@
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 4
+                  "Reference": {
+                    "UserName": "a"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 2
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 4
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/02/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Int": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/03/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/03/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Literal": {
-                    "Int": 8
+                    "Int": 2
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "a"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 8
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/03/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionModuloEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 8
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 2
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Literal": {
-                      "Int": 0
+                      "Int": 8
                     }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 2
+                    }
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/04/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/04/input.expected-parse.serialised.json
@@ -1,32 +1,19 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                }
-              ]
-            },
-            {
-              "UnsafeMod": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
@@ -39,21 +26,42 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "b"
+                        "UserName": "a"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeMod": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -62,8 +70,8 @@
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/04/input.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
@@ -33,29 +20,50 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "b"
+                    "UserName": "a"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "c"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-parse.serialised.json
@@ -1,32 +1,19 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                }
-              ]
-            },
-            {
-              "UnsafeMod": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
@@ -39,21 +26,42 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "b"
+                        "UserName": "a"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeMod": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -62,8 +70,8 @@
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-rewrite.serialised.json
@@ -1,107 +1,115 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+            },
+            {
+              "Reference": {
+                "UserName": "c"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/01-negeq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/01-negeq/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Neg": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
@@ -33,16 +20,37 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "x"
                   }
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/01-negeq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/01-negeq/input.expected-rewrite.serialised.json
@@ -1,24 +1,32 @@
 {
-  "constraints": [
-    {
-      "FlatMinusEq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
+          "FlatMinusEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-parse.serialised.json
@@ -1,50 +1,16 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    }
-                  ]
-                }
-              ]
             },
             {
               "Atomic": [
@@ -54,16 +20,58 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "z"
+                    "UserName": "x"
                   }
+                }
+              ]
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-rewrite.serialised.json
@@ -1,91 +1,99 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "MachineName": 0
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "z"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatMinusEq": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
+          "FlatMinusEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-parse.serialised.json
@@ -1,59 +1,67 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "UnsafeDiv": [
+              "Atomic": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    }
-                  ]
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -62,8 +70,8 @@
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-rewrite.serialised.json
@@ -1,91 +1,99 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatMinusEq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "FlatMinusEq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "UserName": "z"
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 0
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-parse.serialised.json
@@ -1,71 +1,16 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "UnsafeDiv": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "z"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
             },
             {
               "Atomic": [
@@ -75,16 +20,79 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "z"
+                    "UserName": "x"
                   }
+                }
+              ]
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "UnsafeDiv": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-rewrite.serialised.json
@@ -1,148 +1,156 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "UserName": "z"
+                      "MachineName": 0
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Reference": {
                       "UserName": "z"
                     }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatMinusEq": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatMinusEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-parse.serialised.json
@@ -1,36 +1,57 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
-            [
-              {
-                "Neg": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
+                    "Neg": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "Atomic": [
@@ -40,32 +61,19 @@
                       },
                       {
                         "Reference": {
-                          "UserName": "y"
+                          "UserName": "z"
                         }
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              }
-            ]
+              ]
+            }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-rewrite.serialised.json
@@ -1,82 +1,90 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWeightedSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatWeightedSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": 1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
               {
-                "Reference": {
-                  "UserName": "x"
-                }
+                "FlatWeightedSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatWeightedSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": 1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-parse.serialised.json
@@ -1,106 +1,49 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Neg": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
+                          "Neg": [
                             {
                               "clean": false,
                               "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neg": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Minus": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Sum": [
-                                {
-                                  "clean": false,
-                                  "etype": null
-                                },
-                                [
-                                  {
-                                    "Atomic": [
-                                      {
-                                        "clean": false,
-                                        "etype": null
-                                      },
-                                      {
-                                        "Reference": {
-                                          "UserName": "z"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "Atomic": [
-                                      {
-                                        "clean": false,
-                                        "etype": null
-                                      },
-                                      {
-                                        "Literal": {
-                                          "Int": 1
-                                        }
-                                      }
-                                    ]
-                                  }
-                                ]
-                              ]
                             },
                             {
                               "Atomic": [
@@ -110,37 +53,102 @@
                                 },
                                 {
                                   "Reference": {
-                                    "UserName": "a"
+                                    "UserName": "y"
                                   }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "Neg": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Minus": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Sum": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    [
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Reference": {
+                                              "UserName": "z"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Literal": {
+                                              "Int": 1
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Reference": {
+                                        "UserName": "a"
+                                      }
+                                    }
+                                  ]
                                 }
                               ]
                             }
                           ]
                         }
                       ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "b"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
+              ]
+            }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-rewrite.serialised.json
@@ -1,130 +1,138 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWeightedSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatWeightedSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": -1
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": -1
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                }
-              ],
               {
-                "Reference": {
-                  "UserName": "x"
-                }
+                "FlatWeightedSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": -1
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatWeightedSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": -1
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafePow": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafePow": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
+                  "Literal": {
+                    "Int": 4
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 4
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
@@ -1,138 +1,146 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionPow": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "MinionPow": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 4
-                }
-              }
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Neq": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "x"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Literal": {
-                            "Int": 0
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "Neq": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 0
-                          }
-                        }
-                      ]
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 0
                     }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Int": 0
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafePow": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafePow": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
+                  "Literal": {
+                    "Int": 4
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 4
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
@@ -1,138 +1,146 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionPow": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "MinionPow": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 4
-                }
-              }
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Neq": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "x"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Literal": {
-                            "Int": 0
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "Neq": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 0
-                          }
-                        }
-                      ]
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 0
                     }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Int": 0
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafePow": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafePow": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
+                  "Literal": {
+                    "Int": 2
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
@@ -1,138 +1,146 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionPow": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "MinionPow": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 2
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 2
-                }
-              }
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Neq": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "x"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Literal": {
-                            "Int": 0
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "Neq": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 0
-                          }
-                        }
-                      ]
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 0
                     }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Int": 0
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-parse.serialised.json
@@ -1,105 +1,113 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafePow": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Sum": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "x"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
-                        }
-                      }
-                    ]
-                  }
-                ]
-              ]
-            },
-            {
-              "UnsafeDiv": [
+              "UnsafePow": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Atomic": [
+                  "Sum": [
                     {
                       "clean": false,
                       "etype": null
                     },
-                    {
-                      "Reference": {
-                        "UserName": "y"
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
                       }
-                    }
+                    ]
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Literal": {
-                        "Int": 2
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Literal": {
-                "Int": 4
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 4
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
@@ -1,327 +1,335 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionPow": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "MinionPow": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 0
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 1
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Reference": {
-                  "MachineName": 1
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 4
-                }
-              }
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Neq": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "MachineName": 2
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Literal": {
-                            "Int": 0
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 3
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "Neq": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "MachineName": 3
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 0
-                          }
-                        }
-                      ]
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 0
                     }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              },
-              {
-                "Reference": {
-                  "MachineName": 4
-                }
-              },
-              {
-                "Int": 0
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 4
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
-        [
-          {
-            "FlatSumLeq": [
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 0
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ],
               {
-                "Reference": {
-                  "MachineName": 0
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 0
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 2
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ],
               {
-                "Reference": {
-                  "MachineName": 0
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 2
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "y"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 3
+              }
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 4
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 2
-                }
-              }
-            ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 2
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 3
-          }
-        }
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 4
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 5,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafePow": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafePow": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -33,29 +54,16 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "z"
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "z"
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
@@ -1,138 +1,146 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionPow": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "MinionPow": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "z"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              }
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Neq": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "x"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "Neq": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Literal": {
-                            "Int": 0
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                {
-                  "Neq": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 0
-                          }
-                        }
-                      ]
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 0
                     }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Int": 0
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "y"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/product/01-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/product/01-simple/input.expected-parse.serialised.json
@@ -1,86 +1,94 @@
 {
-  "constraints": [
-    {
-      "Lt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Product": [
+          "Lt": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Product": [
+            {
+              "Product": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "x"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "z"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 15
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 15
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/product/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/product/01-simple/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Literal": {
+                "Int": 14
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatProductEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 14
-          }
-        },
-        {
-          "Int": 0
+          "FlatProductEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatProductEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "FlatProductEq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-parse.serialised.json
@@ -1,122 +1,130 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Sum": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "b"
-                          }
+                          "Sum": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "c"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "d"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Sum": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "c"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "d"
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "e"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "e"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 5
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-rewrite.serialised.json
@@ -1,96 +1,104 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "d"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "e"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 5
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "d"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "e"
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 5
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "d"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "e"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 5
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "d"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "e"
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 5
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-parse.serialised.json
@@ -1,74 +1,95 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Sum": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Sum": [
+                {
+                  "Sum": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Atomic": [
+                        "Sum": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
                             {
-                              "clean": false,
-                              "etype": null
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "x"
+                                  }
+                                }
+                              ]
                             },
                             {
-                              "Reference": {
-                                "UserName": "x"
-                              }
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "y"
+                                  }
+                                }
+                              ]
                             }
                           ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "z"
-                        }
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          }
+                        ]
                       }
                     ]
-                  }
-                ]
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -78,30 +99,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "a"
+                  "Literal": {
+                    "Int": 3
                   }
                 }
               ]
             }
           ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 3
-              }
-            }
-          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-rewrite.serialised.json
@@ -1,143 +1,151 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 3
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "MachineName": 0
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "a"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 3
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 0
+                    }
+                  }
+                ]
+              },
+              {
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "z"
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "MachineName": 0
                     }
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              }
-            ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "z"
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 1,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input.expected-parse.serialised.json
@@ -1,132 +1,140 @@
 {
-  "constraints": [
-    {
-      "Lt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Lt": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Product": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Product": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 2
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "x"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          ]
                         },
-                        [
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "x"
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      ]
-                    },
-                    {
-                      "Product": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Atomic": [
+                          "Product": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 3
+                                    }
+                                  }
+                                ]
                               },
                               {
-                                "Literal": {
-                                  "Int": 3
-                                }
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "y"
+                                    }
+                                  }
+                                ]
                               }
                             ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "y"
-                                }
-                              }
-                            ]
-                          }
-                        ]
+                          ]
+                        }
                       ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "z"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 14
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 14
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input.expected-rewrite.serialised.json
@@ -1,47 +1,55 @@
 {
-  "constraints": [
-    {
-      "FlatWeightedSumLeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Int": 2
-          },
-          {
-            "Int": 3
-          },
-          {
-            "Int": 1
-          }
-        ],
-        [
-          {
-            "Reference": {
-              "UserName": "x"
+          "FlatWeightedSumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Int": 2
+              },
+              {
+                "Int": 3
+              },
+              {
+                "Int": 1
+              }
+            ],
+            [
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "z"
+                }
+              }
+            ],
+            {
+              "Literal": {
+                "Int": 13
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "z"
-            }
-          }
-        ],
-        {
-          "Literal": {
-            "Int": 13
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/02-simple-gt/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/02-simple-gt/input.expected-parse.serialised.json
@@ -1,109 +1,117 @@
 {
-  "constraints": [
-    {
-      "Gt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Product": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "x"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Product": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 3
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Gt": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 12
-              }
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 3
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 12
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/02-simple-gt/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/02-simple-gt/input.expected-rewrite.serialised.json
@@ -1,47 +1,55 @@
 {
-  "constraints": [
-    {
-      "FlatWeightedSumGeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Int": 2
-          },
-          {
-            "Int": 3
-          },
-          {
-            "Int": 1
-          }
-        ],
-        [
-          {
-            "Reference": {
-              "UserName": "x"
+          "FlatWeightedSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Int": 2
+              },
+              {
+                "Int": 3
+              },
+              {
+                "Int": 1
+              }
+            ],
+            [
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Literal": {
+                  "Int": -1
+                }
+              }
+            ],
+            {
+              "Literal": {
+                "Int": 12
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          },
-          {
-            "Literal": {
-              "Int": -1
-            }
-          }
-        ],
-        {
-          "Literal": {
-            "Int": 12
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-parse.serialised.json
@@ -1,109 +1,117 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Product": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "x"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Product": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 3
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 12
-              }
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 3
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 12
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-rewrite.serialised.json
@@ -1,82 +1,90 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWeightedSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatWeightedSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": 2
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 12
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Int": 2
-                },
-                {
-                  "Int": 3
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 12
-                }
+                "FlatWeightedSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Int": 2
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 12
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatWeightedSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": 2
-                },
-                {
-                  "Int": 3
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 12
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input.expected-parse.serialised.json
@@ -1,219 +1,240 @@
 {
-  "constraints": [
-    {
-      "Lt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Lt": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Sum": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Sum": [
+                          "Sum": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
-                              },
-                              [
-                                {
-                                  "Product": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    [
-                                      {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Literal": {
-                                              "Int": 5
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Reference": {
-                                              "UserName": "x"
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  ]
-                                },
-                                {
-                                  "Product": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    [
-                                      {
-                                        "Product": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          [
-                                            {
-                                              "Product": [
-                                                {
-                                                  "clean": false,
-                                                  "etype": null
-                                                },
-                                                [
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Reference": {
-                                                          "UserName": "y"
-                                                        }
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Literal": {
-                                                          "Int": 3
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              ]
-                                            },
-                                            {
-                                              "Atomic": [
-                                                {
-                                                  "clean": false,
-                                                  "etype": null
-                                                },
-                                                {
-                                                  "Literal": {
-                                                    "Int": 1
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        ]
-                                      },
-                                      {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Literal": {
-                                              "Int": 3
-                                            }
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  ]
-                                }
-                              ]
-                            ]
-                          },
-                          {
-                            "Neg": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Product": [
+                                "Sum": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   [
                                     {
-                                      "Atomic": [
+                                      "Product": [
                                         {
                                           "clean": false,
                                           "etype": null
                                         },
-                                        {
-                                          "Literal": {
-                                            "Int": 3
+                                        [
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 5
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Reference": {
+                                                  "UserName": "x"
+                                                }
+                                              }
+                                            ]
                                           }
-                                        }
+                                        ]
                                       ]
                                     },
                                     {
-                                      "Atomic": [
+                                      "Product": [
                                         {
                                           "clean": false,
                                           "etype": null
                                         },
-                                        {
-                                          "Reference": {
-                                            "UserName": "x"
+                                        [
+                                          {
+                                            "Product": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              [
+                                                {
+                                                  "Product": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    [
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Reference": {
+                                                              "UserName": "y"
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Literal": {
+                                                              "Int": 3
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  ]
+                                                },
+                                                {
+                                                  "Atomic": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    {
+                                                      "Literal": {
+                                                        "Int": 1
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 3
+                                                }
+                                              }
+                                            ]
                                           }
-                                        }
+                                        ]
                                       ]
                                     }
                                   ]
                                 ]
+                              },
+                              {
+                                "Neg": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Product": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 3
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "x"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
-                      ]
-                    },
-                    {
-                      "Product": [
-                        {
-                          "clean": false,
-                          "etype": null
+                          ]
                         },
-                        [
-                          {
-                            "Neg": [
+                        {
+                          "Product": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
+                                "Neg": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 1
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
                               },
                               {
                                 "Atomic": [
@@ -222,59 +243,25 @@
                                     "etype": null
                                   },
                                   {
-                                    "Literal": {
-                                      "Int": 1
+                                    "Reference": {
+                                      "UserName": "y"
                                     }
                                   }
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "y"
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Product": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Neg": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
+                    ]
+                  },
+                  {
+                    "Product": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
                           "Atomic": [
                             {
@@ -282,36 +269,57 @@
                               "etype": null
                             },
                             {
-                              "Literal": {
-                                "Int": 5
+                              "Reference": {
+                                "UserName": "y"
                               }
+                            }
+                          ]
+                        },
+                        {
+                          "Neg": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Literal": {
+                                    "Int": 5
+                                  }
+                                }
+                              ]
                             }
                           ]
                         }
                       ]
-                    }
-                  ]
+                    ]
+                  }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 11
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 11
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input.expected-rewrite.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "FlatWeightedSumLeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Int": 5
-          },
-          {
-            "Int": 9
-          },
-          {
-            "Int": -3
-          },
-          {
-            "Int": -1
-          },
-          {
-            "Int": -5
-          }
-        ],
-        [
-          {
-            "Reference": {
-              "UserName": "x"
+          "FlatWeightedSumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Int": 5
+              },
+              {
+                "Int": 9
+              },
+              {
+                "Int": -3
+              },
+              {
+                "Int": -1
+              },
+              {
+                "Int": -5
+              }
+            ],
+            [
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              }
+            ],
+            {
+              "Literal": {
+                "Int": 10
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "x"
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          }
-        ],
-        {
-          "Literal": {
-            "Int": 10
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-parse.serialised.json
@@ -1,253 +1,240 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Sum": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Sum": [
+                          "Sum": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
-                              },
-                              [
-                                {
-                                  "Sum": [
+                                "Sum": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  [
                                     {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    [
-                                      {
-                                        "Sum": [
+                                      "Sum": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        [
                                           {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          [
-                                            {
-                                              "Product": [
+                                            "Sum": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              [
                                                 {
-                                                  "clean": false,
-                                                  "etype": null
-                                                },
-                                                [
-                                                  {
-                                                    "Atomic": [
+                                                  "Product": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    [
                                                       {
-                                                        "clean": false,
-                                                        "etype": null
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Literal": {
+                                                              "Int": 2
+                                                            }
+                                                          }
+                                                        ]
                                                       },
                                                       {
-                                                        "Literal": {
-                                                          "Int": 2
-                                                        }
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Reference": {
+                                                              "UserName": "a"
+                                                            }
+                                                          }
+                                                        ]
                                                       }
                                                     ]
-                                                  },
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Reference": {
-                                                          "UserName": "a"
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              ]
-                                            },
-                                            {
-                                              "Product": [
-                                                {
-                                                  "clean": false,
-                                                  "etype": null
-                                                },
-                                                [
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Literal": {
-                                                          "Int": 2
-                                                        }
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Reference": {
-                                                          "UserName": "b"
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              ]
-                                            }
-                                          ]
-                                        ]
-                                      },
-                                      {
-                                        "Product": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          [
-                                            {
-                                              "Product": [
-                                                {
-                                                  "clean": false,
-                                                  "etype": null
-                                                },
-                                                [
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Literal": {
-                                                          "Int": 3
-                                                        }
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "Atomic": [
-                                                      {
-                                                        "clean": false,
-                                                        "etype": null
-                                                      },
-                                                      {
-                                                        "Reference": {
-                                                          "UserName": "c"
-                                                        }
-                                                      }
-                                                    ]
-                                                  }
-                                                ]
-                                              ]
-                                            },
-                                            {
-                                              "Atomic": [
-                                                {
-                                                  "clean": false,
-                                                  "etype": null
+                                                  ]
                                                 },
                                                 {
-                                                  "Reference": {
-                                                    "UserName": "d"
-                                                  }
+                                                  "Product": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    [
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Literal": {
+                                                              "Int": 2
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Reference": {
+                                                              "UserName": "b"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  ]
                                                 }
                                               ]
+                                            ]
+                                          },
+                                          {
+                                            "Product": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              [
+                                                {
+                                                  "Product": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    [
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Literal": {
+                                                              "Int": 3
+                                                            }
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Atomic": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Reference": {
+                                                              "UserName": "c"
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  ]
+                                                },
+                                                {
+                                                  "Atomic": [
+                                                    {
+                                                      "clean": false,
+                                                      "etype": null
+                                                    },
+                                                    {
+                                                      "Reference": {
+                                                        "UserName": "d"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "e"
+                                              }
                                             }
                                           ]
-                                        ]
-                                      }
-                                    ]
-                                  ]
-                                },
-                                {
-                                  "UnsafeDiv": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    {
-                                      "Atomic": [
-                                        {
-                                          "clean": false,
-                                          "etype": null
                                         },
                                         {
-                                          "Reference": {
-                                            "UserName": "e"
-                                          }
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "Atomic": [
-                                        {
-                                          "clean": false,
-                                          "etype": null
-                                        },
-                                        {
-                                          "Reference": {
-                                            "UserName": "f"
-                                          }
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "f"
+                                              }
+                                            }
+                                          ]
                                         }
                                       ]
                                     }
                                   ]
-                                }
-                              ]
-                            ]
-                          },
-                          {
-                            "Product": [
-                              {
-                                "clean": false,
-                                "etype": null
+                                ]
                               },
-                              [
-                                {
-                                  "Atomic": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    {
-                                      "Literal": {
-                                        "Int": 6
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "UnsafeDiv": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
+                              {
+                                "Product": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  [
                                     {
                                       "Atomic": [
                                         {
@@ -255,118 +242,139 @@
                                           "etype": null
                                         },
                                         {
-                                          "Reference": {
-                                            "UserName": "g"
+                                          "Literal": {
+                                            "Int": 6
                                           }
                                         }
                                       ]
                                     },
                                     {
-                                      "Atomic": [
+                                      "UnsafeDiv": [
                                         {
                                           "clean": false,
                                           "etype": null
                                         },
                                         {
-                                          "Reference": {
-                                            "UserName": "h"
-                                          }
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "g"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "h"
+                                              }
+                                            }
+                                          ]
                                         }
                                       ]
                                     }
                                   ]
-                                }
-                              ]
+                                ]
+                              }
                             ]
-                          }
-                        ]
-                      ]
-                    },
-                    {
-                      "Neg": [
-                        {
-                          "clean": false,
-                          "etype": null
+                          ]
                         },
                         {
-                          "Atomic": [
+                          "Neg": [
                             {
                               "clean": false,
                               "etype": null
                             },
                             {
-                              "Reference": {
-                                "UserName": "a"
-                              }
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                }
+                              ]
                             }
                           ]
                         }
                       ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Neg": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "UnsafeDiv": [
+                    "Neg": [
                       {
                         "clean": false,
                         "etype": null
                       },
                       {
-                        "Atomic": [
+                        "UnsafeDiv": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "g"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "g"
+                                }
+                              }
+                            ]
                           },
                           {
-                            "Reference": {
-                              "UserName": "h"
-                            }
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "h"
+                                }
+                              }
+                            ]
                           }
                         ]
                       }
                     ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 18
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 18
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-rewrite.serialised.json
@@ -1,283 +1,291 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatWeightedSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Int": 2
-                },
-                {
-                  "Int": 2
-                },
-                {
-                  "Int": 3
-                },
-                {
-                  "Int": 1
-                },
-                {
-                  "Int": 6
-                },
-                {
-                  "Int": -1
-                },
-                {
-                  "Int": -1
-                }
-              ],
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 1
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 2
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "MachineName": 3
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 18
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "FlatWeightedSumLeq": [
                   {
                     "clean": false,
                     "etype": null
                   },
-                  {
-                    "Reference": {
-                      "UserName": "h"
+                  [
+                    {
+                      "Int": 2
+                    },
+                    {
+                      "Int": 2
+                    },
+                    {
+                      "Int": 3
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 6
+                    },
+                    {
+                      "Int": -1
+                    },
+                    {
+                      "Int": -1
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
+                  ],
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 1
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 2
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "MachineName": 3
+                      }
+                    }
+                  ],
                   {
                     "Literal": {
-                      "Int": 0
+                      "Int": 18
                     }
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "h"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "h"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "f"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "h"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "FlatProductEq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "d"
               }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "f"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+            },
+            {
+              "Reference": {
+                "UserName": "c"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatProductEq": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "d"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "e"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "f"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "c"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "g"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "h"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 2
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "g"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "h"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 3
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "e"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "f"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "g"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "h"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 2
-          }
-        }
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "g"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "h"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 3
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 4,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-parse.serialised.json
@@ -1,15 +1,23 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        []
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            []
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-rewrite.serialised.json
@@ -1,19 +1,27 @@
 {
-  "constraints": [
-    {
-      "Atomic": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": false
-          }
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": false
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-parse.serialised.json
@@ -1,86 +1,94 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Min": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Min": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "a"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Literal": {
-                      "Int": 6
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-rewrite.serialised.json
@@ -1,151 +1,159 @@
 {
-  "constraints": [
-    {
-      "FlatSumLeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Reference": {
-              "MachineName": 0
-            }
-          },
-          {
-            "Literal": {
-              "Int": 6
-            }
-          }
-        ],
-        {
-          "Literal": {
-            "Int": 10
-          }
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
+          "FlatSumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Reference": {
+                  "MachineName": 0
+                }
               },
               {
-                "Atomic": [
+                "Literal": {
+                  "Int": 6
+                }
+              }
+            ],
+            {
+              "Literal": {
+                "Int": 10
+              }
+            }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Eq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-parse.serialised.json
@@ -1,86 +1,94 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Min": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Min": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 5
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Literal": {
-                            "Int": 5
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 7
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 7
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "c"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-rewrite.serialised.json
@@ -1,31 +1,39 @@
 {
-  "constraints": [
-    {
-      "FlatSumLeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Literal": {
-              "Int": 5
+          "FlatSumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Literal": {
+                  "Int": 5
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "c"
+                }
+              }
+            ],
+            {
+              "Literal": {
+                "Int": 10
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "c"
-            }
-          }
-        ],
-        {
-          "Literal": {
-            "Int": 10
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-parse.serialised.json
@@ -1,53 +1,146 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "a"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Not": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "b"
-                }
+                "And": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
-        [
-          {
-            "Not": [
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  }
+                ]
               },
               {
                 "Atomic": [
@@ -63,96 +156,11 @@
                 ]
               }
             ]
-          },
-          {
-            "And": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "d"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
+          ]
         }
       ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "d"
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "c"
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
@@ -1,175 +1,183 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "a"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "FlatWatchedLiteral": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "UserName": "c"
+                        },
+                        {
+                          "Bool": false
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "b"
-                }
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "FlatWatchedLiteral": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "UserName": "c"
+                        },
+                        {
+                          "Bool": false
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "FlatWatchedLiteral": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "UserName": "c"
-                    },
-                    {
-                      "Bool": false
-                    }
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "FlatWatchedLiteral": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "UserName": "c"
-                    },
-                    {
-                      "Bool": false
-                    }
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "d"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "b"
-          }
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "c"
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
         }
       ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "d"
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "c"
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-parse.serialised.json
@@ -1,132 +1,140 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Sum": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Sum": [
+                          "Sum": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
-                              },
-                              [
-                                {
-                                  "Atomic": [
+                                "Sum": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  [
                                     {
-                                      "clean": false,
-                                      "etype": null
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "x"
+                                          }
+                                        }
+                                      ]
                                     },
                                     {
-                                      "Reference": {
-                                        "UserName": "x"
-                                      }
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 10
+                                          }
+                                        }
+                                      ]
                                     }
                                   ]
-                                },
-                                {
-                                  "Atomic": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    {
-                                      "Literal": {
-                                        "Int": 10
-                                      }
-                                    }
-                                  ]
-                                }
-                              ]
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
+                                ]
                               },
                               {
-                                "Literal": {
-                                  "Int": 20
-                                }
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 20
+                                    }
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "y"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Literal": {
-                      "Int": 5
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 100
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 100
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
@@ -1,76 +1,84 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 35
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 100
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 35
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 100
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 35
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 100
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 35
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 100
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
@@ -18,6 +18,15 @@ true
 
 --
 
+Or([Or([a, b]), false]),
+true,
+And([c, true]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([Or([a, b]), false]),
+And([c, true]) 
+
+--
+
 Or([Or([a, b]), false]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 Or([Or([a, b])]) 
@@ -51,6 +60,5 @@ find c: bool
 such that
 
 Or([a, b]),
-true,
 c
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace.json
@@ -93,6 +93,236 @@
   },
   {
     "initial_expression": {
+      "Root": [
+        [
+          {
+            "And": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": true
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": false
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "And": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": true
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": false
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
       "Or": [
         [
           {
@@ -402,6 +632,6 @@
     }
   },
   {
-    "Number of rules applied": 5
+    "Number of rules applied": 6
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-parse.serialised.json
@@ -1,173 +1,181 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Or": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Atomic": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Reference": {
-                        "UserName": "a"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
                     }
                   ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
+                ]
               },
               {
-                "Literal": {
-                  "Bool": false
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": false
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
+          ]
+        },
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "AllDiff": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Atomic": [
+                "AllDiff": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 1
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Literal": {
-                        "Int": 1
-                      }
-                    }
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Literal": {
-                        "Int": 2
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
                     }
                   ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
+                ]
               },
               {
-                "Literal": {
-                  "Bool": true
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": true
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "And": [
+          ]
+        },
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "c"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "c"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": true
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Bool": true
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
@@ -1,68 +1,63 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "a"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
+          ]
+        },
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "c"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
+            }
+          ]
         }
       ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-parse.serialised.json
@@ -1,132 +1,140 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Sum": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
-                          {
-                            "Sum": [
+                          "Sum": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            [
                               {
-                                "clean": false,
-                                "etype": null
-                              },
-                              [
-                                {
-                                  "Atomic": [
+                                "Sum": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  [
                                     {
-                                      "clean": false,
-                                      "etype": null
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "x"
+                                          }
+                                        }
+                                      ]
                                     },
                                     {
-                                      "Reference": {
-                                        "UserName": "x"
-                                      }
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 10
+                                          }
+                                        }
+                                      ]
                                     }
                                   ]
-                                },
-                                {
-                                  "Atomic": [
-                                    {
-                                      "clean": false,
-                                      "etype": null
-                                    },
-                                    {
-                                      "Literal": {
-                                        "Int": 10
-                                      }
-                                    }
-                                  ]
-                                }
-                              ]
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
+                                ]
                               },
                               {
-                                "Literal": {
-                                  "Int": 20
-                                }
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 20
+                                    }
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "y"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Literal": {
-                      "Int": 5
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              ]
             },
             {
-              "Literal": {
-                "Int": 100
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 100
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
@@ -1,76 +1,84 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 35
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 100
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 35
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 100
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 35
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 100
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "y"
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 35
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 100
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
@@ -18,6 +18,15 @@ true
 
 --
 
+Or([Or([a, b]), false]),
+true,
+And([c, true]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([Or([a, b]), false]),
+And([c, true]) 
+
+--
+
 Or([Or([a, b]), false]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 Or([Or([a, b])]) 
@@ -51,6 +60,5 @@ find c: bool
 such that
 
 Or([a, b]),
-true,
 c
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace.json
@@ -93,6 +93,236 @@
   },
   {
     "initial_expression": {
+      "Root": [
+        [
+          {
+            "And": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": true
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": false
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "And": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": true
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Atomic": [
+                    {
+                      "Literal": {
+                        "Bool": false
+                      }
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
       "Or": [
         [
           {
@@ -402,6 +632,6 @@
     }
   },
   {
-    "Number of rules applied": 5
+    "Number of rules applied": 6
   }
 ]

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-parse.serialised.json
@@ -1,173 +1,181 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Or": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Atomic": [
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Reference": {
-                        "UserName": "a"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
                     }
                   ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
+                ]
               },
               {
-                "Literal": {
-                  "Bool": false
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": false
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
+          ]
+        },
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "AllDiff": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Atomic": [
+                "AllDiff": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
                     {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 1
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Literal": {
-                        "Int": 1
-                      }
-                    }
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
                     },
                     {
-                      "Literal": {
-                        "Int": 2
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
                     }
                   ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
+                ]
               },
               {
-                "Literal": {
-                  "Bool": true
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": true
+                    }
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "And": [
+          ]
+        },
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "c"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "c"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Bool": true
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Literal": {
-                  "Bool": true
-                }
-              }
-            ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
@@ -1,68 +1,63 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Atomic": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
               },
               {
-                "Reference": {
-                  "UserName": "a"
-                }
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
+          ]
+        },
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "c"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
+            }
+          ]
         }
       ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "c"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-parse.serialised.json
@@ -1,120 +1,128 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "a"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "c"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 4
+                  }
+                }
+              ]
+            }
           ]
         },
         {
-          "Atomic": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 4
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "a"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    },
-    {
-      "Geq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "b"
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
@@ -1,97 +1,105 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 4
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 4
-                }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/experiment/works/max2/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input.expected-parse.serialised.json
@@ -1,143 +1,151 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Max": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
+            {
+              "Max": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "a"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 2
                   }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
+                }
+              ]
             }
           ]
         },
         {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Max": [
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Max": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "a"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Literal": {
-                      "Int": 1
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
+              ]
+            }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/experiment/works/max2/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input.expected-rewrite.serialised.json
@@ -1,327 +1,335 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Literal": {
-            "Int": 2
-          }
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
+              },
+              {
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "MachineName": 0
+                      }
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ],
+                  {
+                    "Reference": {
+                      "UserName": "x"
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         },
         {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
         }
       ]
-    },
-    {
-      "And": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "MachineName": 0
-                  }
-                },
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                }
-              ],
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        },
-        {
-          "Int": 0
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/diseq/input.expected-rewrite.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
+                  "Literal": {
+                    "Int": 5
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 5
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "y"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 5
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -33,29 +54,16 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "z"
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "z"
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "y"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "z"
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-parse.serialised.json
@@ -1,29 +1,16 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                }
-              ]
             },
             {
               "UnsafeDiv": [
@@ -39,44 +26,65 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "y"
+                        "UserName": "x"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-rewrite.serialised.json
@@ -1,153 +1,161 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionDivEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 10
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "MachineName": 1
+                      "UserName": "x"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Reference": {
-                      "UserName": "z"
+                      "MachineName": 0
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 10
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "y"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-parse.serialised.json
@@ -1,29 +1,16 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                }
-              ]
             },
             {
               "UnsafeDiv": [
@@ -39,44 +26,65 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "y"
+                        "UserName": "x"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeDiv": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Literal": {
-                "Int": 10
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 10
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
@@ -1,187 +1,195 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 10
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 1
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
               }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+            },
+            {
+              "Reference": {
+                "MachineName": 2
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 2
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 2
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 3,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-parse.serialised.json
@@ -1,35 +1,22 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "UnsafeDiv": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    }
-                  ]
                 },
                 {
                   "UnsafeDiv": [
@@ -45,46 +32,67 @@
                         },
                         {
                           "Reference": {
-                            "UserName": "y"
+                            "UserName": "x"
                           }
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "UnsafeDiv": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "z"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 10
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 10
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -1,93 +1,67 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               {
-                "Atomic": [
+                "MinionDivEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "MachineName": 0
+                      "UserName": "y"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "MinionDivEqUndefZero": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              }
-            ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Reference": {
                       "UserName": "z"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Literal": {
@@ -95,59 +69,93 @@
                     }
                   }
                 ]
+              },
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionDivEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionDivEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/eq/input.expected-rewrite.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Lt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Lt": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-01-strict-less-than/input.expected-rewrite.serialised.json
@@ -1,31 +1,39 @@
 {
-  "constraints": [
-    {
-      "FlatSumGeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Reference": {
-              "UserName": "y"
+          "FlatSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Literal": {
+                  "Int": -1
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "x"
+              }
             }
-          },
-          {
-            "Literal": {
-              "Int": -1
-            }
-          }
-        ],
-        {
-          "Reference": {
-            "UserName": "x"
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-02-leq/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Int": 0
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
             }
-          ]
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              }
-            ]
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-03-leq-plus-k/input.expected-rewrite.serialised.json
@@ -1,31 +1,39 @@
 {
-  "constraints": [
-    {
-      "FlatSumGeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Reference": {
-              "UserName": "y"
+          "FlatSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Literal": {
+                  "Int": 2
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "x"
+              }
             }
-          },
-          {
-            "Literal": {
-              "Int": 2
-            }
-          }
-        ],
-        {
-          "Reference": {
-            "UserName": "x"
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-04-strict-greater-than/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-04-strict-greater-than/input.expected-parse.serialised.json
@@ -1,40 +1,48 @@
 {
-  "constraints": [
-    {
-      "Gt": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Gt": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "y"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "y"
+                  }
+                }
+              ]
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-04-strict-greater-than/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-04-strict-greater-than/input.expected-rewrite.serialised.json
@@ -1,27 +1,35 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Int": -1
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Int": -1
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input.expected-parse.serialised.json
@@ -1,16 +1,50 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Minus": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
+            },
+            {
+              "Minus": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "Atomic": [
@@ -20,9 +54,61 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "x"
                   }
                 }
+              ]
+            }
+          ]
+        },
+        {
+          "Geq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Neg": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 1
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  }
+                ]
               ]
             },
             {
@@ -32,95 +118,17 @@
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 1
+                  "Reference": {
+                    "UserName": "x"
                   }
                 }
               ]
             }
           ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
         }
       ]
-    },
-    {
-      "Geq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Neg": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 1
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input.expected-rewrite.serialised.json
@@ -1,48 +1,56 @@
 {
-  "constraints": [
-    {
-      "FlatIneq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Int": -1
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Int": -1
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Int": -1
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Int": -1
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input.expected-parse.serialised.json
@@ -1,26 +1,13 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Minus": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
@@ -33,10 +20,52 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "x"
                   }
                 }
               ]
+            },
+            {
+              "Minus": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Leq": [
+            {
+              "clean": false,
+              "etype": null
             },
             {
               "Atomic": [
@@ -45,47 +74,39 @@
                   "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 1
+                  "Reference": {
+                    "UserName": "x"
                   }
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Leq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
-            }
-          ]
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Neg": [
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
+                    "Neg": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 1
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "Atomic": [
@@ -94,33 +115,20 @@
                         "etype": null
                       },
                       {
-                        "Literal": {
-                          "Int": 1
+                        "Reference": {
+                          "UserName": "y"
                         }
                       }
                     ]
                   }
                 ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              }
-            ]
+              ]
+            }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input.expected-rewrite.serialised.json
@@ -1,56 +1,64 @@
 {
-  "constraints": [
-    {
-      "FlatSumGeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "FlatSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              },
+              {
+                "Literal": {
+                  "Int": -1
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         },
-        [
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          },
-          {
-            "Literal": {
-              "Int": -1
-            }
-          }
-        ],
         {
-          "Reference": {
-            "UserName": "x"
-          }
+          "FlatSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Literal": {
+                  "Int": -1
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "FlatSumGeq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Literal": {
-              "Int": -1
-            }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          }
-        ],
-        {
-          "Reference": {
-            "UserName": "x"
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -32,30 +53,17 @@
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "y"
+                  "Literal": {
+                    "Int": 3
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 3
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionModuloEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 3
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "y"
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 3
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-parse.serialised.json
@@ -1,27 +1,48 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
+              "UnsafeMod": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Reference": {
-                    "UserName": "x"
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "x"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "y"
+                      }
+                    }
+                  ]
                 }
               ]
             },
@@ -33,29 +54,16 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "y"
+                    "UserName": "z"
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "z"
-              }
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-rewrite.serialised.json
@@ -1,73 +1,81 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionModuloEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
+                      "UserName": "x"
+                    }
+                  },
+                  {
+                    "Reference": {
                       "UserName": "y"
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "z"
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-parse.serialised.json
@@ -1,29 +1,16 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                }
-              ]
             },
             {
               "UnsafeMod": [
@@ -39,44 +26,65 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "y"
+                        "UserName": "x"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeMod": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Literal": {
-                "Int": 3
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 3
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-rewrite.serialised.json
@@ -1,153 +1,161 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionModuloEqUndefZero": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "x"
-                }
-              },
-              {
-                "Reference": {
-                  "MachineName": 0
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 3
-                }
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "MachineName": 1
+                      "UserName": "x"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Reference": {
-                      "UserName": "z"
+                      "MachineName": 0
+                    }
+                  },
+                  {
+                    "Literal": {
+                      "Int": 3
                     }
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "y"
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-parse.serialised.json
@@ -1,29 +1,16 @@
 {
-  "constraints": [
-    {
-      "Neq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
+          "Neq": [
             {
               "clean": false,
               "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "x"
-                  }
-                }
-              ]
             },
             {
               "UnsafeMod": [
@@ -39,44 +26,65 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "y"
+                        "UserName": "x"
                       }
                     }
                   ]
                 },
                 {
-                  "Atomic": [
+                  "UnsafeMod": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "y"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
-              "Literal": {
-                "Int": 3
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 3
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
@@ -1,187 +1,195 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "MachineName": 0
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
                   }
                 ]
               },
               {
-                "Atomic": [
+                "Neq": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Literal": {
-                      "Int": 3
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 1
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+          ]
+        },
+        {
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
               }
-            ]
-          },
-          {
-            "Neq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
+            },
+            {
+              "Reference": {
+                "MachineName": 2
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 2
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 2
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 2
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 3,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-parse.serialised.json
@@ -1,35 +1,22 @@
 {
-  "constraints": [
-    {
-      "Not": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
+          "Not": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "UnsafeMod": [
+              "Eq": [
                 {
                   "clean": false,
                   "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    }
-                  ]
                 },
                 {
                   "UnsafeMod": [
@@ -45,46 +32,67 @@
                         },
                         {
                           "Reference": {
-                            "UserName": "y"
+                            "UserName": "x"
                           }
                         }
                       ]
                     },
                     {
-                      "Atomic": [
+                      "UnsafeMod": [
                         {
                           "clean": false,
                           "etype": null
                         },
                         {
-                          "Reference": {
-                            "UserName": "z"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ]
                         }
                       ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
-                  "Literal": {
-                    "Int": 3
-                  }
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -1,93 +1,67 @@
 {
-  "constraints": [
-    {
-      "Or": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Neq": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "Neq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "MachineName": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               {
-                "Atomic": [
+                "MinionModuloEqUndefZero": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
                     "Reference": {
-                      "MachineName": 0
+                      "UserName": "y"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "MinionModuloEqUndefZero": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "y"
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "z"
-                }
-              },
-              {
-                "Literal": {
-                  "Int": 0
-                }
-              }
-            ]
-          },
-          {
-            "Eq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Reference": {
                       "UserName": "z"
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
                     "Literal": {
@@ -95,59 +69,93 @@
                     }
                   }
                 ]
+              },
+              {
+                "Eq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Reference": {
-            "UserName": "x"
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "x"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "y"
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "z"
+              }
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "y"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "z"
-          }
-        },
-        {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 2,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Geq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "z"
-              }
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "x"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "z"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumgeq/input.expected-rewrite.serialised.json
@@ -1,31 +1,39 @@
 {
-  "constraints": [
-    {
-      "FlatSumGeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Reference": {
-              "UserName": "x"
+          "FlatSumGeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "z"
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          }
-        ],
-        {
-          "Reference": {
-            "UserName": "z"
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-parse.serialised.json
@@ -1,63 +1,71 @@
 {
-  "constraints": [
-    {
-      "Leq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Atomic": [
+          "Leq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "z"
-              }
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "x"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "y"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "z"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/sumleq/input.expected-rewrite.serialised.json
@@ -1,31 +1,39 @@
 {
-  "constraints": [
-    {
-      "FlatSumLeq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Reference": {
-              "UserName": "x"
+          "FlatSumLeq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Reference": {
+                  "UserName": "x"
+                }
+              },
+              {
+                "Reference": {
+                  "UserName": "y"
+                }
+              }
+            ],
+            {
+              "Reference": {
+                "UserName": "z"
+              }
             }
-          },
-          {
-            "Reference": {
-              "UserName": "y"
-            }
-          }
-        ],
-        {
-          "Reference": {
-            "UserName": "z"
-          }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
@@ -40,15 +40,96 @@ true
 
 --
 
+true,
+Or([(a) -> (z), (z) -> (a)]),
+Or([(b) -> (c), (b) -> (Not(c))]),
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([(a) -> (z), (z) -> (a)]),
+Or([(b) -> (c), (b) -> (Not(c))]),
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
+
+--
+
 Or([(a) -> (z), (z) -> (a)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 true 
 
 --
 
+true,
+Or([(b) -> (c), (b) -> (Not(c))]),
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+Or([(b) -> (c), (b) -> (Not(c))]),
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
+
+--
+
 Or([(b) -> (c), (b) -> (Not(c))]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
 true 
+
+--
+
+true,
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+((l = 10)) -> ((l = 10)),
+Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
+Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+(o = n),
+(d = (n < 6)),
+(p = m % 2),
+Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
+Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
+Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
+Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
 
 --
 
@@ -1152,9 +1233,6 @@ find __14: bool
 
 such that
 
-true,
-true,
-true,
 ReifyImply((l = 10), __0),
 Or([ReifyImply(ModEq(m, 2, 0), __1), ReifyImply(Ineq(n, 5, 0), __2)]),
 Or([ReifyImply(ModEq(m, 2, 0), __3), a, b, ReifyImply(Ineq(n, 5, 0), __4)]),

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace.json
@@ -55,6 +55,3402 @@
   },
   {
     "initial_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "a"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "z"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
       "Or": [
         [
           {
@@ -144,6 +3540,3246 @@
             "Bool": true
           }
         },
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "c"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
@@ -250,6 +6886,3074 @@
             "Bool": true
           }
         },
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    }
+  },
+  {
+    "initial_expression": {
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
+        {
+          "clean": false,
+          "etype": null
+        }
+      ]
+    },
+    "rule_name": "partial_evaluator",
+    "rule_priority": 9000,
+    "rule_set": {
+      "name": "Base"
+    },
+    "transformed_expression": {
+      "Root": [
+        [
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Lt": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 6
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "n"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "o"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Reference": {
+                      "UserName": "p"
+                    }
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Imply": [
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "Eq": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 10
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Reference": {
+                          "UserName": "l"
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "p"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "o"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Atomic": [
+                        {
+                          "Reference": {
+                            "UserName": "d"
+                          }
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "p"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "o"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeMod": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "m"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 0
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeMod": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "m"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Lt": [
+                        {
+                          "Atomic": [
+                            {
+                              "Literal": {
+                                "Int": 6
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "n"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Or": [
+              [
+                {
+                  "Imply": [
+                    {
+                      "Eq": [
+                        {
+                          "Atomic": [
+                            {
+                              "Reference": {
+                                "UserName": "r"
+                              }
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "UnsafeDiv": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "q"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "Not": [
+                        {
+                          "Lt": [
+                            {
+                              "Atomic": [
+                                {
+                                  "Literal": {
+                                    "Int": 6
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "n"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "clean": false,
+                              "etype": null
+                            }
+                          ]
+                        },
+                        {
+                          "clean": false,
+                          "etype": null
+                        }
+                      ]
+                    },
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                },
+                {
+                  "Or": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "Reference": {
+                                    "UserName": "a"
+                                  }
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            },
+                            {
+                              "Imply": [
+                                {
+                                  "Eq": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "r"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "UnsafeDiv": [
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Literal": {
+                                                "Int": 2
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "Reference": {
+                                                "UserName": "q"
+                                              }
+                                            },
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Lt": [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "Reference": {
+                                            "UserName": "n"
+                                          }
+                                        },
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    }
+                                  ]
+                                },
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                }
+                              ]
+                            }
+                          ],
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "clean": false,
+                      "etype": null
+                    }
+                  ]
+                }
+              ],
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
@@ -19580,6 +29284,6 @@
     }
   },
   {
-    "Number of rules applied": 173
+    "Number of rules applied": 176
   }
 ]

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-parse.serialised.json
@@ -1,182 +1,148 @@
 {
-  "constraints": [
-    {
-      "Imply": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
+          "Imply": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "x"
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "x"
+                  }
+                }
+              ]
             }
           ]
         },
         {
-          "Atomic": [
+          "Or": [
             {
               "clean": false,
               "etype": null
             },
-            {
-              "Reference": {
-                "UserName": "x"
+            [
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "z"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "a"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
-            }
+            ]
           ]
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
         },
-        [
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Imply": [
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "Not": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "b"
+                        }
+                      }
+                    ]
                   },
                   {
                     "Atomic": [
@@ -192,103 +158,9 @@
                     ]
                   }
                 ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Imply": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "l"
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 10
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Eq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "UserName": "l"
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 10
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
               },
               {
-                "Lt": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
@@ -301,34 +173,13 @@
                       },
                       {
                         "Reference": {
-                          "UserName": "n"
+                          "UserName": "b"
                         }
                       }
                     ]
                   },
                   {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 6
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeMod": [
+                    "Not": [
                       {
                         "clean": false,
                         "etype": null
@@ -341,212 +192,327 @@
                           },
                           {
                             "Reference": {
-                              "UserName": "m"
+                              "UserName": "c"
                             }
                           }
                         ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
                       }
                     ]
                   }
                 ]
               }
             ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeMod": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "m"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Lt": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 6
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
-        [
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
+        {
+          "Imply": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Eq": [
                 {
-                  "Or": [
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
                     {
                       "clean": false,
                       "etype": null
                     },
-                    [
+                    {
+                      "Reference": {
+                        "UserName": "l"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 10
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Eq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "l"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 10
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Lt": [
                       {
-                        "Imply": [
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Lt": [
+                            "Reference": {
+                              "UserName": "n"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 6
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeMod": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Reference": {
-                                      "UserName": "n"
-                                    }
-                                  }
-                                ]
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Literal": {
-                                      "Int": 6
-                                    }
-                                  }
-                                ]
+                                "Reference": {
+                                  "UserName": "m"
+                                }
                               }
                             ]
                           },
                           {
-                            "Eq": [
+                            "Atomic": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "UnsafeMod": [
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeMod": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Lt": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "n"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 6
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Or": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        [
+                          {
+                            "Imply": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Lt": [
                                   {
                                     "clean": false,
                                     "etype": null
@@ -559,7 +525,7 @@
                                       },
                                       {
                                         "Reference": {
-                                          "UserName": "m"
+                                          "UserName": "n"
                                         }
                                       }
                                     ]
@@ -572,7 +538,7 @@
                                       },
                                       {
                                         "Literal": {
-                                          "Int": 2
+                                          "Int": 6
                                         }
                                       }
                                     ]
@@ -580,17 +546,135 @@
                                 ]
                               },
                               {
-                                "Atomic": [
+                                "Eq": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   {
-                                    "Literal": {
-                                      "Int": 0
-                                    }
+                                    "UnsafeMod": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Reference": {
+                                              "UserName": "m"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Literal": {
+                                              "Int": 2
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 0
+                                        }
+                                      }
+                                    ]
                                   }
                                 ]
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeMod": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
                               }
                             ]
                           }
@@ -603,45 +687,16 @@
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "a"
+                            "Literal": {
+                              "Int": 0
                             }
                           }
                         ]
                       }
                     ]
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ]
-                }
-              ]
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
                   },
                   {
-                    "UnsafeMod": [
+                    "Lt": [
                       {
                         "clean": false,
                         "etype": null
@@ -654,7 +709,7 @@
                           },
                           {
                             "Reference": {
-                              "UserName": "m"
+                              "UserName": "n"
                             }
                           }
                         ]
@@ -667,125 +722,36 @@
                           },
                           {
                             "Literal": {
-                              "Int": 2
+                              "Int": 6
                             }
                           }
                         ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Lt": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 6
-                        }
                       }
                     ]
                   }
                 ]
               }
             ]
-          }
-        ]
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
+          ]
         },
         {
-          "Atomic": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "o"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "n"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "d"
-              }
-            }
-          ]
-        },
-        {
-          "Lt": [
-            {
-              "clean": false,
-              "etype": null
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "o"
+                  }
+                }
+              ]
             },
             {
               "Atomic": [
@@ -799,45 +765,11 @@
                   }
                 }
               ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 6
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "p"
-              }
             }
           ]
         },
         {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
@@ -850,302 +782,16 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "m"
+                    "UserName": "d"
                   }
                 }
               ]
             },
             {
-              "Atomic": [
+              "Lt": [
                 {
                   "clean": false,
                   "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Lt": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "o"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 6
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "p"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeMod": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "m"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Or": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    [
-                      {
-                        "Imply": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Lt": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Reference": {
-                                      "UserName": "o"
-                                    }
-                                  }
-                                ]
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Literal": {
-                                      "Int": 6
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          {
-                            "Eq": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Reference": {
-                                      "UserName": "p"
-                                    }
-                                  }
-                                ]
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Literal": {
-                                      "Int": 0
-                                    }
-                                  }
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "a"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  ]
                 },
                 {
                   "Atomic": [
@@ -1155,260 +801,92 @@
                     },
                     {
                       "Reference": {
-                        "UserName": "b"
+                        "UserName": "n"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 6
                       }
                     }
                   ]
                 }
               ]
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeMod": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "m"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
+            }
+          ]
         },
-        [
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeDiv": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "q"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "r"
-                        }
-                      }
-                    ]
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "p"
                   }
-                ]
-              },
-              {
-                "Lt": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
-                        }
+                }
+              ]
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "m"
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 6
-                        }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
                       }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "Imply": [
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UnsafeDiv": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "q"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 2
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "r"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Not": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
@@ -1427,7 +905,7 @@
                           },
                           {
                             "Reference": {
-                              "UserName": "n"
+                              "UserName": "o"
                             }
                           }
                         ]
@@ -1446,49 +924,151 @@
                         ]
                       }
                     ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "Or": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Or": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    [
+                  },
+                  {
+                    "Eq": [
                       {
-                        "Imply": [
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Eq": [
+                            "Reference": {
+                              "UserName": "p"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeMod": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "UnsafeDiv": [
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "d"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Or": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        [
+                          {
+                            "Imply": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Lt": [
                                   {
                                     "clean": false,
                                     "etype": null
@@ -1501,7 +1081,7 @@
                                       },
                                       {
                                         "Reference": {
-                                          "UserName": "q"
+                                          "UserName": "o"
                                         }
                                       }
                                     ]
@@ -1514,7 +1094,7 @@
                                       },
                                       {
                                         "Literal": {
-                                          "Int": 2
+                                          "Int": 6
                                         }
                                       }
                                     ]
@@ -1522,116 +1102,116 @@
                                 ]
                               },
                               {
-                                "Atomic": [
+                                "Eq": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   {
-                                    "Reference": {
-                                      "UserName": "r"
-                                    }
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "p"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 0
+                                        }
+                                      }
+                                    ]
                                   }
                                 ]
                               }
                             ]
                           },
                           {
-                            "Lt": [
+                            "Atomic": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Reference": {
-                                      "UserName": "n"
-                                    }
-                                  }
-                                ]
-                              },
-                              {
-                                "Atomic": [
-                                  {
-                                    "clean": false,
-                                    "etype": null
-                                  },
-                                  {
-                                    "Literal": {
-                                      "Int": 6
-                                    }
-                                  }
-                                ]
+                                "Reference": {
+                                  "UserName": "a"
+                                }
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "a"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  ]
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
+                      ]
                     },
                     {
-                      "Reference": {
-                        "UserName": "b"
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            ]
-          },
-          {
-            "Imply": [
-              {
-                "clean": false,
-                "etype": null
+                ]
               },
               {
-                "Eq": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
                   },
                   {
-                    "UnsafeDiv": [
+                    "Eq": [
                       {
                         "clean": false,
                         "etype": null
                       },
                       {
-                        "Atomic": [
+                        "UnsafeMod": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "q"
-                            }
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
                           }
                         ]
                       },
@@ -1643,7 +1223,7 @@
                           },
                           {
                             "Literal": {
-                              "Int": 2
+                              "Int": 0
                             }
                           }
                         ]
@@ -1658,18 +1238,83 @@
                       },
                       {
                         "Reference": {
-                          "UserName": "r"
+                          "UserName": "d"
                         }
                       }
                     ]
                   }
                 ]
-              },
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "Not": [
+                "Imply": [
                   {
                     "clean": false,
                     "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeDiv": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "q"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "r"
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "Lt": [
@@ -1706,13 +1351,376 @@
                     ]
                   }
                 ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeDiv": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "q"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "r"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Not": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Lt": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 6
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
-          }
-        ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "Or": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Or": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        [
+                          {
+                            "Imply": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Eq": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "UnsafeDiv": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Reference": {
+                                              "UserName": "q"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "Atomic": [
+                                          {
+                                            "clean": false,
+                                            "etype": null
+                                          },
+                                          {
+                                            "Literal": {
+                                              "Int": 2
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "r"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Lt": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "n"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 6
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Reference": {
+                            "UserName": "b"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              },
+              {
+                "Imply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeDiv": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "q"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "r"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Not": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Lt": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 6
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-rewrite.serialised.json
@@ -1,49 +1,243 @@
 {
-  "constraints": [
-    {
-      "Atomic": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
+          "MinionReifyImply": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Eq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "l"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 10
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
         },
         {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "MinionModuloEqUndefZero": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 1
+                    }
+                  }
+                ]
+              },
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatIneq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      },
+                      {
+                        "Int": 0
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 2
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
         },
         {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "MinionReifyImply": [
-        {
-          "clean": false,
-          "etype": null
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "MinionModuloEqUndefZero": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "m"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 3
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
+              },
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatIneq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      },
+                      {
+                        "Int": 0
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 4
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
         },
         {
           "Eq": [
@@ -59,671 +253,10 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "l"
+                    "UserName": "o"
                   }
                 }
               ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 10
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "m"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 1
-                }
-              }
-            ]
-          },
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "n"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 2
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "m"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 3
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
-              }
-            ]
-          },
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "n"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 4
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "o"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "n"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "n"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
-            }
-          ]
-        },
-        {
-          "Reference": {
-            "UserName": "d"
-          }
-        }
-      ]
-    },
-    {
-      "MinionModuloEqUndefZero": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "m"
-          }
-        },
-        {
-          "Literal": {
-            "Int": 2
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "p"
-          }
-        }
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "p"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 5
-                }
-              }
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "MachineName": 6
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "d"
-                }
-              },
-              {
-                "Int": 0
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "p"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 7
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
-              }
-            ]
-          },
-          {
-            "FlatIneq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "MachineName": 8
-                }
-              },
-              {
-                "Reference": {
-                  "UserName": "d"
-                }
-              },
-              {
-                "Int": 0
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "n"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 9
-                }
-              }
-            ]
-          },
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatWatchedLiteral": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "MachineName": 11
-                  },
-                  {
-                    "Bool": false
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 10
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "Or": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "n"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 12
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "a"
-                }
-              }
-            ]
-          },
-          {
-            "Atomic": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "Reference": {
-                  "UserName": "b"
-                }
-              }
-            ]
-          },
-          {
-            "MinionReifyImply": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              {
-                "FlatWatchedLiteral": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "MachineName": 14
-                  },
-                  {
-                    "Bool": false
-                  }
-                ]
-              },
-              {
-                "Reference": {
-                  "MachineName": 13
-                }
-              }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Eq": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
               "Atomic": [
@@ -733,526 +266,962 @@
                 },
                 {
                   "Reference": {
-                    "UserName": "l"
+                    "UserName": "n"
                   }
                 }
               ]
+            }
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
             },
             {
-              "Atomic": [
+              "FlatIneq": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
+                  "Reference": {
+                    "UserName": "n"
+                  }
+                },
+                {
                   "Literal": {
-                    "Int": 10
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
+              "Reference": {
+                "UserName": "d"
+              }
+            }
+          ]
+        },
+        {
+          "MinionModuloEqUndefZero": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "m"
+              }
+            },
+            {
+              "Literal": {
+                "Int": 2
+              }
+            },
+            {
+              "Reference": {
+                "UserName": "p"
+              }
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "p"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 5
+                    }
+                  }
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 6
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "p"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 7
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
+              },
+              {
+                "FlatIneq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 8
+                    }
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "d"
+                    }
+                  },
+                  {
+                    "Int": 0
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatIneq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      },
+                      {
+                        "Int": 0
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 9
+                    }
+                  }
+                ]
+              },
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatWatchedLiteral": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "MachineName": 11
+                      },
+                      {
+                        "Bool": false
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 10
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatIneq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "n"
+                        }
+                      },
+                      {
+                        "Literal": {
+                          "Int": 5
+                        }
+                      },
+                      {
+                        "Int": 0
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 12
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "a"
+                    }
+                  }
+                ]
+              },
+              {
+                "Atomic": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "Reference": {
+                      "UserName": "b"
+                    }
+                  }
+                ]
+              },
+              {
+                "MinionReifyImply": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  {
+                    "FlatWatchedLiteral": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "MachineName": 14
+                      },
+                      {
+                        "Bool": false
+                      }
+                    ]
+                  },
+                  {
+                    "Reference": {
+                      "MachineName": 13
+                    }
+                  }
+                ]
+              }
+            ]
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Eq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "l"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 10
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 0
+              }
+            }
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "n"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
+              "Reference": {
+                "MachineName": 1
+              }
+            }
+          ]
+        },
+        {
+          "MinionReify": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "MinionModuloEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "m"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 0
                   }
                 }
               ]
+            },
+            {
+              "Reference": {
+                "MachineName": 2
+              }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 0
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "n"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "n"
+                "MachineName": 3
               }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 1
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionModuloEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionModuloEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "m"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 0
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "m"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Literal": {
-                "Int": 0
+                "MachineName": 4
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 2
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "o"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "n"
+                "MachineName": 5
               }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 3
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionModuloEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionModuloEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "m"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 0
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "m"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Literal": {
-                "Int": 0
+                "MachineName": 6
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 4
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "o"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "o"
+                "MachineName": 7
               }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 5
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionModuloEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionModuloEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "m"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 0
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "m"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Literal": {
-                "Int": 0
+                "MachineName": 8
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 6
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionDivEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "q"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Reference": {
+                    "UserName": "r"
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "o"
+                "MachineName": 9
               }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 7
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionModuloEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionDivEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "q"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Reference": {
+                    "UserName": "r"
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "m"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Literal": {
-                "Int": 0
+                "MachineName": 10
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 8
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionDivEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "q"
-              }
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "n"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
             },
             {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
               "Reference": {
-                "UserName": "r"
+                "MachineName": 11
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 9
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionDivEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "q"
-              }
+              "MinionDivEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "q"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Reference": {
+                    "UserName": "r"
+                  }
+                }
+              ]
             },
             {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
               "Reference": {
-                "UserName": "r"
+                "MachineName": 12
               }
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 10
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
+              "MinionDivEqUndefZero": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "q"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 2
+                  }
+                },
+                {
+                  "Reference": {
+                    "UserName": "r"
+                  }
+                }
+              ]
+            },
+            {
               "Reference": {
-                "UserName": "n"
+                "MachineName": 13
               }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
             }
           ]
         },
         {
-          "Reference": {
-            "MachineName": 11
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionDivEqUndefZero": [
+          "MinionReify": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Reference": {
-                "UserName": "q"
-              }
+              "FlatIneq": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "n"
+                  }
+                },
+                {
+                  "Literal": {
+                    "Int": 5
+                  }
+                },
+                {
+                  "Int": 0
+                }
+              ]
             },
             {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
               "Reference": {
-                "UserName": "r"
+                "MachineName": 14
               }
             }
           ]
-        },
-        {
-          "Reference": {
-            "MachineName": 12
-          }
         }
       ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "MinionDivEqUndefZero": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "q"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 2
-              }
-            },
-            {
-              "Reference": {
-                "UserName": "r"
-              }
-            }
-          ]
-        },
-        {
-          "Reference": {
-            "MachineName": 13
-          }
-        }
-      ]
-    },
-    {
-      "MinionReify": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "FlatIneq": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "n"
-              }
-            },
-            {
-              "Literal": {
-                "Int": 5
-              }
-            },
-            {
-              "Int": 0
-            }
-          ]
-        },
-        {
-          "Reference": {
-            "MachineName": 14
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 15,
     "table": [

--- a/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar-expected-rule-trace-human.txt
@@ -15,50 +15,16 @@ true
 
 --
 
-(UnsafeDiv(3, 2) = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(-(3), 2) = -(2)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(3, -(2)) = -(2)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(-(3), -(2)) = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(3 % 2 = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(3 % -(2) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(-(3) % 2 = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(-(3) % -(2) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+(UnsafeDiv(3, 2) = 1),
+(UnsafeDiv(-(3), 2) = -(2)),
+(UnsafeDiv(3, -(2)) = -(2)),
+(UnsafeDiv(-(3), -(2)) = 1),
+(3 % 2 = 1),
+(3 % -(2) = -(1)),
+(-(3) % 2 = 1),
+(-(3) % -(2) = -(1)),
+true, 
+   ~~> eval_root ([("Constant", 9001)]) 
 true 
 
 --
@@ -68,13 +34,5 @@ Final model:
 
 such that
 
-true,
-true,
-true,
-true,
-true,
-true,
-true,
-true,
 true
 

--- a/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar-expected-rule-trace.json
@@ -1,594 +1,586 @@
 [
   {
     "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
                   }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
                       }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
                       }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
         }
       ]
     },
-    "rule_name": "apply_eval_constant",
+    "rule_name": "eval_root",
     "rule_priority": 9001,
     "rule_set": {
       "name": "Constant"
     },
     "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
           }
-        },
+        ],
         {
           "clean": false,
           "etype": null
@@ -597,105 +589,6 @@
     }
   },
   {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "Number of rules applied": 8
+    "Number of rules applied": 1
   }
 ]

--- a/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar.expected-parse.serialised.json
@@ -1,74 +1,19 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
@@ -85,77 +30,6 @@
                       }
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
                   "Atomic": [
@@ -171,211 +45,6 @@
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
               "Atomic": [
@@ -391,89 +60,39 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
         },
         {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Neg": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Atomic": [
+                  "Neg": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Literal": {
-                        "Int": 3
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
                   "Atomic": [
@@ -483,7 +102,7 @@
                     },
                     {
                       "Literal": {
-                        "Int": 3
+                        "Int": 2
                       }
                     }
                   ]
@@ -514,10 +133,131 @@
           ]
         },
         {
-          "Neg": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
             {
               "Atomic": [
@@ -533,23 +273,291 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
         },
         {
-          "Literal": {
-            "Bool": true
-          }
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": []

--- a/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod-novar/divide-mod-novar.expected-rewrite.serialised.json
@@ -1,123 +1,27 @@
 {
-  "constraints": [
-    {
-      "Atomic": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": []

--- a/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod-expected-rule-trace-human.txt
@@ -16,50 +16,16 @@ true
 
 --
 
-(UnsafeDiv(3, 2) = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(-(3), 2) = -(2)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(3, -(2)) = -(2)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(UnsafeDiv(-(3), -(2)) = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(3 % 2 = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(3 % -(2) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(-(3) % 2 = 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
-true 
-
---
-
-(-(3) % -(2) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+(UnsafeDiv(3, 2) = 1),
+(UnsafeDiv(-(3), 2) = -(2)),
+(UnsafeDiv(3, -(2)) = -(2)),
+(UnsafeDiv(-(3), -(2)) = 1),
+(3 % 2 = 1),
+(3 % -(2) = -(1)),
+(-(3) % 2 = 1),
+(-(3) % -(2) = -(1)),
+true, 
+   ~~> eval_root ([("Constant", 9001)]) 
 true 
 
 --
@@ -70,13 +36,5 @@ find x: int(1..1)
 
 such that
 
-true,
-true,
-true,
-true,
-true,
-true,
-true,
-true,
 true
 

--- a/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod-expected-rule-trace.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod-expected-rule-trace.json
@@ -1,594 +1,586 @@
 [
   {
     "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
                   }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
                       }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
                       }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Atomic": [
-            {
-              "Literal": {
-                "Int": 1
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
               }
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Atomic": [
+                  {
+                    "Literal": {
+                      "Int": 1
                     }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeMod": [
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          },
+          {
+            "Eq": [
+              {
+                "Neg": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "UnsafeDiv": [
+                  {
+                    "Atomic": [
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "Neg": [
+                      {
+                        "Atomic": [
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          },
+                          {
+                            "clean": false,
+                            "etype": null
+                          }
+                        ]
+                      },
+                      {
+                        "clean": false,
+                        "etype": null
+                      }
+                    ]
+                  },
+                  {
+                    "clean": false,
+                    "etype": null
+                  }
+                ]
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
+          }
+        ],
         {
           "clean": false,
           "etype": null
         }
       ]
     },
-    "rule_name": "apply_eval_constant",
+    "rule_name": "eval_root",
     "rule_priority": 9001,
     "rule_set": {
       "name": "Constant"
     },
     "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
+      "Root": [
+        [
+          {
+            "Atomic": [
+              {
+                "Literal": {
+                  "Bool": true
+                }
+              },
+              {
+                "clean": false,
+                "etype": null
+              }
+            ]
           }
-        },
+        ],
         {
           "clean": false,
           "etype": null
@@ -597,105 +589,6 @@
     }
   },
   {
-    "initial_expression": {
-      "Eq": [
-        {
-          "Neg": [
-            {
-              "Atomic": [
-                {
-                  "Literal": {
-                    "Int": 1
-                  }
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "UnsafeMod": [
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "Atomic": [
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    },
-                    {
-                      "clean": false,
-                      "etype": null
-                    }
-                  ]
-                },
-                {
-                  "clean": false,
-                  "etype": null
-                }
-              ]
-            },
-            {
-              "clean": false,
-              "etype": null
-            }
-          ]
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    },
-    "rule_name": "apply_eval_constant",
-    "rule_priority": 9001,
-    "rule_set": {
-      "name": "Constant"
-    },
-    "transformed_expression": {
-      "Atomic": [
-        {
-          "Literal": {
-            "Bool": true
-          }
-        },
-        {
-          "clean": false,
-          "etype": null
-        }
-      ]
-    }
-  },
-  {
-    "Number of rules applied": 8
+    "Number of rules applied": 1
   }
 ]

--- a/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod.expected-parse.serialised.json
@@ -1,74 +1,19 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
@@ -85,77 +30,6 @@
                       }
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
                   "Atomic": [
@@ -171,211 +45,6 @@
                   ]
                 }
               ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeDiv": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 3
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 3
-                  }
-                }
-              ]
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Atomic": [
-                    {
-                      "clean": false,
-                      "etype": null
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Neg": [
-            {
-              "clean": false,
-              "etype": null
             },
             {
               "Atomic": [
@@ -391,89 +60,39 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
         },
         {
-          "UnsafeMod": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Neg": [
+              "UnsafeDiv": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "Atomic": [
+                  "Neg": [
                     {
                       "clean": false,
                       "etype": null
                     },
                     {
-                      "Literal": {
-                        "Int": 3
-                      }
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "Atomic": [
-                {
-                  "clean": false,
-                  "etype": null
-                },
-                {
-                  "Literal": {
-                    "Int": 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Literal": {
-                "Int": 1
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "Eq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "UnsafeMod": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Neg": [
-                {
-                  "clean": false,
-                  "etype": null
                 },
                 {
                   "Atomic": [
@@ -483,7 +102,7 @@
                     },
                     {
                       "Literal": {
-                        "Int": 3
+                        "Int": 2
                       }
                     }
                   ]
@@ -514,10 +133,131 @@
           ]
         },
         {
-          "Neg": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeDiv": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
             {
               "Atomic": [
@@ -533,23 +273,291 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
         },
         {
-          "Literal": {
-            "Bool": true
-          }
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 3
+                      }
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 2
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeMod": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 3
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Neg": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Atomic": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        {
+                          "Literal": {
+                            "Int": 2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Neg": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Literal": {
+                        "Int": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/savilerow/divide-mod/divide-mod.expected-rewrite.serialised.json
@@ -1,123 +1,27 @@
 {
-  "constraints": [
-    {
-      "Atomic": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
+          "Atomic": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Literal": {
+                "Bool": true
+              }
+            }
+          ]
         }
       ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    },
-    {
-      "Atomic": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Literal": {
-            "Bool": true
-          }
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-parse.serialised.json
@@ -1,120 +1,128 @@
 {
-  "constraints": [
-    {
-      "Eq": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Sum": [
+          "Eq": [
             {
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Sum": [
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
                   {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
+                    "Sum": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      [
                         {
-                          "clean": false,
-                          "etype": null
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            }
+                          ]
                         },
                         {
-                          "Reference": {
-                            "UserName": "a"
-                          }
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ]
                         }
                       ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
+                    ]
                   },
                   {
-                    "Reference": {
-                      "UserName": "c"
-                    }
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "c"
+                        }
+                      }
+                    ]
                   }
                 ]
-              }
-            ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 4
+                  }
+                }
+              ]
+            }
           ]
         },
         {
-          "Atomic": [
+          "Geq": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Int": 4
-              }
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "a"
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
             }
           ]
         }
       ]
-    },
-    {
-      "Geq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "a"
-              }
-            }
-          ]
-        },
-        {
-          "Atomic": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            {
-              "Reference": {
-                "UserName": "b"
-              }
-            }
-          ]
-        }
-      ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
@@ -1,97 +1,105 @@
 {
-  "constraints": [
-    {
-      "And": [
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
         {
-          "clean": false,
-          "etype": null
-        },
-        [
-          {
-            "FlatSumLeq": [
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            [
               {
-                "clean": false,
-                "etype": null
+                "FlatSumLeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                }
-              ],
               {
-                "Literal": {
-                  "Int": 4
-                }
+                "FlatSumGeq": [
+                  {
+                    "clean": false,
+                    "etype": null
+                  },
+                  [
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "b"
+                      }
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "c"
+                      }
+                    }
+                  ],
+                  {
+                    "Literal": {
+                      "Int": 4
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "FlatSumGeq": [
-              {
-                "clean": false,
-                "etype": null
-              },
-              [
-                {
-                  "Reference": {
-                    "UserName": "a"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "b"
-                  }
-                },
-                {
-                  "Reference": {
-                    "UserName": "c"
-                  }
-                }
-              ],
-              {
-                "Literal": {
-                  "Int": 4
-                }
+          ]
+        },
+        {
+          "FlatIneq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Reference": {
+                "UserName": "b"
               }
-            ]
-          }
-        ]
-      ]
-    },
-    {
-      "FlatIneq": [
-        {
-          "clean": false,
-          "etype": null
-        },
-        {
-          "Reference": {
-            "UserName": "b"
-          }
-        },
-        {
-          "Reference": {
-            "UserName": "a"
-          }
-        },
-        {
-          "Int": 0
+            },
+            {
+              "Reference": {
+                "UserName": "a"
+              }
+            },
+            {
+              "Int": 0
+            }
+          ]
         }
       ]
-    }
-  ],
+    ]
+  },
   "symbols": {
     "next_machine_name": 0,
     "table": [

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -1,12 +1,13 @@
 use std::collections::VecDeque;
 use std::process::exit;
 
+use conjure_core::rule_engine::rewrite_naive;
 use conjure_core::solver::SolverFamily;
 use conjure_core::{rule_engine::get_all_rules, rules::eval_constant};
 use conjure_oxide::{
     ast::*,
     get_rule_by_name,
-    rule_engine::{resolve_rule_sets, rewrite_model},
+    rule_engine::resolve_rule_sets,
     solver::{adaptors, Solver},
     Metadata, Model, Rule,
 };
@@ -656,12 +657,13 @@ fn rewrite_solve_xyz() {
     };
 
     // Apply rewrite function to the nested expression
-    let rewritten_expr = rewrite_model(
+    let rewritten_expr = rewrite_naive(
         &Model::new(SymbolTable::new(), vec![nested_expr], Default::default()),
         &rule_sets,
+        true,
     )
     .unwrap()
-    .constraints;
+    .get_constraints_vec();
 
     // Check if the expression is in its simplest form
 

--- a/crates/conjure_core/src/model.rs
+++ b/crates/conjure_core/src/model.rs
@@ -7,12 +7,14 @@ use serde::{Deserialize, Serialize};
 use uniplate::{Biplate, Tree, Uniplate};
 
 use crate::ast::{DecisionVariable, Domain, Expression, Name, SymbolTable};
+use crate::bug;
 use crate::context::Context;
 
 use crate::ast::pretty::{
     pretty_domain_letting_declaration, pretty_expressions_as_top_level,
     pretty_value_letting_declaration, pretty_variable_declaration,
 };
+use crate::metadata::Metadata;
 
 /// Represents a computational model containing variables, constraints, and a shared context.
 ///
@@ -37,7 +39,8 @@ use crate::ast::pretty::{
 #[derive(Derivative, Clone, Debug, Serialize, Deserialize)]
 #[derivative(PartialEq, Eq)]
 pub struct Model {
-    pub constraints: Vec<Expression>,
+    /// Top level constraints. This should be a `Expression::Root`.
+    constraints: Box<Expression>,
 
     symbols: SymbolTable,
 
@@ -55,7 +58,7 @@ impl Model {
     ) -> Model {
         Model {
             symbols,
-            constraints,
+            constraints: Box::new(Expression::Root(Metadata::new(), constraints)),
             context,
         }
     }
@@ -95,15 +98,19 @@ impl Model {
     }
 
     pub fn get_constraints_vec(&self) -> Vec<Expression> {
-        self.constraints.clone()
+        match *self.constraints {
+            Expression::Root(_, ref exprs) => exprs.clone(),
+            ref e => {
+                bug!(
+                    "get_constraints_vec: unexpected top level expression, {} ",
+                    e
+                );
+            }
+        }
     }
 
     pub fn set_constraints(&mut self, constraints: Vec<Expression>) {
-        if constraints.is_empty() {
-            self.constraints = Vec::new();
-        } else {
-            self.constraints = constraints;
-        }
+        self.constraints = Box::new(Expression::Root(Metadata::new(), constraints));
     }
 
     pub fn set_context(&mut self, context: Arc<RwLock<Context<'static>>>) {
@@ -111,7 +118,7 @@ impl Model {
     }
 
     pub fn add_constraint(&mut self, expression: Expression) {
-        // ToDo (gs248) - there is no checking whatsoever
+        // TODO (gs248): there is no checking whatsoever
         // We need to properly validate the expression but this is just for testing
         let mut constraints = self.get_constraints_vec();
         constraints.push(expression);
@@ -162,7 +169,7 @@ impl Biplate<Expression> for Model {
 
             let mut self3 = self2.clone();
             self3.symbols = (symtab_ctx)(fields[0].clone());
-            self3.constraints = (constraints_ctx)(fields[1].clone());
+            self3.constraints = Box::new((constraints_ctx)(fields[1].clone()));
             self3
         });
 
@@ -198,7 +205,11 @@ impl Display for Model {
 
         writeln!(f, "\nsuch that\n")?;
 
-        writeln!(f, "{}", pretty_expressions_as_top_level(&self.constraints))?;
+        writeln!(
+            f,
+            "{}",
+            pretty_expressions_as_top_level(&self.get_constraints_vec())
+        )?;
 
         Ok(())
     }

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -119,16 +119,16 @@ pub fn rewrite_model<'a>(
 
     //the while loop is exited when None is returned implying the sub-expression is clean
     let mut i: usize = 0;
-    while i < new_model.constraints.len() {
+    while i < new_model.get_constraints_vec().len() {
         while let Some(step) = rewrite_iteration(
-            &new_model.constraints[i],
+            &new_model.get_constraints_vec()[i],
             &new_model,
             &rules,
             apply_optimizations,
             &mut stats,
         ) {
             debug_assert!(is_vec_bool(&step.new_top)); // All new_top expressions should be boolean
-            new_model.constraints[i] = step.new_expression.clone();
+            new_model.get_constraints_vec()[i] = step.new_expression.clone();
             step.apply(&mut new_model); // Apply side-effects (e.g., symbol table updates)
         }
 

--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -101,7 +101,7 @@ impl Reduction {
     /// Applies side-effects (e.g. symbol table updates)
     pub fn apply(self, model: &mut Model) {
         model.extend_sym_table(self.symbols); // Add new assignments to the symbol table
-        model.constraints.extend(self.new_top.clone());
+        model.add_constraints(self.new_top.clone());
     }
 
     /// Gets symbols added by this reduction

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -28,6 +28,7 @@ fn remove_empty_expression(expr: &Expr, _: &Model) -> ApplicationResult {
     if matches!(
         expr,
         Atomic(_, _)
+            | Root(_, _)
             | FlatIneq(_, _, _, _)
             | FlatMinusEq(_, _, _)
             | FlatSumGeq(_, _, _)

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -3,7 +3,8 @@ use std::collections::HashSet;
 use conjure_core::ast::{Atom, Expression as Expr, Literal as Lit};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
+    register_rule, register_rule_set, ApplicationError, ApplicationError::RuleNotApplicable,
+    ApplicationResult, Reduction,
 };
 use conjure_core::Model;
 use itertools::izip;
@@ -41,6 +42,9 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
         Expr::Not(_, expr) => un_op::<bool, bool>(|e| !e, expr).map(Lit::Bool),
 
         Expr::And(_, exprs) => vec_op::<bool, bool>(|e| e.iter().all(|&e| e), exprs).map(Lit::Bool),
+        // this is done elsewhere instead - root should return a new root with a literal inside it,
+        // not a literal
+        Expr::Root(_, _) => None,
         Expr::Or(_, exprs) => vec_op::<bool, bool>(|e| e.iter().any(|&e| e), exprs).map(Lit::Bool),
         Expr::Imply(_, box1, box2) => {
             let a: &Atom = (&**box1).try_into().ok()?;
@@ -277,6 +281,36 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             } else {
                 None
             }
+        }
+    }
+}
+
+/// Evaluate the root expression.
+///
+/// This returns either Expr::Root([true]) or Expr::Root([false]).
+#[register_rule(("Constant", 9001))]
+fn eval_root(expr: &Expr, _: &Model) -> ApplicationResult {
+    // this is its own rule not part of apply_eval_constant, because root should return a new root
+    // with a literal inside it, not just a literal
+
+    let Expr::Root(_, exprs) = expr else {
+        return Err(RuleNotApplicable);
+    };
+
+    match exprs.len() {
+        0 => Ok(Reduction::pure(Expr::Root(
+            Metadata::new(),
+            vec![true.into()],
+        ))),
+        1 => Err(RuleNotApplicable),
+        _ => {
+            let lit =
+                vec_op::<bool, bool>(|e| e.iter().all(|&e| e), exprs).ok_or(RuleNotApplicable)?;
+
+            Ok(Reduction::pure(Expr::Root(
+                Metadata::new(),
+                vec![lit.into()],
+            )))
         }
     }
 }


### PR DESCRIPTION
Add `Expr::Root`, and use this to store top-level constraints in `Model` (instead of the current `Vec<Expr>`).

Among other things, this allows partial evaluation of the top level of the model again. For more details, see the RFC: https://github.com/conjure-cp/conjure-oxide/issues/596.

Closes: #596
