### PR TITLE
hotfix: downgrade crate 'versions' to 6.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -1446,15 +1446,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2801,12 +2792,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "versions"
-version = "7.0.0"
+version = "6.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
+checksum = "f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139"
 dependencies = [
- "itertools 0.14.0",
- "nom 8.0.0",
+ "itertools 0.13.0",
+ "nom",
 ]
 
 [[package]]

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1.0.97"
 clap = { version = "4.5.31", features = ["derive"] }
 strum_macros = "0.27.1"
 strum = "0.27.1"
-versions = "7.0.0"
+versions = "6.3.2"
 linkme = "0.3.32"
 walkdir = "2.5.0"
 regex = "1.11.1"


### PR DESCRIPTION
The `7.0.0` release of crate `versions` requires the 2024 edition of Rust, whereas most of our project is on 2021.
This breaks the build for me:

```
> cargo check
error: failed to download `versions v7.0.0`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/mayday/.cargo/registry/src/index.crates.io-6f17d22bba15001f/versions-7.0.0/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.1 (66221abde 2024-11-19)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
  ```
  
  Updating `cargo` to `1.85` does fix this, but causes a different issue - `proc_macros` fails to compile.
  
  I've tried reinstalling my toolchain, `cargo clean`, `git clean`, etc, so I'm pretty sure this is not just an issue on my machine.
  In case anyone else is affected, just pinning `versions` to any `6.x`  release fixes it!