### PR TITLE
Improving error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "conjure_macros",
  "derivative",
  "enum_compatability_macro",
+ "git-version",
  "im",
  "itertools 0.14.0",
  "linkme",
@@ -393,6 +394,7 @@ dependencies = [
  "clap",
  "conjure_core",
  "env_logger",
+ "git-version",
  "glob",
  "itertools 0.14.0",
  "linkme",
@@ -761,6 +763,26 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "glob"

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1.41"
 tree-sitter = "0.24.7"
 tree-sitter-essence = { version = "0.1.0", path = "../crates/tree-sitter-essence" }
 tree-sitter-haskell = "0.23.0"
+git-version = "0.3.9"
 
 [features]
 

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -20,11 +20,11 @@ use conjure_oxide::{get_rules, model_from_json};
 
 use conjure_oxide::utils::conjure::{get_minion_solutions, minion_solutions_to_json};
 use conjure_oxide::SolverFamily;
+use git_version::git_version;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
-use git_version::git_version;
 
 static AFTER_HELP_TEXT: &str = include_str!("help_text.txt");
 

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -24,11 +24,12 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer};
+use git_version::git_version;
 
 static AFTER_HELP_TEXT: &str = include_str!("help_text.txt");
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None, after_long_help=AFTER_HELP_TEXT)]
+#[command(author, about, long_about = None, after_long_help=AFTER_HELP_TEXT)]
 struct Cli {
     #[arg(value_name = "INPUT_ESSENCE", help = "The input Essence file")]
     input_file: PathBuf,
@@ -63,6 +64,13 @@ struct Cli {
         help = "Print the schema for the info JSON and exit"
     )]
     print_info_schema: bool,
+
+    #[arg(
+        long = "version",
+        short = 'V',
+        help = "Print the version of the program (git commit) and exit"
+    )]
+    version: bool,
 
     #[arg(long, help = "Save execution info as JSON to the given file-path.")]
     info_json_path: Option<PathBuf>,
@@ -182,6 +190,11 @@ pub fn main() -> AnyhowResult<()> {
                 .with_filter(env_filter),
         )
     };
+
+    if cli.version {
+        println!("Version: {}", git_version!());
+        return Ok(());
+    }
 
     // load the loggers
     tracing_subscriber::registry()

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -1,4 +1,3 @@
-use std::clone;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -32,6 +32,7 @@ schemars = "0.8.21"
 clap = { version = "4.5.28", features = ["derive"] }
 itertools = "0.14.0"
 im = "15.1.0"
+git-version = "0.3.9"
 
 [lints]
 workspace = true

--- a/crates/conjure_core/src/bug.rs
+++ b/crates/conjure_core/src/bug.rs
@@ -7,8 +7,6 @@
 /// - `msg`: A string expression describing the cause of the panic or bug.
 ///
 /// ```
-// rust doesn't recognize the git_version macro for some reason, so can't use 'use git_version::git_version;'
-
 #[macro_export]
 macro_rules! bug {
     ($msg:expr $(, $arg:tt)*) => {{

--- a/crates/conjure_core/src/bug.rs
+++ b/crates/conjure_core/src/bug.rs
@@ -7,6 +7,8 @@
 /// - `msg`: A string expression describing the cause of the panic or bug.
 ///
 /// ```
+use git_version::git_version;
+
 #[macro_export]
 macro_rules! bug {
     ($msg:expr $(, $arg:tt)*) => {{
@@ -23,8 +25,10 @@ You can help us by providing a minimal failing example.
 
 Issue tracker: http://github.com/conjure-cp/conjure-oxide/issues
 
+version: {}
+
 {}
-"#, &formatted_msg);
+"#, git_version!(), &formatted_msg);
 
         panic!("{}", full_message);
     }};

--- a/crates/conjure_core/src/bug.rs
+++ b/crates/conjure_core/src/bug.rs
@@ -26,9 +26,10 @@ You can help us by providing a minimal failing example.
 Issue tracker: http://github.com/conjure-cp/conjure-oxide/issues
 
 version: {}
+location: {}:{}:{}
 
 {}
-"#, git_version::git_version!(), &formatted_msg);
+"#, git_version::git_version!(),file!(),module_path!(),line!(), &formatted_msg);
 
         panic!("{}", full_message);
     }};

--- a/crates/conjure_core/src/bug.rs
+++ b/crates/conjure_core/src/bug.rs
@@ -7,7 +7,7 @@
 /// - `msg`: A string expression describing the cause of the panic or bug.
 ///
 /// ```
-use git_version::git_version;
+// rust doesn't recognize the git_version macro for some reason, so can't use 'use git_version::git_version;'
 
 #[macro_export]
 macro_rules! bug {
@@ -28,7 +28,7 @@ Issue tracker: http://github.com/conjure-cp/conjure-oxide/issues
 version: {}
 
 {}
-"#, git_version!(), &formatted_msg);
+"#, git_version::git_version!(), &formatted_msg);
 
         panic!("{}", full_message);
     }};

--- a/crates/conjure_core/src/error.rs
+++ b/crates/conjure_core/src/error.rs
@@ -20,7 +20,6 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
-
 // Macro to add an error with the line number and function name
 #[macro_export]
 macro_rules! throw_error {
@@ -32,7 +31,21 @@ macro_rules! throw_error {
             module_path!(),
             line!()
         );
-        Err(Error::Parse(error_msg))?
+        Err(Error::Parse(error_msg))
     }};
 }
 
+// Macro to add an error with the line number and function name
+#[macro_export]
+macro_rules! error {
+    ($msg:expr) => {{
+        let error_msg = format!(
+            " {} | File: {} | Function: {} | Line: {}",
+            $msg,
+            file!(),
+            module_path!(),
+            line!()
+        );
+        Error::Parse(error_msg)
+    }};
+}

--- a/crates/conjure_core/src/error.rs
+++ b/crates/conjure_core/src/error.rs
@@ -19,3 +19,20 @@ pub enum Error {
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
+
+
+// Macro to add an error with the line number and function name
+#[macro_export]
+macro_rules! throw_error {
+    ($msg:expr) => {{
+        let error_msg = format!(
+            " {} | File: {} | Function: {} | Line: {}",
+            $msg,
+            file!(),
+            module_path!(),
+            line!()
+        );
+        Err(Error::Parse(error_msg))?
+    }};
+}
+

--- a/crates/conjure_core/src/error.rs
+++ b/crates/conjure_core/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     Other(#[from] anyhow::Error),
 }
 
-// Macro to add an error with the line number and function name
+// Macro to throw an error with the line number and function name
 #[macro_export]
 macro_rules! throw_error {
     ($msg:expr) => {{
@@ -35,7 +35,7 @@ macro_rules! throw_error {
     }};
 }
 
-// Macro to add an error with the line number and function name
+// Macro to add an error with the line number and function name (for functions that take an error like ok_or)
 #[macro_export]
 macro_rules! error {
     ($msg:expr) => {{

--- a/crates/conjure_core/src/parse/parse_model.rs
+++ b/crates/conjure_core/src/parse/parse_model.rs
@@ -57,7 +57,7 @@ pub fn model_from_json(str: &str, context: Arc<RwLock<Context<'static>>>) -> Res
                 for (kind, value) in decl {
                     match kind.as_str() {
                         "FindOrGiven" => {parse_variable(value, m.symbols_mut())?; valid_decl = true; break} 
-                        "letting" => {parse_letting(value, m.symbols_mut())?; valid_decl = true; break}
+                        "Letting" => {parse_letting(value, m.symbols_mut())?; valid_decl = true; break}
                         _ => {continue}
                     }
                 }


### PR DESCRIPTION
A mixture of a few improvements to how we handle errors:

added macros for parsing errors to also display the file,function & line in which the error was thrown. May be of note to @spritezs and @niklasdewally 

changed version to output the current git hash rather than 'conjure oxide 0.0.1'

changed bug to do both of the above, this also solves issue #404 

folded parse declaration into model_from_json

note that changing version required making input file an option (otherwise doing --version would need something after due to input file being mandatory) and thus some clones I don't particularly like, if someone knows how to get rid of these clones that would be appreciated.