### PR TITLE
update rand to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
  "log",
  "minion_rs",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.9.0",
  "regex",
  "schemars",
  "serde",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -32,7 +32,7 @@ structured-logger = "1.0.3"
 schemars = "0.8.21"
 toml = "0.8.19"
 glob = "0.3.2"
-rand = "0.8.5"
+rand = "0.9.0"
 tracing-appender = "0.2"
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["ansi", "env-filter", "json"] }

--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -129,8 +129,8 @@ pub fn get_solutions_from_conjure(
 ) -> Result<Vec<BTreeMap<Name, Literal>>, EssenceParseError> {
     // this is ran in parallel, and we have no guarantee by rust that invocations to this function
     // don't share the same tmp dir.
-    let mut rng = rand::thread_rng();
-    let rand: i8 = rng.gen();
+    let mut rng = rand::rng();
+    let rand: i8 = rng.random();
 
     let mut tmp_dir = std::env::temp_dir();
     tmp_dir.push(Path::new(&rand.to_string()));


### PR DESCRIPTION
@lixitrixi updated rand to 0.9.0 in #635, but the conjure_oxide crate was not updated as part of that.