### PR TITLE
fix(tester): fix generation of rule trace files

### DIFF
--- a/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
@@ -1,11 +1,11 @@
 Model before rewriting:
 
-find a: int(0..3)
-find b: int(0..3)
+find a: int(0..4)
+find b: int(0..4)
 
 such that
 
-(UnsafeDiv(a, b) = 1)
+(UnsafeDiv(a, b) = 2)
 
 --
 
@@ -15,15 +15,15 @@ UnsafeDiv(a, b),
 
 --
 
-({SafeDiv(a, b) @ (b != 0)} = 1), 
+({SafeDiv(a, b) @ (b != 0)} = 2), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(a, b) = 1) @ And([(b != 0)])} 
+{(SafeDiv(a, b) = 2) @ And([(b != 0)])} 
 
 --
 
-{(SafeDiv(a, b) = 1) @ And([(b != 0)])}, 
+{(SafeDiv(a, b) = 2) @ And([(b != 0)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(a, b) = 1), And([(b != 0)])]) 
+And([(SafeDiv(a, b) = 2), And([(b != 0)])]) 
 
 --
 
@@ -33,18 +33,18 @@ And([(b != 0)]),
 
 --
 
-(SafeDiv(a, b) = 1), 
+(SafeDiv(a, b) = 2), 
    ~~> introduce_diveq ([("Minion", 4200)]) 
-DivEq(a, b, 1) 
+DivEq(a, b, 2) 
 
 --
 
 Final model:
 
-find a: int(0..3)
-find b: int(0..3)
+find a: int(0..4)
+find b: int(0..4)
 
 such that
 
-And([DivEq(a, b, 1), (b != 0)])
+And([DivEq(a, b, 2), (b != 0)])
 

--- a/conjure_oxide/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
@@ -1,0 +1,32 @@
+Model before rewriting:
+
+find a: matrix indexed by [[int(1..5)]] of bool
+
+such that
+
+(a[[1]] = true),
+(a[[2]] = true),
+(a[[3]] = true),
+(a[[4]] = true),
+(a[[5]] = Not(a[[4]]))
+
+--
+
+Not(a[[4]]), 
+   ~~> not_constraint_to_reify ([("Minion", 4090)]) 
+Reify(a[[4]], false) 
+
+--
+
+Final model:
+
+find a: matrix indexed by [[int(1..5)]] of bool
+
+such that
+
+(a[[1]] = true),
+(a[[2]] = true),
+(a[[3]] = true),
+(a[[4]] = true),
+(a[[5]] = Reify(a[[4]], false))
+

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
@@ -1,0 +1,20 @@
+Model before rewriting:
+
+find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
+
+such that
+
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1)
+
+--
+
+Final model:
+
+find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
+
+such that
+
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1)
+

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
@@ -1,0 +1,30 @@
+Model before rewriting:
+
+letting MATRIX be domain matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
+find a: MATRIX
+
+such that
+
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1)
+
+--
+
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1), 
+   ~~> substitute_domain_lettings ([("Base", 5000)]) 
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1) 
+
+--
+
+Final model:
+
+letting MATRIX be domain matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
+find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
+
+such that
+
+(a[[1, 1]] = 1),
+(a[[2, 2]] = 1)
+

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use itertools::Itertools;
 use std::sync::Arc;
+use tracing::trace;
 use uniplate::Biplate;
 
 /// A naive, exhaustive rewriter for development purposes. Applies rules in priority order,
@@ -28,6 +29,12 @@ pub fn rewrite_naive<'a>(
 
     let mut model = model.clone();
     let mut done_something = true;
+
+    trace!(
+        target: "rule_engine_human",
+        "Model before rewriting:\n\n{}\n--\n",
+        model
+    );
 
     // Rewrite until there are no more rules left to apply.
     while done_something {
@@ -53,6 +60,11 @@ pub fn rewrite_naive<'a>(
         }
     }
 
+    trace!(
+        target: "rule_engine_human",
+        "Final model:\n\n{}",
+        model
+    );
     Ok(model)
 }
 


### PR DESCRIPTION
Before this commit, the tester was not creating expected rule trace files on ACCEPT=true. This commit fixes this with the following changes:

+ Set validate_traces tester option to true by default to generate and check
  rule trace files

+ On ACCEPT=true, update expected rule traces before it is checked against the generated rule traces.

+ Re-add model printing to the rule traces.
