### PR TITLE
refactor(tree_morph): mut_meta to use Box<dyn FnOnce(&mut M)>

### DIFF
--- a/crates/tree_morph/src/commands.rs
+++ b/crates/tree_morph/src/commands.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use uniplate::Uniplate;
 
 enum Command<T: Uniplate, M> {
-    Transform(fn(T) -> T),
+    Transform(Box<dyn FnOnce(T) -> T>),
     MutMeta(Box<dyn FnOnce(&mut M)>),
 }
 
@@ -38,10 +38,10 @@ enum Command<T: Uniplate, M> {
 /// }
 ///
 /// fn rule(cmds: &mut Commands<Expr, bool>, subtree: &Expr, meta: &bool) -> Option<Expr> {
-///     cmds.transform(|t| match t { // A pure transformation (no other side-effects)
+///     cmds.transform(Box::new(|t| match t { // A pure transformation (no other side-effects)
 ///         Expr::B => Expr::C,
 ///         _ => t,
-///     });
+///     }));
 ///     cmds.mut_meta(Box::new(|m: &mut bool| *m = true)); // Set the metadata to 'true'
 ///
 ///     match subtree {
@@ -76,7 +76,7 @@ impl<T: Uniplate, M> Commands<T, M> {
     /// tree.
     ///
     /// Side-effects are applied in order of registration after the rule is applied.
-    pub fn transform(&mut self, f: fn(T) -> T) {
+    pub fn transform(&mut self, f: Box<dyn FnOnce(T) -> T>) {
         self.commands.push_back(Command::Transform(f));
     }
 

--- a/crates/tree_morph/src/commands.rs
+++ b/crates/tree_morph/src/commands.rs
@@ -3,7 +3,7 @@ use uniplate::Uniplate;
 
 enum Command<T: Uniplate, M> {
     Transform(fn(T) -> T),
-    MutMeta(fn(&mut M)),
+    MutMeta(Box<dyn FnOnce(&mut M)>),
 }
 
 /// A queue of commands (side-effects) to be applied after a successful rule application.
@@ -42,7 +42,7 @@ enum Command<T: Uniplate, M> {
 ///         Expr::B => Expr::C,
 ///         _ => t,
 ///     });
-///     cmds.mut_meta(|m| *m = true); // Set the metadata to 'true'
+///     cmds.mut_meta(Box::new(|m: &mut bool| *m = true)); // Set the metadata to 'true'
 ///
 ///     match subtree {
 ///         Expr::A => Some(Expr::B),
@@ -83,7 +83,7 @@ impl<T: Uniplate, M> Commands<T, M> {
     /// Updates the global metadata in-place via a mutable reference.
     ///
     /// Side-effects are applied in order of registration after the rule is applied.
-    pub fn mut_meta(&mut self, f: fn(&mut M)) {
+    pub fn mut_meta(&mut self, f: Box<dyn FnOnce(&mut M)>) {
         self.commands.push_back(Command::MutMeta(f));
     }
 

--- a/crates/tree_morph/src/engine.rs
+++ b/crates/tree_morph/src/engine.rs
@@ -44,7 +44,7 @@ use uniplate::Uniplate;
 ///
 /// // a * b ~> (value of) a * b, where 'a' and 'b' are literal values
 /// fn rule_eval_mul(cmds: &mut Commands<Expr, i32>, subtree: &Expr, meta: &i32) -> Option<Expr> {
-///     cmds.mut_meta(|m| *m += 1);
+///     cmds.mut_meta(Box::new(|m: &mut i32| *m += 1));
 ///
 ///     if let Expr::Mul(a, b) = subtree {
 ///         if let (Expr::Val(a_v), Expr::Val(b_v)) = (a.as_ref(), b.as_ref()) {
@@ -58,7 +58,7 @@ use uniplate::Uniplate;
 /// // If this rule is applied before the sub-expression is fully evaluated, duplicate work
 /// // will be done on the resulting two identical sub-expressions.
 /// fn rule_expand_sqr(cmds: &mut Commands<Expr, i32>, subtree: &Expr, meta: &i32) -> Option<Expr> {
-///     cmds.mut_meta(|m| *m += 1);
+///     cmds.mut_meta(Box::new(|m: &mut i32| *m += 1));
 ///
 ///     if let Expr::Sqr(expr) = subtree {
 ///         return Some(Expr::Mul(

--- a/crates/tree_morph/tests/enum_rules.rs
+++ b/crates/tree_morph/tests/enum_rules.rs
@@ -38,14 +38,13 @@ enum MyRule {
 
 impl Rule<Expr, Meta> for MyRule {
     fn apply(&self, cmd: &mut Commands<Expr, Meta>, expr: &Expr, meta: &Meta) -> Option<Expr> {
-        cmd.mut_meta(|m| m.num_applications += 1); // Only applied if successful
+        cmd.mut_meta(Box::new(|m: &mut Meta| m.num_applications += 1)); // Only applied if successful
         match self {
             MyRule::EvalAdd => rule_eval_add(cmd, expr, meta),
             MyRule::EvalMul => rule_eval_mul(cmd, expr, meta),
         }
     }
 }
-
 struct Meta {
     num_applications: u32,
 }

--- a/crates/tree_morph/tests/lambda_calc.rs
+++ b/crates/tree_morph/tests/lambda_calc.rs
@@ -102,7 +102,7 @@ fn beta_reduce(expr: &Expr) -> Option<Expr> {
 fn transform_beta_reduce(cmd: &mut Commands<Expr, u32>, expr: &Expr, _: &u32) -> Option<Expr> {
     let retval = beta_reduce(expr);
     if retval.is_some() {
-        cmd.mut_meta(|m| *m += 1);
+        cmd.mut_meta(Box::new(|m: &mut u32| *m += 1));
     }
     retval
 }


### PR DESCRIPTION
Refactored mut_meta from using fn to Box<dyn FnOnce(&mut M)>

This change was needed as we I needed to move reduction.symbols into a mut_meta closure when implementing the Rule trait of treemorph for the conjure-oxide rule. (I'll link a PR later when I open one)