### PR TITLE
update uniplate to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,9 +2460,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "uniplate"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a420fa5d028a50263abc4eab5615443a2403e09434384f3fbcd91440fa6d7f"
+checksum = "ded483267ade2874f323e70e22a736402540d8388131658a55dcbe2e1b7fdad4"
 dependencies = [
  "thiserror 2.0.11",
  "uniplate-derive",
@@ -2470,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "uniplate-derive"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60accd71a95cd3a3ed58373e78daf00e63b00593c88b02fd6d600ce0201fa71f"
+checksum = "5ae4a009d2e0408c0dd6bd57b78e19670f9475404349a5b23cd840580f8acab9"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -13,7 +13,7 @@ conjure_core = { path = "../crates/conjure_core" }
 minion_rs = { path = "../solvers/minion" }
 
 
-uniplate = "0.2.0"
+uniplate = "0.2.1"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 serde_with = "3.12.0"

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -11,7 +11,7 @@ conjure_macros = { path = "../conjure_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }
 minion_rs = { path = "../../solvers/minion" }
 
-uniplate = "0.2.0"
+uniplate = "0.2.1"
 project-root = "0.2.2"
 linkme = "0.3.31"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 multipeek = "0.1.2"
 rand = "0.9.0"
-uniplate = "0.2.0"
+uniplate = "0.2.1"
 
 
 [lints]


### PR DESCRIPTION
Update to uniplate to v0.2.1. This changes Zipper::focus_mut() to return &mut T
not &T.
