### PR TITLE
feat: Parser and AST support for `dominanceRelation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "log",
  "minion_rs",
  "pretty_assertions",
+ "project-root",
  "rand 0.9.0",
  "regex",
  "schemars",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -35,12 +35,17 @@ glob = "0.3.2"
 rand = "0.9.0"
 tracing-appender = "0.2"
 tracing-log = "0.2.0"
-tracing-subscriber = { version = "0.3.18", features = ["ansi", "env-filter", "json"] }
+tracing-subscriber = { version = "0.3.18", features = [
+    "ansi",
+    "env-filter",
+    "json",
+] }
 tracing = "0.1.41"
 tree-sitter = "0.24.7"
 tree-sitter-essence = { version = "0.1.0", path = "../crates/tree-sitter-essence" }
 tree-sitter-haskell = "0.23.0"
 git-version = "0.3.9"
+project-root = "0.2.2"
 
 [features]
 

--- a/conjure_oxide/examples/solver-hello-minion.rs
+++ b/conjure_oxide/examples/solver-hello-minion.rs
@@ -6,7 +6,7 @@ use conjure_core::{
     ast::{Literal, Name},
     solver::{adaptors::Minion, states::ExecutionSuccess},
 };
-use conjure_oxide::defaults::get_default_rule_sets;
+use conjure_oxide::defaults::DEFAULT_RULE_SETS;
 use itertools::Itertools;
 use std::collections::HashMap;
 
@@ -25,7 +25,7 @@ pub fn main() {
     println!("Input model: \n {model} \n",);
 
     // TODO: We will have a nicer way to do this in the future
-    let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets()).unwrap();
+    let rule_sets = resolve_rule_sets(SolverFamily::Minion, DEFAULT_RULE_SETS).unwrap();
 
     let model = rewrite_model(&model, &rule_sets).unwrap();
     println!("Rewritten model: \n {model} \n",);

--- a/conjure_oxide/src/defaults.rs
+++ b/conjure_oxide/src/defaults.rs
@@ -1,8 +1,1 @@
-/// Returns the default rule sets, excluding solver specific ones.
-pub fn get_default_rule_sets() -> Vec<String> {
-    vec![
-        "Base".to_string(),
-        "Constant".to_string(),
-        "Bubble".to_string(),
-    ]
-}
+pub static DEFAULT_RULE_SETS: &[&str] = &["Base", "Constant", "Bubble"];

--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -41,7 +41,7 @@ pub fn parse_essence_file_native(
                 let mut constraint_vec: Vec<Expression> = Vec::new();
                 for constraint in named_children(&statement) {
                     if constraint.kind() != "single_line_comment" {
-                        constraint_vec.push(parse_constraint(constraint, &source_code));
+                        constraint_vec.push(parse_constraint(constraint, &source_code, &statement));
                     }
                 }
                 model.as_submodel_mut().add_constraints(constraint_vec);
@@ -50,6 +50,19 @@ pub fn parse_essence_file_native(
             "letting_statement_list" => {
                 let letting_vars = parse_letting_statement(statement, &source_code);
                 model.as_submodel_mut().symbols_mut().extend(letting_vars);
+            }
+            "dominance_relation" => {
+                let inner = statement
+                    .child(1)
+                    .expect("Expected a sub-expression inside `dominanceRelation`");
+                let expr = parse_constraint(inner, &source_code, &statement);
+                let dominance = Expression::DominanceRelation(Metadata::new(), Box::new(expr));
+                if model.dominance.is_some() {
+                    return Err(EssenceParseError::ParseError(Error::Parse(
+                        "Duplicate dominance relation".to_owned(),
+                    )));
+                }
+                model.dominance = Some(dominance);
             }
             _ => {
                 let kind = statement.kind();
@@ -63,8 +76,9 @@ pub fn parse_essence_file_native(
 }
 
 fn get_tree(path: &str, filename: &str, extension: &str) -> (Tree, String) {
-    let source_code = fs::read_to_string(format!("{path}/{filename}.{extension}"))
-        .expect("Failed to read the source code file");
+    let pth = format!("{path}/{filename}.{extension}");
+    let source_code = fs::read_to_string(&pth)
+        .expect(format!("Failed to read the source code file {}", pth).as_str());
     let mut parser = Parser::new();
     parser.set_language(&LANGUAGE.into()).unwrap();
     (
@@ -201,7 +215,7 @@ fn parse_letting_statement(letting_statement_list: Node, source_code: &str) -> S
                 for name in temp_symbols {
                     symbol_table.insert(Rc::new(Declaration::new_value_letting(
                         Name::UserName(String::from(name)),
-                        parse_constraint(expr_or_domain, source_code),
+                        parse_constraint(expr_or_domain, source_code, &letting_statement_list),
                     )));
                 }
             }
@@ -219,24 +233,24 @@ fn parse_letting_statement(letting_statement_list: Node, source_code: &str) -> S
     symbol_table
 }
 
-fn parse_constraint(constraint: Node, source_code: &str) -> Expression {
+fn parse_constraint(constraint: Node, source_code: &str, root: &Node) -> Expression {
     match constraint.kind() {
-        "constraint" | "expression" => child_expr(constraint, source_code),
+        "constraint" | "expression" => child_expr(constraint, source_code, root),
         "not_expr" => Expression::Not(
             Metadata::new(),
-            Box::new(child_expr(constraint, source_code)),
+            Box::new(child_expr(constraint, source_code, root)),
         ),
         "abs_value" => Expression::Abs(
             Metadata::new(),
-            Box::new(child_expr(constraint, source_code)),
+            Box::new(child_expr(constraint, source_code, root)),
         ),
         "negative_expr" => Expression::Neg(
             Metadata::new(),
-            Box::new(child_expr(constraint, source_code)),
+            Box::new(child_expr(constraint, source_code, root)),
         ),
         "exponent" | "product_expr" | "sum_expr" | "comparison" | "and_expr" | "or_expr"
         | "implication" => {
-            let expr1 = child_expr(constraint, source_code);
+            let expr1 = child_expr(constraint, source_code, root);
             let op = constraint.child(1).unwrap_or_else(|| {
                 panic!(
                     "Error: missing node in expression of kind {}",
@@ -250,7 +264,7 @@ fn parse_constraint(constraint: Node, source_code: &str) -> Expression {
                     constraint.kind()
                 )
             });
-            let expr2 = parse_constraint(expr2_node, source_code);
+            let expr2 = parse_constraint(expr2_node, source_code, root);
 
             match op_type {
                 "**" => Expression::UnsafePow(Metadata::new(), Box::new(expr1), Box::new(expr2)),
@@ -280,7 +294,7 @@ fn parse_constraint(constraint: Node, source_code: &str) -> Expression {
         "quantifier_expr" => {
             let mut expr_list = Vec::new();
             for expr in named_children(&constraint) {
-                expr_list.push(parse_constraint(expr, source_code));
+                expr_list.push(parse_constraint(expr, source_code, root));
             }
 
             let quantifier = constraint.child(0).unwrap_or_else(|| {
@@ -331,6 +345,18 @@ fn parse_constraint(constraint: Node, source_code: &str) -> Expression {
                 Atom::Reference(Name::UserName(variable_name)),
             )
         }
+        "from_solution" => match root.kind() {
+            "dominance_relation" => {
+                let inner = child_expr(constraint, source_code, root);
+                match inner {
+                    Expression::Atomic(_, _) => {
+                        Expression::FromSolution(Metadata::new(), Box::new(inner))
+                    }
+                    _ => panic!("Expression inside a `fromSolution()` must be a variable name"),
+                }
+            }
+            _ => panic!("`fromSolution()` is only allowed inside dominance relation definitions"),
+        },
         _ => panic!("{} is not a recognized node kind", constraint.kind()),
     }
 }
@@ -339,9 +365,9 @@ fn named_children<'a>(node: &'a Node<'a>) -> impl Iterator<Item = Node<'a>> + 'a
     (0..node.named_child_count()).filter_map(|i| node.named_child(i))
 }
 
-fn child_expr(node: Node, source_code: &str) -> Expression {
+fn child_expr(node: Node, source_code: &str, root: &Node) -> Expression {
     let child = node
         .named_child(0)
         .unwrap_or_else(|| panic!("Error: missing node in expression of kind {}", node.kind()));
-    parse_constraint(child, source_code)
+    parse_constraint(child, source_code, root)
 }

--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -78,7 +78,7 @@ pub fn parse_essence_file_native(
 fn get_tree(path: &str, filename: &str, extension: &str) -> (Tree, String) {
     let pth = format!("{path}/{filename}.{extension}");
     let source_code = fs::read_to_string(&pth)
-        .expect(format!("Failed to read the source code file {}", pth).as_str());
+        .unwrap_or_else(|_| panic!("Failed to read the source code file {}", pth));
     let mut parser = Parser::new();
     parser.set_language(&LANGUAGE.into()).unwrap();
     (

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -2,10 +2,9 @@
 
 use conjure_core::rule_engine::rewrite_model;
 use conjure_core::rule_engine::rewrite_naive;
-use conjure_core::Model;
 use conjure_oxide::defaults::DEFAULT_RULE_SETS;
 use conjure_oxide::utils::essence_parser::parse_essence_file_native;
-use conjure_oxide::utils::testing::{read_human_rule_trace, read_rule_trace};
+use conjure_oxide::utils::testing::read_human_rule_trace;
 use glob::glob;
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -13,7 +12,6 @@ use std::env;
 use std::error::Error;
 use std::fs;
 use std::fs::File;
-use std::str::FromStr;
 use tracing::{span, Level, Metadata as OtherMetadata};
 use tracing_subscriber::{
     filter::EnvFilter, filter::FilterFn, fmt, layer::SubscriberExt, Layer, Registry,

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -2,6 +2,7 @@
 
 use conjure_core::rule_engine::rewrite_naive;
 use conjure_core::Model;
+use conjure_oxide::defaults::DEFAULT_RULE_SETS;
 use conjure_oxide::utils::essence_parser::parse_essence_file_native;
 use conjure_oxide::utils::testing::{read_human_rule_trace, read_rule_trace};
 use glob::glob;
@@ -26,7 +27,6 @@ use std::sync::RwLock;
 use conjure_core::ast::Atom;
 use conjure_core::ast::{Expression, Literal, Name};
 use conjure_core::context::Context;
-use conjure_oxide::defaults::get_default_rule_sets;
 use conjure_oxide::rule_engine::resolve_rule_sets;
 use conjure_oxide::utils::conjure::minion_solutions_to_json;
 use conjure_oxide::utils::conjure::{
@@ -186,7 +186,7 @@ fn integration_test_inner(
     assert_eq!(model, expected_model);
 
     // Stage 2: Rewrite the model using the rule engine and check that the result is as expected
-    let rule_sets = resolve_rule_sets(SolverFamily::Minion, &get_default_rule_sets())?;
+    let rule_sets = resolve_rule_sets(SolverFamily::Minion, DEFAULT_RULE_SETS)?;
 
     // TODO: temporarily set to always use rewrite_naive
     // remove before merging?

--- a/conjure_oxide/tests/parser_tests/dominance_simple.essence
+++ b/conjure_oxide/tests/parser_tests/dominance_simple.essence
@@ -1,0 +1,13 @@
+find cost: int(1..10)
+find carbon: int(1..10)
+
+such that (cost + carbon) <= 15
+
+dominanceRelation (
+    (cost <= fromSolution(cost)) /\
+    (carbon <= fromSolution(carbon)) /\
+    (
+        (cost < fromSolution(cost)) \/
+        (carbon < fromSolution(carbon))
+    )
+)

--- a/conjure_oxide/tests/parser_tests/dominance_twice.essence
+++ b/conjure_oxide/tests/parser_tests/dominance_twice.essence
@@ -1,0 +1,17 @@
+find cost: int(1..10)
+find carbon: int(1..10)
+
+such that (cost + carbon) <= 15
+
+dominanceRelation (
+    (cost <= fromSolution(cost)) /\
+    (carbon <= fromSolution(carbon)) /\
+    (
+        (cost < fromSolution(cost)) \/
+        (carbon < fromSolution(carbon))
+    )
+)
+
+dominanceRelation (
+    (cost <= fromSolution(cost))
+)

--- a/conjure_oxide/tests/parser_tests/mod.rs
+++ b/conjure_oxide/tests/parser_tests/mod.rs
@@ -1,4 +1,94 @@
-use conjure_oxide::utils::essence_parser::parse_essence_file_native;
+use conjure_core::{
+    ast::{Atom, Expression},
+    context::Context,
+};
+use conjure_oxide::{
+    utils::essence_parser::parse_essence_file_native, Metadata,
+};
+use project_root::get_project_root;
+use std::sync::{Arc, RwLock};
 
 #[test]
-fn test_parse_dominance() {}
+fn test_parse_dominance() {
+    let root = get_project_root().unwrap().canonicalize().unwrap();
+    let path = root.join("conjure_oxide/tests/parser_tests");
+    let file = "dominance_simple";
+
+    let expected_dominance = Some(Expression::DominanceRelation(
+        Metadata::new(),
+        Box::new(Expression::And(
+            Metadata::new(),
+            vec![
+                Expression::And(
+                    Metadata::new(),
+                    vec![
+                        Expression::Leq(
+                            Metadata::new(),
+                            Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("cost"))),
+                            Box::new(Expression::FromSolution(
+                                Metadata::new(),
+                                Box::new(Expression::Atomic(
+                                    Metadata::new(),
+                                    Atom::new_uref("cost"),
+                                )),
+                            )),
+                        ),
+                        Expression::Leq(
+                            Metadata::new(),
+                            Box::new(Expression::Atomic(
+                                Metadata::new(),
+                                Atom::new_uref("carbon"),
+                            )),
+                            Box::new(Expression::FromSolution(
+                                Metadata::new(),
+                                Box::new(Expression::Atomic(
+                                    Metadata::new(),
+                                    Atom::new_uref("carbon"),
+                                )),
+                            )),
+                        ),
+                    ],
+                ),
+                Expression::Or(
+                    Metadata::new(),
+                    vec![
+                        Expression::Lt(
+                            Metadata::new(),
+                            Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("cost"))),
+                            Box::new(Expression::FromSolution(
+                                Metadata::new(),
+                                Box::new(Expression::Atomic(
+                                    Metadata::new(),
+                                    Atom::new_uref("cost"),
+                                )),
+                            )),
+                        ),
+                        Expression::Lt(
+                            Metadata::new(),
+                            Box::new(Expression::Atomic(
+                                Metadata::new(),
+                                Atom::new_uref("carbon"),
+                            )),
+                            Box::new(Expression::FromSolution(
+                                Metadata::new(),
+                                Box::new(Expression::Atomic(
+                                    Metadata::new(),
+                                    Atom::new_uref("carbon"),
+                                )),
+                            )),
+                        ),
+                    ],
+                ),
+            ],
+        )),
+    ));
+
+    let ctx = Arc::new(RwLock::new(Context::default()));
+    let pth = path.to_str().unwrap();
+
+    let res = parse_essence_file_native(pth, file, "essence", ctx);
+    assert!(res.is_ok());
+
+    let model = res.unwrap();
+    assert_eq!(model.dominance, expected_dominance);
+}

--- a/conjure_oxide/tests/parser_tests/mod.rs
+++ b/conjure_oxide/tests/parser_tests/mod.rs
@@ -2,9 +2,8 @@ use conjure_core::{
     ast::{Atom, Expression},
     context::Context,
 };
-use conjure_oxide::{
-    utils::essence_parser::parse_essence_file_native, Metadata,
-};
+use conjure_oxide::{utils::essence_parser::parse_essence_file_native, Metadata};
+use pretty_assertions::assert_eq;
 use project_root::get_project_root;
 use std::sync::{Arc, RwLock};
 
@@ -91,4 +90,47 @@ fn test_parse_dominance() {
 
     let model = res.unwrap();
     assert_eq!(model.dominance, expected_dominance);
+}
+
+#[test]
+fn test_dominance_twice() {
+    let root = get_project_root().unwrap().canonicalize().unwrap();
+    let path = root.join("conjure_oxide/tests/parser_tests");
+    let file = "dominance_twice";
+
+    let ctx = Arc::new(RwLock::new(Context::default()));
+    let pth = path.to_str().unwrap();
+
+    let res = parse_essence_file_native(pth, file, "essence", ctx);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_no_dominance() {
+    let root = get_project_root().unwrap().canonicalize().unwrap();
+    let path = root.join("conjure_oxide/tests/parser_tests");
+
+    let pth = path.to_str().unwrap();
+    let res_nodom = parse_essence_file_native(
+        pth,
+        "no_dominance",
+        "essence",
+        Arc::new(RwLock::new(Context::default())),
+    );
+    let res_dom = parse_essence_file_native(
+        pth,
+        "dominance_simple",
+        "essence",
+        Arc::new(RwLock::new(Context::default())),
+    );
+
+    assert!(res_nodom.is_ok());
+    assert!(res_dom.is_ok());
+
+    let mod_nodom = res_nodom.unwrap();
+    let mod_dom = res_dom.unwrap();
+
+    assert_eq!(mod_nodom.as_submodel(), mod_dom.as_submodel());
+    assert!(mod_nodom.dominance.is_none());
+    assert!(mod_dom.dominance.is_some());
 }

--- a/conjure_oxide/tests/parser_tests/no_dominance.essence
+++ b/conjure_oxide/tests/parser_tests/no_dominance.essence
@@ -1,0 +1,4 @@
+find cost: int(1..10)
+find carbon: int(1..10)
+
+such that (cost + carbon) <= 15

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -615,7 +615,7 @@ fn rule_distribute_or_over_and() {
 fn rewrite_solve_xyz() {
     println!("Rules: {:?}", get_all_rules());
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);
@@ -657,7 +657,7 @@ fn rewrite_solve_xyz() {
         ],
     );
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -615,7 +615,7 @@ fn rule_distribute_or_over_and() {
 fn rewrite_solve_xyz() {
     println!("Rules: {:?}", get_all_rules());
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);
@@ -657,7 +657,7 @@ fn rewrite_solve_xyz() {
         ],
     );
 
-    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]) {
+    let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
             eprintln!("Error resolving rule sets: {}", e);

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -18,6 +18,13 @@ pub enum Atom {
     Reference(Name),
 }
 
+impl Atom {
+    /// Shorthand to create a reference by user name.
+    pub fn new_uref(name: &str) -> Atom {
+        Atom::Reference(Name::UserName(name.to_string()))
+    }
+}
+
 impl std::fmt::Display for Atom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/conjure_core/src/ast/name.rs
+++ b/crates/conjure_core/src/ast/name.rs
@@ -21,3 +21,21 @@ impl Display for Name {
         }
     }
 }
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        Name::UserName(s)
+    }
+}
+
+impl From<&str> for Name {
+    fn from(s: &str) -> Self {
+        Name::UserName(s.to_string())
+    }
+}
+
+impl From<i32> for Name {
+    fn from(i: i32) -> Self {
+        Name::MachineName(i)
+    }
+}

--- a/crates/conjure_core/src/rule_engine/resolve_rules.rs
+++ b/crates/conjure_core/src/rule_engine/resolve_rules.rs
@@ -91,7 +91,7 @@ fn get_rule_set(rule_set_name: &str) -> Result<&'static RuleSet<'static>, Resolv
 ///
 #[allow(clippy::mutable_key_type)] // RuleSet is 'static so it's fine
 fn rule_sets_by_names(
-    rule_set_names: &Vec<String>,
+    rule_set_names: &[&str],
 ) -> Result<HashSet<&'static RuleSet<'static>>, ResolveRulesError> {
     let mut rs_set: HashSet<&'static RuleSet<'static>> = HashSet::new();
 
@@ -164,7 +164,7 @@ pub fn get_rules_grouped<'a>(
 ///
 pub fn resolve_rule_sets(
     target_solver: SolverFamily,
-    extra_rs_names: &Vec<String>,
+    extra_rs_names: &[&str],
 ) -> Result<Vec<&'static RuleSet<'static>>, ResolveRulesError> {
     #[allow(clippy::mutable_key_type)]
     // Hashing is done by name which never changes, and the references are 'static

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -28,6 +28,10 @@ fn apply_eval_constant(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 /// `Some(Const)` if the expression can be simplified to a constant
 pub fn eval_constant(expr: &Expr) -> Option<Lit> {
     match expr {
+        // `fromSolution()` pulls a literal value from last found solution
+        Expr::FromSolution(_, _) => None,
+        // Same as Expr::Root, we should not replace the dominance relation with a constant
+        Expr::DominanceRelation(_, _) => None,
         Expr::Atomic(_, Atom::Literal(c)) => Some(c.clone()),
         Expr::Atomic(_, Atom::Reference(_c)) => None,
         Expr::Abs(_, e) => un_op::<i32, i32>(|a| a.abs(), e).map(Lit::Int),

--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -20,6 +20,8 @@ fn partial_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     // rule infinitely!
     // This is why we always check whether we found a constant or not.
     match expr.clone() {
+        DominanceRelation(_, _) => Err(RuleNotApplicable),
+        FromSolution(_, _) => Err(RuleNotApplicable),
         Bubble(_, _, _) => Err(RuleNotApplicable),
         Atomic(_, _) => Err(RuleNotApplicable),
         Scope(_, _) => Err(RuleNotApplicable),

--- a/crates/conjure_core/src/solver/mod.rs
+++ b/crates/conjure_core/src/solver/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! // Define and rewrite a model for minion.
 //! let model = get_example_model("bool-03").unwrap();
-//! let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant".to_string()]).unwrap();
+//! let rule_sets = resolve_rule_sets(SolverFamily::Minion, &vec!["Constant"]).unwrap();
 //! let model = rewrite_model(&model,&rule_sets).unwrap();
 //!
 //!
@@ -157,7 +157,7 @@ pub type SolverMutCallback =
 /// usage details.**
 ///
 /// # Encapsulation
-///  
+///
 ///  The [`SolverAdaptor`] trait **must** only be implemented inside a submodule of this one,
 ///  and **should** only be called through [`Solver`].
 ///

--- a/crates/tree-sitter-essence/grammar.js
+++ b/crates/tree-sitter-essence/grammar.js
@@ -13,6 +13,7 @@ module.exports = grammar ({
       $.find_statement_list,
       $.constraint_list,
       $.letting_statement_list,
+      $.dominance_relation
     )),
 
     single_line_comment: $ => token(seq('$', /.*/)),
@@ -112,7 +113,8 @@ module.exports = grammar ({
       $.implication,
       $.quantifier_expr,
       $.constant,
-      $.variable
+      $.variable,
+      $.from_solution
     ),
 
     not_expr: $ => prec(20, seq("!", $.expression)),
@@ -150,5 +152,17 @@ module.exports = grammar ({
       )),
       "])"
     )),
+
+    from_solution: $ => seq(
+      "fromSolution",
+      "(",
+      $.variable,
+      ")"
+    ),
+
+    dominance_relation: $ => seq(
+      "dominanceRelation",
+      $.expression
+    )
   }
 })


### PR DESCRIPTION
This PR adds support for parsing dominance relations.

It also contains some minor QOL improvements:
- `resolve_rule_sets` functions now take `&str` literals, not the `String` type.
  This should reduce annoying type casting
- `Atom` variants now have an extra method `Atom::new_uref("name")`
  This is a shorthand for `Atom::Reference(Name::UserName("name".to_string()))`
- `Name` now has `From` implemented for `&str`, `String`, and `i32`

Closes #671 and #670 
