### PR TITLE
feat!: add `Submodel`

### DIFF
--- a/conjure_oxide/examples/solver-hello-minion.rs
+++ b/conjure_oxide/examples/solver-hello-minion.rs
@@ -13,10 +13,7 @@ use std::collections::HashMap;
 #[allow(clippy::unwrap_used)]
 pub fn main() {
     use conjure_core::solver::SolverFamily;
-    use conjure_core::{
-        ast::pretty::pretty_expressions_as_top_level, parse::get_example_model,
-        rule_engine::resolve_rule_sets,
-    };
+    use conjure_core::{parse::get_example_model, rule_engine::resolve_rule_sets};
     use conjure_core::{
         rule_engine::rewrite_model,
         solver::{adaptors, Solver},
@@ -25,19 +22,13 @@ pub fn main() {
 
     // Load an example model and rewrite it with conjure oxide.
     let model = get_example_model("div-05").unwrap();
-    println!(
-        "Input model: \n {} \n",
-        pretty_expressions_as_top_level(&model.get_constraints_vec())
-    );
+    println!("Input model: \n {model} \n",);
 
     // TODO: We will have a nicer way to do this in the future
     let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets()).unwrap();
 
     let model = rewrite_model(&model, &rule_sets).unwrap();
-    println!(
-        "Rewritten model: \n {} \n",
-        pretty_expressions_as_top_level(&model.get_constraints_vec())
-    );
+    println!("Rewritten model: \n {model} \n",);
 
     // To tell the `Solver` type what solver to use, you pass it a `SolverAdaptor`.
     // Here we use Minion.

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
 
-use conjure_core::ast::model::SerdeModel;
+use conjure_core::ast::SerdeModel;
 use conjure_core::context::Context;
 use serde_json::{json, Error as JsonError, Value as JsonValue};
 

--- a/conjure_oxide/tests/model_tests.rs
+++ b/conjure_oxide/tests/model_tests.rs
@@ -1,32 +1,32 @@
 // Tests for various functionalities of the Model
 
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Rc;
 
 use conjure_core::ast::Model;
 use conjure_oxide::ast::*;
-use declaration::Declaration;
 
 #[test]
 fn modify_domain() {
+    let mut m = Model::new(Default::default());
+
+    let mut symbols = m.as_submodel_mut().symbols_mut();
+
     let a = Name::UserName(String::from("a"));
 
     let d1 = Domain::IntDomain(vec![Range::Bounded(1, 3)]);
     let d2 = Domain::IntDomain(vec![Range::Bounded(1, 2)]);
 
-    let mut symbols = SymbolTable::new();
     symbols
         .insert(Rc::new(Declaration::new_var(a.clone(), d1.clone())))
         .unwrap();
 
-    let m = Model::new(Rc::new(RefCell::new(symbols)), vec![], Default::default());
+    assert_eq!(symbols.domain(&a).unwrap(), d1);
 
-    assert_eq!(&m.symbols().domain(&a).unwrap(), &d1);
-
-    let mut decl_a = m.symbols().lookup(&a).unwrap();
+    let mut decl_a = symbols.lookup(&a).unwrap();
 
     Rc::make_mut(&mut decl_a).as_var_mut().unwrap().domain = d2.clone();
 
-    m.symbols_mut().update_insert(decl_a);
+    symbols.update_insert(decl_a);
 
-    assert_eq!(&m.symbols().domain(&a).unwrap(), &d2);
+    assert_eq!(symbols.domain(&a).unwrap(), d2);
 }

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -16,7 +16,7 @@ use crate::ast::Name;
 use crate::ast::ReturnType;
 use crate::metadata::Metadata;
 
-use super::{Domain, Range};
+use super::{Domain, Range, SubModel};
 
 /// Represents different types of expressions used to define rules and constraints in the model.
 ///
@@ -24,12 +24,13 @@ use super::{Domain, Range};
 /// used to build rules and conditions for the model.
 #[document_compatibility]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Uniplate)]
-#[uniplate(walk_into=[Atom])]
+#[uniplate(walk_into=[Atom,Submodel])]
 #[biplate(to=Literal)]
 #[biplate(to=Metadata)]
 #[biplate(to=Atom)]
 #[biplate(to=Name)]
 #[biplate(to=Vec<Expression>)]
+#[biplate(to=SubModel)]
 pub enum Expression {
     /// The top of the model
     Root(Metadata, Vec<Expression>),

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -1,24 +1,27 @@
 pub mod pretty;
-pub mod types;
+pub mod serde;
 
 mod atom;
-pub mod declaration;
+mod declaration;
 mod domains;
 mod expressions;
 mod literals;
-pub mod model;
+mod model;
 mod name;
-pub mod serde;
+mod submodel;
 mod symbol_table;
+mod types;
 mod variables;
 
 pub use atom::Atom;
+pub use declaration::*;
 pub use domains::Domain;
 pub use domains::Range;
 pub use expressions::Expression;
 pub use literals::Literal;
-pub use model::Model;
+pub use model::*;
 pub use name::Name;
+pub use submodel::SubModel;
 pub use symbol_table::SymbolTable;
-pub use types::ReturnType;
+pub use types::*;
 pub use variables::DecisionVariable;

--- a/crates/conjure_core/src/ast/submodel.rs
+++ b/crates/conjure_core/src/ast/submodel.rs
@@ -1,0 +1,273 @@
+use super::{
+    declaration::DeclarationKind,
+    pretty::{
+        pretty_domain_letting_declaration, pretty_expressions_as_top_level,
+        pretty_value_letting_declaration, pretty_variable_declaration,
+    },
+    serde::RcRefCellAsInner,
+};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use uniplate::{Biplate, Tree, Uniplate};
+
+use crate::{bug, metadata::Metadata};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    collections::VecDeque,
+    fmt::Display,
+    rc::Rc,
+};
+
+use super::{types::Typeable, Expression, ReturnType, SymbolTable};
+
+/// A sub-model, representing a lexical scope in the model.
+///
+/// Each sub-model contains a symbol table representing its scope, as well as a expression tree.
+///
+/// The expression tree is formed of a root node of type [`Expression::Root`], which contains a
+/// vector of top-level constraints.
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct SubModel {
+    constraints: Expression,
+    #[serde_as(as = "RcRefCellAsInner")]
+    symbols: Rc<RefCell<SymbolTable>>,
+}
+
+impl SubModel {
+    /// Creates a new [`Submodel`] with no parent scope.
+    ///
+    /// Top level models are represented as [`Model`](super::model): consider using
+    /// [`Model::new`](super::Model::new) instead.
+    #[doc(hidden)]
+    pub(super) fn new_top_level() -> SubModel {
+        SubModel {
+            constraints: Expression::Root(Metadata::new(), vec![]),
+            symbols: Rc::new(RefCell::new(SymbolTable::new())),
+        }
+    }
+
+    /// Creates a new [`Submodel`] as a child scope of `parent`.
+    ///
+    /// `parent` should be the symbol table of the containing scope of this sub-model.
+    pub fn new(parent: Rc<RefCell<SymbolTable>>) -> SubModel {
+        SubModel {
+            constraints: Expression::Root(Metadata::new(), vec![]),
+            symbols: Rc::new(RefCell::new(SymbolTable::with_parent(parent))),
+        }
+    }
+
+    /// The symbol table for this sub-model as a pointer.
+    ///
+    /// The caller should only mutate the returned symbol table if this method was called on a
+    /// mutable model.
+    pub fn symbols_ptr_unchecked(&self) -> &Rc<RefCell<SymbolTable>> {
+        &self.symbols
+    }
+
+    /// The symbol table for this sub-model as a reference.
+    pub fn symbols(&self) -> Ref<SymbolTable> {
+        (*self.symbols).borrow()
+    }
+
+    /// The symbol table for this sub-model as a mutable reference.
+    pub fn symbols_mut(&mut self) -> RefMut<SymbolTable> {
+        (*self.symbols).borrow_mut()
+    }
+
+    /// The root node of this sub-model.
+    ///
+    /// The root node is an [`Expression::Root`] containing a vector of the top level constraints
+    /// in this sub-model.
+    pub fn root(&self) -> &Expression {
+        &self.constraints
+    }
+
+    /// The root node of this sub-model, as a mutable reference.
+    ///
+    /// The caller is responsible for ensuring that the root node remains an [`Expression::Root`].
+    ///
+    fn root_mut_unchecked(&mut self) -> &mut Expression {
+        &mut self.constraints
+    }
+
+    /// Replaces the root node with `new_root`, returning the old root node.
+    ///
+    /// # Panics
+    ///
+    /// - If `new_root` is not an [`Expression::Root`].
+    pub fn replace_root(&mut self, new_root: Expression) -> Expression {
+        let Expression::Root(_, _) = new_root else {
+            panic!("new_root is not an Expression::Root");
+        };
+
+        // INVARIANT: already checked that `new_root` is an [`Expression::Root`]
+        std::mem::replace(self.root_mut_unchecked(), new_root)
+    }
+
+    /// The top-level constraints in this sub-model.
+    pub fn constraints(&self) -> &Vec<Expression> {
+        let Expression::Root(_, constraints) = &self.constraints else {
+            bug!("The top level expression in a submodel should be Expr::Root");
+        };
+
+        constraints
+    }
+
+    /// The top-level constraints in this sub-model as a mutable vector.
+    pub fn constraints_mut(&mut self) -> &mut Vec<Expression> {
+        let Expression::Root(_, constraints) = &mut self.constraints else {
+            bug!("The top level expression in a submodel should be Expr::Root");
+        };
+
+        constraints
+    }
+
+    /// Replaces the top-level constraints with `new_constraints`, returning the old ones.
+    pub fn replace_constraints(&mut self, new_constraints: Vec<Expression>) -> Vec<Expression> {
+        std::mem::replace(self.constraints_mut(), new_constraints)
+    }
+
+    /// Adds a top-level constraint.
+    pub fn add_constraint(&mut self, constraint: Expression) {
+        self.constraints_mut().push(constraint);
+    }
+
+    /// Adds top-level constraints.
+    pub fn add_constraints(&mut self, constraints: Vec<Expression>) {
+        self.constraints_mut().extend(constraints);
+    }
+}
+
+impl Typeable for SubModel {
+    fn return_type(&self) -> Option<super::ReturnType> {
+        Some(ReturnType::Bool)
+    }
+}
+
+impl Display for SubModel {
+    #[allow(clippy::unwrap_used)] // [rustdocs]: should only fail iff the formatter fails
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (name, decl) in self.symbols().clone().into_iter_local() {
+            match decl.kind() {
+                DeclarationKind::DecisionVariable(_) => {
+                    writeln!(
+                        f,
+                        "{}",
+                        pretty_variable_declaration(&self.symbols(), &name).unwrap()
+                    )?;
+                }
+                DeclarationKind::ValueLetting(_) => {
+                    writeln!(
+                        f,
+                        "{}",
+                        pretty_value_letting_declaration(&self.symbols(), &name).unwrap()
+                    )?;
+                }
+                DeclarationKind::DomainLetting(_) => {
+                    writeln!(
+                        f,
+                        "{}",
+                        pretty_domain_letting_declaration(&self.symbols(), &name).unwrap()
+                    )?;
+                }
+            }
+        }
+
+        writeln!(f, "\nsuch that\n")?;
+
+        writeln!(f, "{}", pretty_expressions_as_top_level(self.constraints()))?;
+
+        Ok(())
+    }
+}
+
+// Using manual implementations of Uniplate so that we can update the old Rc<RefCell<<>>> with the
+// new value instead of creating a new one. This will keep the parent pointers in sync.
+//
+// I considered adding Rc RefCell shared-mutability to Uniplate, but I think this is unsound in
+// generality: e.g. two pointers to the same object are in our tree, and both get modified in
+// different ways.
+//
+// Shared mutability is probably fine here, as we only have one pointer to each symbol table
+// reachable via Uniplate, the one in its Submodel. The SymbolTable implementation doesn't return
+// or traverse through the parent pointers.
+//
+// -- nd60
+
+impl Uniplate for SubModel {
+    fn uniplate(&self) -> (Tree<Self>, Box<dyn Fn(Tree<Self>) -> Self>) {
+        // Look inside constraint tree and symbol tables.
+
+        let (expr_tree, expr_ctx) = <Expression as Biplate<SubModel>>::biplate(self.root());
+
+        let symtab_ptr = self.symbols();
+        let (symtab_tree, symtab_ctx) = <SymbolTable as Biplate<SubModel>>::biplate(&symtab_ptr);
+
+        let tree = Tree::Many(VecDeque::from([expr_tree, symtab_tree]));
+
+        let self2 = self.clone();
+        let ctx = Box::new(move |x| {
+            let Tree::Many(xs) = x else {
+                panic!();
+            };
+
+            let root = expr_ctx(xs[0].clone());
+            let symtab = symtab_ctx(xs[1].clone());
+
+            let mut self3 = self2.clone();
+
+            let Expression::Root(_, _) = root else {
+                bug!("root expression not root");
+            };
+
+            *self3.root_mut_unchecked() = root;
+
+            *self3.symbols_mut() = symtab;
+
+            self3
+        });
+
+        (tree, ctx)
+    }
+}
+
+impl Biplate<Expression> for SubModel {
+    fn biplate(&self) -> (Tree<Expression>, Box<dyn Fn(Tree<Expression>) -> Self>) {
+        // Return constraints tree and look inside symbol table.
+        let symtab_ptr = self.symbols();
+        let (symtab_tree, symtab_ctx) = <SymbolTable as Biplate<Expression>>::biplate(&symtab_ptr);
+
+        let tree = Tree::Many(VecDeque::from([
+            Tree::One(self.root().clone()),
+            symtab_tree,
+        ]));
+
+        let self2 = self.clone();
+        let ctx = Box::new(move |x| {
+            let Tree::Many(xs) = x else {
+                panic!();
+            };
+
+            let Tree::One(root) = xs[0].clone() else {
+                panic!();
+            };
+
+            let symtab = symtab_ctx(xs[1].clone());
+
+            let mut self3 = self2.clone();
+
+            let Expression::Root(_, _) = root else {
+                bug!("root expression not root");
+            };
+
+            *self3.root_mut_unchecked() = root;
+
+            *self3.symbols_mut() = symtab;
+
+            self3
+        });
+
+        (tree, ctx)
+    }
+}

--- a/crates/conjure_core/src/ast/symbol_table.rs
+++ b/crates/conjure_core/src/ast/symbol_table.rs
@@ -20,7 +20,7 @@ use uniplate::Tree;
 use uniplate::{Biplate, Uniplate};
 
 use super::name::Name;
-use super::{Domain, Expression, ReturnType};
+use super::{Domain, Expression, ReturnType, SubModel};
 use derivative::Derivative;
 
 // Count symbol tables per thread / model.
@@ -333,5 +333,21 @@ impl Biplate<Expression> for SymbolTable {
         });
 
         (tree, ctx)
+    }
+}
+
+impl Biplate<SubModel> for SymbolTable {
+    // walk into expressions
+    fn biplate(&self) -> (Tree<SubModel>, Box<dyn Fn(Tree<SubModel>) -> Self>) {
+        let (exprs, exprs_ctx) = <SymbolTable as Biplate<Expression>>::biplate(self);
+        let (submodel_tree, submodel_ctx) =
+            <VecDeque<Expression> as Biplate<SubModel>>::biplate(&exprs.into_iter().collect());
+
+        let ctx = Box::new(move |x| {
+            exprs_ctx(Tree::Many(
+                submodel_ctx(x).into_iter().map(Tree::One).collect(),
+            ))
+        });
+        (submodel_tree, ctx)
     }
 }

--- a/crates/conjure_core/src/lib.rs
+++ b/crates/conjure_core/src/lib.rs
@@ -1,6 +1,6 @@
 pub extern crate self as conjure_core;
 
-pub use ast::model::Model;
+pub use ast::Model;
 
 pub mod ast;
 pub mod bug;

--- a/crates/conjure_core/src/metadata.rs
+++ b/crates/conjure_core/src/metadata.rs
@@ -1,4 +1,4 @@
-use crate::ast::types::ReturnType;
+use crate::ast::ReturnType;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 use uniplate::derive_unplateable;

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -119,16 +119,16 @@ pub fn rewrite_model<'a>(
 
     //the while loop is exited when None is returned implying the sub-expression is clean
     let mut i: usize = 0;
-    while i < new_model.get_constraints_vec().len() {
+    while i < new_model.as_submodel().constraints().len() {
         while let Some(step) = rewrite_iteration(
-            &new_model.get_constraints_vec()[i],
+            &new_model.as_submodel().constraints()[i],
             &new_model,
             &rules,
             apply_optimizations,
             &mut stats,
         ) {
             debug_assert!(is_vec_bool(&step.new_top)); // All new_top expressions should be boolean
-            new_model.get_constraints_vec()[i] = step.new_expression.clone();
+            new_model.as_submodel_mut().constraints_mut()[i] = step.new_expression.clone();
             step.apply(&mut new_model); // Apply side-effects (e.g., symbol table updates)
         }
 
@@ -281,7 +281,10 @@ fn apply_all_rules<'a>(
 ) -> Vec<RuleResult<'a>> {
     let mut results = Vec::new();
     for rule_data in rules {
-        match rule_data.rule.apply(expression, &model.symbols()) {
+        match rule_data
+            .rule
+            .apply(expression, &model.as_submodel().symbols())
+        {
             Ok(red) => {
                 stats.rewriter_rule_application_attempts =
                     Some(stats.rewriter_rule_application_attempts.unwrap() + 1);

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -55,7 +55,7 @@ fn try_rewrite_model(
             let expr = expr.clone();
             let ctx = ctx.clone();
             for rd in rules {
-                match (rd.rule.application)(&expr, &model.symbols()) {
+                match (rd.rule.application)(&expr, &model.as_submodel().symbols()) {
                     Ok(red) => {
                         // Collect applicable rules
                         results.push((

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -63,7 +63,7 @@ pub fn log_rule_application(
     let new_variables_str = {
         let mut vars: Vec<String> = vec![];
 
-        for var_name in red.added_symbols(&initial_model.symbols()) {
+        for var_name in red.added_symbols(&initial_model.as_submodel().symbols()) {
             #[allow(clippy::unwrap_used)]
             vars.push(format!(
                 "  {}",

--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use thiserror::Error;
 
-use crate::ast::declaration::Declaration;
+use crate::ast::Declaration;
 use crate::ast::{Expression, Model, Name, SymbolTable};
 
 #[derive(Debug, Error)]
@@ -101,8 +101,9 @@ impl Reduction {
 
     /// Applies side-effects (e.g. symbol table updates)
     pub fn apply(self, model: &mut Model) {
-        model.symbols_mut().extend(self.symbols); // Add new assignments to the symbol table
-        model.add_constraints(self.new_top.clone());
+        let submodel = model.as_submodel_mut();
+        submodel.symbols_mut().extend(self.symbols); // Add new assignments to the symbol table
+        submodel.add_constraints(self.new_top.clone());
     }
 
     /// Gets symbols added by this reduction

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -11,7 +11,7 @@ use Atom::*;
 use Expr::*;
 use Lit::*;
 
-use crate::ast::declaration::Declaration;
+use crate::ast::Declaration;
 
 register_rule_set!("Base", ());
 

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -5,7 +5,7 @@
 use std::convert::TryInto;
 use std::rc::Rc;
 
-use crate::ast::declaration::Declaration;
+use crate::ast::Declaration;
 use crate::ast::{Atom, Domain, Expression as Expr, Literal as Lit, ReturnType, SymbolTable};
 
 use crate::metadata::Metadata;

--- a/crates/conjure_core/src/rules/utils.rs
+++ b/crates/conjure_core/src/rules/utils.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::ast::{declaration::Declaration, SymbolTable};
+use crate::ast::{Declaration, SymbolTable};
 use tracing::instrument;
 use uniplate::{Biplate, Uniplate};
 

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -8,7 +8,7 @@ use minion_rs::error::MinionError;
 use minion_rs::{get_from_table, run_minion};
 
 use crate::ast as conjure_ast;
-use crate::ast::declaration::Declaration;
+use crate::ast::Declaration;
 use crate::solver::SolverError::*;
 use crate::solver::SolverFamily;
 use crate::solver::SolverMutCallback;
@@ -29,7 +29,12 @@ fn load_symbol_table(
     conjure_model: &ConjureModel,
     minion_model: &mut MinionModel,
 ) -> Result<(), SolverError> {
-    for (name, decl) in conjure_model.symbols().clone().into_iter_local() {
+    for (name, decl) in conjure_model
+        .as_submodel()
+        .symbols()
+        .clone()
+        .into_iter_local()
+    {
         let Some(var) = decl.as_var() else {
             continue;
         }; // ignore lettings, etc.
@@ -126,7 +131,7 @@ fn load_constraints(
     conjure_model: &ConjureModel,
     minion_model: &mut MinionModel,
 ) -> Result<(), SolverError> {
-    for expr in conjure_model.get_constraints_vec().iter() {
+    for expr in conjure_model.as_submodel().constraints().iter() {
         // TODO: top level false / trues should not go to the solver to begin with
         // ... but changing this at this stage would require rewriting the tester
         use crate::metadata::Metadata;

--- a/crates/conjure_core/src/solver/adaptors/sat_common.rs
+++ b/crates/conjure_core/src/solver/adaptors/sat_common.rs
@@ -39,7 +39,8 @@ impl CNFModel {
     pub fn from_conjure(conjure_model: ConjureModel) -> Result<CNFModel, SolverError> {
         let mut ans: CNFModel = CNFModel::new();
 
-        let symtab = conjure_model.symbols();
+        let submodel = conjure_model.as_submodel();
+        let symtab = submodel.symbols();
         for (name, decl) in symtab.clone().into_iter() {
             // ignore symbols that are not variables.
             let Some(var) = decl.as_var() else {
@@ -57,8 +58,8 @@ impl CNFModel {
             ans.add_variable(&name);
         }
 
-        for expr in conjure_model.get_constraints_vec() {
-            match ans.add_expression(&expr) {
+        for expr in submodel.constraints() {
+            match ans.add_expression(expr) {
                 Ok(_) => {}
                 Err(error) => {
                     let message = format!("{:?}", error);


### PR DESCRIPTION
Add `Submodel`, and refactor `Model` to be a wrapper over `Submodel`.

This commit is part of on-going work to add lexical scope to Conjure
Oxide and is a follow up to 863643260 (feat!: add parent symbol tables
(#680), 2025-02-17).

DETAILS

A `Submodel` represents a particular scope and holds the symbol-table
and constraints tree for that scope.

This commit refactors `Model` to be a wrapper over `Submodel`, and
removes methods operating on constraints and the symbol table from
`Model`, placing them in `Submodel` instead. A `Model` can be borrowed as
a `Submodel` using `as_submodel()` and `as_submodel_mut()`.

The language semantics of a top level model and a sub-model are
identical, so treating it as `Submodel` in most cases is valid.

`Model` is a separate type than `Submodel` for the following reasons:

  + It will hold global-only information in the future, such as dominance
    constraints.

  + It holds a pointer to the context.

  + We need special initialisation and de-serialisation logic for the
    top level model that we do not want for `Submodel`. See
    `SerdeModel`.
