### PR TITLE
fix: ignore unwrap and expect with clippy, like we do in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 ]
 
 [workspace.lints.clippy]
-unwrap_used = "warn"
-expect_used = "warn"
+unwrap_used = "allow"
+expect_used = "allow"
 wildcard_imports = "warn"
 
 [profile.dev]


### PR DESCRIPTION
In our Hygiene CI, we ignore the unwrap_used and expect_used warnings . This commit sets them to allowed locally, making `cargo clippy` give the same output as CI.
