### PR TITLE
feat!: make (most) vecops take a matrix instead, add matrix literals

### DIFF
--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::legacy_numeric_constants)]
 use conjure_core::ast::Declaration;
 use conjure_core::error::Error;
 use std::fs;
@@ -12,7 +11,7 @@ use conjure_core::ast::{Atom, Domain, Expression, Literal, Name, Range, SymbolTa
 use crate::utils::conjure::EssenceParseError;
 use conjure_core::context::Context;
 use conjure_core::metadata::Metadata;
-use conjure_core::Model;
+use conjure_core::{into_matrix_expr, matrix_expr, Model};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub fn parse_essence_file_native(
@@ -285,8 +284,8 @@ fn parse_constraint(constraint: Node, source_code: &str, root: &Node) -> Express
                 ">=" => Expression::Geq(Metadata::new(), Box::new(expr1), Box::new(expr2)),
                 "<" => Expression::Lt(Metadata::new(), Box::new(expr1), Box::new(expr2)),
                 ">" => Expression::Gt(Metadata::new(), Box::new(expr1), Box::new(expr2)),
-                "/\\" => Expression::And(Metadata::new(), vec![expr1, expr2]),
-                "\\/" => Expression::Or(Metadata::new(), vec![expr1, expr2]),
+                "/\\" => Expression::And(Metadata::new(), Box::new(matrix_expr![expr1, expr2])),
+                "\\/" => Expression::Or(Metadata::new(), Box::new(matrix_expr![expr1, expr2])),
                 "->" => Expression::Imply(Metadata::new(), Box::new(expr1), Box::new(expr2)),
                 _ => panic!("Error: unsupported operator"),
             }
@@ -306,12 +305,14 @@ fn parse_constraint(constraint: Node, source_code: &str, root: &Node) -> Express
             let quantifier_type = &source_code[quantifier.start_byte()..quantifier.end_byte()];
 
             match quantifier_type {
-                "and" => Expression::And(Metadata::new(), expr_list),
-                "or" => Expression::Or(Metadata::new(), expr_list),
-                "min" => Expression::Min(Metadata::new(), expr_list),
-                "max" => Expression::Max(Metadata::new(), expr_list),
+                "and" => Expression::And(Metadata::new(), Box::new(into_matrix_expr![expr_list])),
+                "or" => Expression::Or(Metadata::new(), Box::new(into_matrix_expr![expr_list])),
+                "min" => Expression::Min(Metadata::new(), Box::new(into_matrix_expr![expr_list])),
+                "max" => Expression::Max(Metadata::new(), Box::new(into_matrix_expr![expr_list])),
                 "sum" => Expression::Sum(Metadata::new(), expr_list),
-                "allDiff" => Expression::AllDiff(Metadata::new(), expr_list),
+                "allDiff" => {
+                    Expression::AllDiff(Metadata::new(), Box::new(into_matrix_expr![expr_list]))
+                }
                 _ => panic!("Error: unsupported quantifier"),
             }
         }

--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::legacy_numeric_constants)]
 use conjure_core::ast::Declaration;
 use conjure_core::error::Error;
 use std::fs;

--- a/conjure_oxide/src/utils/essence_parser.rs
+++ b/conjure_oxide/src/utils/essence_parser.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::legacy_numeric_constants)]
+#![allow(clippy::legacy_numeric_constants)]
 use conjure_core::ast::Declaration;
 use conjure_core::error::Error;
 use std::fs;

--- a/conjure_oxide/tests/generated_tests.rs
+++ b/conjure_oxide/tests/generated_tests.rs
@@ -574,13 +574,19 @@ fn assert_vector_operators_have_partially_evaluated(model: &conjure_core::Model)
         use conjure_core::ast::Expression::*;
         match node {
             Sum(_, ref vec) => assert_constants_leq_one(&node, vec),
-            Min(_, ref vec) => assert_constants_leq_one(&node, vec),
-            Max(_, ref vec) => assert_constants_leq_one(&node, vec),
-            Or(_, ref vec) => assert_constants_leq_one(&node, vec),
-            And(_, ref vec) => assert_constants_leq_one(&node, vec),
+            Min(_, ref vec) => assert_constants_leq_one_vec_lit(&node, vec),
+            Max(_, ref vec) => assert_constants_leq_one_vec_lit(&node, vec),
+            Or(_, ref vec) => assert_constants_leq_one_vec_lit(&node, vec),
+            And(_, ref vec) => assert_constants_leq_one_vec_lit(&node, vec),
             _ => (),
         };
     }
+}
+
+fn assert_constants_leq_one_vec_lit(parent_expr: &Expression, expr: &Expression) {
+    if let Some(exprs) = expr.clone().unwrap_list() {
+        assert_constants_leq_one(parent_expr, &exprs);
+    };
 }
 
 fn assert_constants_leq_one(parent_expr: &Expression, exprs: &[Expression]) {

--- a/conjure_oxide/tests/integration/basic/abs/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/abs/01-simple/input-expected-rule-trace-human.txt
@@ -11,7 +11,7 @@ such that
 
 (Sum([|x|, |y|]) = 10), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]) 
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]) 
 new variables:
   find __0: int(0..5)
   find __1: int(0..5)
@@ -41,7 +41,7 @@ find __1: int(0..5)
 
 such that
 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]),
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]),
 AbsEq(__0,x),
 AbsEq(__1,y)
 

--- a/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/01-simple/input.expected-rewrite.serialised.json
@@ -12,58 +12,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "MachineName": 1
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 1
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -105,8 +124,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 103,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -115,7 +135,7 @@
           "UserName": "x"
         },
         {
-          "id": 3,
+          "id": 10,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -140,7 +160,7 @@
           "UserName": "y"
         },
         {
-          "id": 4,
+          "id": 11,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -165,7 +185,7 @@
           "MachineName": 0
         },
         {
-          "id": 5,
+          "id": 12,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -190,7 +210,7 @@
           "MachineName": 1
         },
         {
-          "id": 6,
+          "id": 13,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/abs/02-neg/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/abs/02-neg/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ such that
 
 (Sum([|x|, |y|]) = 10), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]) 
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]) 
 new variables:
   find __0: int(0..5)
   find __1: int(0..5)
@@ -53,7 +53,7 @@ find __1: int(0..5)
 
 such that
 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]),
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]),
 AbsEq(__0,x),
 AbsEq(__1,y)
 

--- a/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/02-neg/input.expected-rewrite.serialised.json
@@ -12,58 +12,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "MachineName": 1
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 1
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -105,8 +124,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 119,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -115,7 +135,7 @@
           "UserName": "x"
         },
         {
-          "id": 23,
+          "id": 5,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -140,7 +160,7 @@
           "UserName": "y"
         },
         {
-          "id": 24,
+          "id": 6,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -165,7 +185,7 @@
           "MachineName": 0
         },
         {
-          "id": 25,
+          "id": 7,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -190,7 +210,7 @@
           "MachineName": 1
         },
         {
-          "id": 26,
+          "id": 8,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/abs/03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/abs/03-nested/input-expected-rule-trace-human.txt
@@ -36,11 +36,11 @@ true
 
 Sum([{SafeDiv(x, 2) @ true}, y, -(z)]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([SafeDiv(x, 2), y, -(z)]) @ And([true])} 
+{Sum([SafeDiv(x, 2), y, -(z)]) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -48,11 +48,11 @@ true
 
 |{Sum([SafeDiv(x, 2), y, -(z)]) @ true}|, 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{|Sum([SafeDiv(x, 2), y, -(z)])| @ And([true])} 
+{|Sum([SafeDiv(x, 2), y, -(z)])| @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -60,11 +60,11 @@ true
 
 Sum([{|Sum([SafeDiv(x, 2), y, -(z)])| @ true}, UnsafeDiv(|y|, 2)]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) @ And([true])} 
+{Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -72,11 +72,11 @@ true
 
 ({Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) @ true} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10) @ And([true])} 
+{(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -84,17 +84,17 @@ true
 
 {(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10), true]) 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10),true;int(1..)]) 
 
 --
 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10), true]), 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10)]) 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10);int(1..)]) 
 
 --
 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10)]), 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, UnsafeDiv(|y|, 2)]) = 10) 
 
@@ -114,11 +114,11 @@ true
 
 Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, {SafeDiv(|y|, 2) @ true}]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) @ And([true])} 
+{Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -126,11 +126,11 @@ true
 
 ({Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) @ true} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10) @ And([true])} 
+{(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -138,17 +138,17 @@ true
 
 {(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10), true]) 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10),true;int(1..)]) 
 
 --
 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10), true]), 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10)]) 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10);int(1..)]) 
 
 --
 
-And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10)]), 
+and([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10) 
 
@@ -156,7 +156,7 @@ And([(Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10)]),
 
 (Sum([|Sum([SafeDiv(x, 2), y, -(z)])|, SafeDiv(|y|, 2)]) = 10), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]) 
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]) 
 new variables:
   find __0: int(0..10)
   find __1: int(0..2)
@@ -176,7 +176,7 @@ new constraints:
 
 __2 =aux Sum([SafeDiv(x, 2), y, -(z)]), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([FlatWeightedSumLeq([1, 1, -1],[__3, y, z],__2), FlatWeightedSumGeq([1, 1, -1],[__3, y, z],__2)]) 
+and([FlatWeightedSumLeq([1, 1, -1],[__3, y, z],__2),FlatWeightedSumGeq([1, 1, -1],[__3, y, z],__2);int(1..)]) 
 new variables:
   find __3: int(-3..1)
 new constraints:
@@ -229,10 +229,10 @@ find __4: int(0..5)
 
 such that
 
-And([SumLeq([__0, __1], 10), SumGeq([__0, __1], 10)]),
+and([SumLeq([__0, __1], 10),SumGeq([__0, __1], 10);int(1..)]),
 AbsEq(__0,__2),
 DivEq(__4, 2, __1),
-And([FlatWeightedSumLeq([1, 1, -1],[__3, y, z],__2), FlatWeightedSumGeq([1, 1, -1],[__3, y, z],__2)]),
+and([FlatWeightedSumLeq([1, 1, -1],[__3, y, z],__2),FlatWeightedSumGeq([1, 1, -1],[__3, y, z],__2);int(1..)]),
 DivEq(x, 2, __3),
 AbsEq(__4,y)
 

--- a/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/abs/03-nested/input.expected-rewrite.serialised.json
@@ -12,58 +12,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "MachineName": 1
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 0
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 1
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -113,90 +132,109 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWeightedSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": -1
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 3
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": -1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 3
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": -1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 3
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatWeightedSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": -1
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 3
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 2
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -243,8 +281,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 634,
+    "id": 0,
     "next_machine_name": 5,
     "parent": null,
     "table": [
@@ -253,7 +292,7 @@
           "UserName": "x"
         },
         {
-          "id": 7,
+          "id": 16,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -278,7 +317,7 @@
           "UserName": "y"
         },
         {
-          "id": 8,
+          "id": 17,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -303,7 +342,7 @@
           "UserName": "z"
         },
         {
-          "id": 9,
+          "id": 18,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -328,7 +367,7 @@
           "MachineName": 0
         },
         {
-          "id": 10,
+          "id": 19,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -353,7 +392,7 @@
           "MachineName": 1
         },
         {
-          "id": 11,
+          "id": 20,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -378,7 +417,7 @@
           "MachineName": 2
         },
         {
-          "id": 12,
+          "id": 21,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -403,7 +442,7 @@
           "MachineName": 3
         },
         {
-          "id": 13,
+          "id": 22,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -428,7 +467,7 @@
           "MachineName": 4
         },
         {
-          "id": 14,
+          "id": 23,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
@@ -17,17 +17,17 @@ UnsafeDiv(a, b),
 
 ({SafeDiv(a, b) @ (b != 0)} = 2), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(a, b) = 2) @ And([(b != 0)])} 
+{(SafeDiv(a, b) = 2) @ and([(b != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(a, b) = 2) @ And([(b != 0)])}, 
+{(SafeDiv(a, b) = 2) @ and([(b != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(a, b) = 2), And([(b != 0)])]) 
+and([(SafeDiv(a, b) = 2),and([(b != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(b != 0)]), 
+and([(b != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (b != 0) 
 
@@ -46,5 +46,5 @@ find b: int(0..4)
 
 such that
 
-And([DivEq(a, b, 2), (b != 0)])
+and([DivEq(a, b, 2),(b != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/div/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/01/input.expected-rewrite.serialised.json
@@ -12,65 +12,84 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "b"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]

--- a/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
@@ -16,17 +16,17 @@ UnsafeDiv(8, a),
 
 (2 = {SafeDiv(8, a) @ (a != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(2 = SafeDiv(8, a)) @ And([(a != 0)])} 
+{(2 = SafeDiv(8, a)) @ and([(a != 0);int(1..)])} 
 
 --
 
-{(2 = SafeDiv(8, a)) @ And([(a != 0)])}, 
+{(2 = SafeDiv(8, a)) @ and([(a != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(2 = SafeDiv(8, a)), And([(a != 0)])]) 
+and([(2 = SafeDiv(8, a)),and([(a != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(a != 0)]), 
+and([(a != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (a != 0) 
 
@@ -44,5 +44,5 @@ find a: int(0..9)
 
 such that
 
-And([DivEq(8, a, 2), (a != 0)])
+and([DivEq(8, a, 2),(a != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/div/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/03/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 8
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 8
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "a"
         },
         {
-          "id": 0,
+          "id": 34,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
@@ -18,25 +18,25 @@ UnsafeDiv(b, c),
 
 (a = {SafeDiv(b, c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeDiv(b, c)) @ And([(c != 0)])} 
+{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a = SafeDiv(b, c)) @ And([(c != 0)])}, 
+{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a = SafeDiv(b, c)), And([(c != 0)])]) 
+and([(a = SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
 --
 
-Not(And([(a = SafeDiv(b, c)), (c != 0)])), 
+Not(and([(a = SafeDiv(b, c)),(c != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeDiv(b, c))), Not((c != 0))]) 
+or([Not((a = SafeDiv(b, c))),Not((c != 0));int(1..)]) 
 
 --
 
@@ -76,6 +76,6 @@ find __0: int(0..3)
 
 such that
 
-Or([(a != __0), (c = 0)]),
+or([(a != __0),(c = 0);int(1..)]),
 DivEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/div/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/04/input.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 158,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
@@ -18,17 +18,17 @@ UnsafeDiv(b, c),
 
 (a != {SafeDiv(b, c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a != SafeDiv(b, c)) @ And([(c != 0)])} 
+{(a != SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a != SafeDiv(b, c)) @ And([(c != 0)])}, 
+{(a != SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a != SafeDiv(b, c)), And([(c != 0)])]) 
+and([(a != SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
@@ -58,6 +58,6 @@ find __0: int(0..3)
 
 such that
 
-And([(a != __0), (c != 0)]),
+and([(a != __0),(c != 0);int(1..)]),
 DivEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/div/05/div-05.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 127,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
@@ -18,25 +18,25 @@ UnsafeDiv(b, c),
 
 (a = {SafeDiv(b, c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeDiv(b, c)) @ And([(c != 0)])} 
+{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a = SafeDiv(b, c)) @ And([(c != 0)])}, 
+{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a = SafeDiv(b, c)), And([(c != 0)])]) 
+and([(a = SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
 --
 
-Not(And([(a = SafeDiv(b, c)), (c != 0)])), 
+Not(and([(a = SafeDiv(b, c)),(c != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeDiv(b, c))), Not((c != 0))]) 
+or([Not((a = SafeDiv(b, c))),Not((c != 0));int(1..)]) 
 
 --
 
@@ -76,6 +76,6 @@ find __0: int(0..3)
 
 such that
 
-Or([(a != __0), (c = 0)]),
+or([(a != __0),(c = 0);int(1..)]),
 DivEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/div/06/div-06.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 158,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/02-flattening/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/02-flattening/input-expected-rule-trace-human.txt
@@ -25,13 +25,13 @@ Sum([3, -1]),
 
 (Sum([y, z]) = 8), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([y, z], 8), SumGeq([y, z], 8)]) 
+and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]) 
 
 --
 
 (Sum([x, 2]) = 3), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]) 
+and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]) 
 
 --
 
@@ -56,24 +56,24 @@ Reify((x <= 2), __0)
 
 --
 
-(And([SumLeq([y, z], 8), SumGeq([y, z], 8)])) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])), 
+(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)])) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])), 
    ~~> flatten_imply ([("Minion", 4200)]) 
-(__1) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])) 
+(__1) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])) 
 new variables:
   find __1: bool
 new constraints:
-  __1 =aux And([SumLeq([y, z], 8), SumGeq([y, z], 8)])
+  __1 =aux and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)])
 --
 
-(__1) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])), 
+(__1) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])), 
    ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
-ReifyImply(And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]), __1) 
+ReifyImply(and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]), __1) 
 
 --
 
-__1 =aux And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), 
+__1 =aux and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), 
    ~~> bool_eq_to_reify ([("Minion", 4400)]) 
-Reify(And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), __1) 
+Reify(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), __1) 
 
 --
 
@@ -100,7 +100,7 @@ find __1: bool
 such that
 
 ReifyImply(Ineq(5, y, 0), __0),
-ReifyImply(And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]), __1),
+ReifyImply(and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]), __1),
 Reify(Ineq(x, 2, 0), __0),
-Reify(And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), __1)
+Reify(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), __1)
 

--- a/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/02-flattening/input.expected-rewrite.serialised.json
@@ -52,58 +52,77 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "FlatSumLeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "x"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "FlatSumLeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "x"
+                                  }
+                                },
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "FlatSumGeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "x"
+                                  }
+                                },
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
                           }
-                        },
+                        ],
                         {
-                          "Literal": {
-                            "Int": 2
-                          }
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 3
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "FlatSumGeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "x"
-                          }
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
-                          }
-                        }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 3
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -159,58 +178,77 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "FlatSumLeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "y"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "FlatSumLeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "y"
+                                  }
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "z"
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 8
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "FlatSumGeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "y"
+                                  }
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "z"
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 8
+                                }
+                              }
+                            ]
                           }
-                        },
+                        ],
                         {
-                          "Reference": {
-                            "UserName": "z"
-                          }
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 8
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "FlatSumGeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "z"
-                          }
-                        }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 8
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -223,8 +261,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 536,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input-expected-rule-trace-human.txt
@@ -10,8 +10,8 @@ find z: bool
 such that
 
 (x) -> (x),
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))])
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)])
 
 --
 
@@ -22,30 +22,53 @@ true
 --
 
 true,
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))]), 
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))]) 
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)]) 
 
 --
 
-Or([(a) -> (z), (z) -> (a)]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-true 
+(a) -> (z), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(a, z, 0) 
 
 --
 
-true,
-Or([(b) -> (c), (b) -> (Not(c))]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([(b) -> (c), (b) -> (Not(c))]) 
+(z) -> (a), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(z, a, 0) 
 
 --
 
-Or([(b) -> (c), (b) -> (Not(c))]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-true 
+(b) -> (c), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(b, c, 0) 
+
+--
+
+(b) -> (Not(c)), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+ReifyImply(Not(c), b) 
+
+--
+
+Not(c), 
+   ~~> not_literal_to_wliteral ([("Minion", 4100)]) 
+WatchedLiteral(c,false) 
+
+--
+
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..)]) 
+
+--
+
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..)]) 
 
 --
 
@@ -60,5 +83,6 @@ find z: bool
 
 such that
 
-true
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..)]),
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-parse.serialised.json
@@ -46,76 +46,98 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -124,89 +146,112 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Not": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
+                        "Imply": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "c"
-                            }
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Not": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "c"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
                           }
                         ]
                       }
-                    ]
-                  }
-                ]
-              }
-            ]
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,

--- a/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/03-tautologies/input.expected-rewrite.serialised.json
@@ -7,23 +7,159 @@
       },
       [
         {
-          "Atomic": [
+          "Or": [
             {
               "clean": false,
               "etype": null
             },
             {
-              "Literal": {
-                "Bool": true
-              }
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      },
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatWatchedLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UserName": "c"
+                              },
+                              {
+                                "Bool": false
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 38,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input-expected-rule-trace-human.txt
@@ -22,7 +22,7 @@ Not((Not(x)) -> (Not(y))),
 
 Not((Not(x)) -> (Not(y))), 
    ~~> normalise_implies_negation ([("Base", 8800)]) 
-And([Not(x), Not(Not(y))]) 
+and([Not(x),Not(Not(y));int(1..)]) 
 
 --
 
@@ -46,13 +46,13 @@ y
 
 (c) -> ((d) -> (e)), 
    ~~> normalise_implies_uncurry ([("Base", 8400)]) 
-(And([c, d])) -> (e) 
+(and([c,d;int(1..)])) -> (e) 
 
 --
 
 (h) -> ((f) -> (g)), 
    ~~> normalise_implies_uncurry ([("Base", 8400)]) 
-(And([h, f])) -> (g) 
+(and([h,f;int(1..)])) -> (g) 
 
 --
 
@@ -62,13 +62,13 @@ Ineq(b, a, 0)
 
 --
 
-(And([c, d])) -> (e), 
+(and([c,d;int(1..)])) -> (e), 
    ~~> flatten_imply ([("Minion", 4200)]) 
 (__0) -> (e) 
 new variables:
   find __0: bool
 new constraints:
-  __0 =aux And([c, d])
+  __0 =aux and([c,d;int(1..)])
 --
 
 (__0) -> (e), 
@@ -77,19 +77,19 @@ Ineq(__0, e, 0)
 
 --
 
-__0 =aux And([c, d]), 
+__0 =aux and([c,d;int(1..)]), 
    ~~> bool_eq_to_reify ([("Minion", 4400)]) 
-Reify(And([c, d]), __0) 
+Reify(and([c,d;int(1..)]), __0) 
 
 --
 
-(And([h, f])) -> (g), 
+(and([h,f;int(1..)])) -> (g), 
    ~~> flatten_imply ([("Minion", 4200)]) 
 (__1) -> (g) 
 new variables:
   find __1: bool
 new constraints:
-  __1 =aux And([h, f])
+  __1 =aux and([h,f;int(1..)])
 --
 
 (__1) -> (g), 
@@ -98,9 +98,9 @@ Ineq(__1, g, 0)
 
 --
 
-__1 =aux And([h, f]), 
+__1 =aux and([h,f;int(1..)]), 
    ~~> bool_eq_to_reify ([("Minion", 4400)]) 
-Reify(And([h, f]), __1) 
+Reify(and([h,f;int(1..)]), __1) 
 
 --
 
@@ -127,10 +127,10 @@ find __1: bool
 
 such that
 
-And([WatchedLiteral(x,false), y]),
+and([WatchedLiteral(x,false),y;int(1..)]),
 Ineq(b, a, 0),
 Ineq(__0, e, 0),
 Ineq(__1, g, 0),
-Reify(And([c, d]), __0),
-Reify(And([h, f]), __1)
+Reify(and([c,d;int(1..)]), __0),
+Reify(and([h,f;int(1..)]), __1)
 

--- a/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/04-needs-normalising/input.expected-rewrite.serialised.json
@@ -12,35 +12,54 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWatchedLiteral": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "UserName": "x"
-                  },
-                  {
-                    "Bool": false
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWatchedLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "UserName": "x"
+                          },
+                          {
+                            "Bool": false
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -118,34 +137,53 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "d"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "d"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -167,34 +205,53 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "h"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "h"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "f"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "f"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -207,8 +264,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 477,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input-expected-rule-trace-human.txt
@@ -25,13 +25,13 @@ Sum([3, -1]),
 
 (Sum([y, z]) = 8), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([y, z], 8), SumGeq([y, z], 8)]) 
+and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]) 
 
 --
 
 (Sum([x, 2]) = 3), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]) 
+and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]) 
 
 --
 
@@ -56,24 +56,24 @@ Reify((x <= 2), __0)
 
 --
 
-(And([SumLeq([y, z], 8), SumGeq([y, z], 8)])) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])), 
+(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)])) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])), 
    ~~> flatten_imply ([("Minion", 4200)]) 
-(__1) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])) 
+(__1) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])) 
 new variables:
   find __1: bool
 new constraints:
-  __1 =aux And([SumLeq([y, z], 8), SumGeq([y, z], 8)])
+  __1 =aux and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)])
 --
 
-(__1) -> (And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)])), 
+(__1) -> (and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)])), 
    ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
-ReifyImply(And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]), __1) 
+ReifyImply(and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]), __1) 
 
 --
 
-__1 =aux And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), 
+__1 =aux and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), 
    ~~> bool_eq_to_reify ([("Minion", 4400)]) 
-Reify(And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), __1) 
+Reify(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), __1) 
 
 --
 
@@ -100,7 +100,7 @@ find __1: bool
 such that
 
 ReifyImply(Ineq(5, y, 0), __0),
-ReifyImply(And([SumLeq([x, 2], 3), SumGeq([x, 2], 3)]), __1),
+ReifyImply(and([SumLeq([x, 2], 3),SumGeq([x, 2], 3);int(1..)]), __1),
 Reify(Ineq(x, 2, 0), __0),
-Reify(And([SumLeq([y, z], 8), SumGeq([y, z], 8)]), __1)
+Reify(and([SumLeq([y, z], 8),SumGeq([y, z], 8);int(1..)]), __1)
 

--- a/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input.expected-rewrite.serialised.json
@@ -52,58 +52,77 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "FlatSumLeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "x"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "FlatSumLeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "x"
+                                  }
+                                },
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "FlatSumGeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "x"
+                                  }
+                                },
+                                {
+                                  "Literal": {
+                                    "Int": 2
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
                           }
-                        },
+                        ],
                         {
-                          "Literal": {
-                            "Int": 2
-                          }
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 3
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "FlatSumGeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "x"
-                          }
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
-                          }
-                        }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 3
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -159,58 +178,77 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "FlatSumLeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "y"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "FlatSumLeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "y"
+                                  }
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "z"
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 8
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "FlatSumGeq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              [
+                                {
+                                  "Reference": {
+                                    "UserName": "y"
+                                  }
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "z"
+                                  }
+                                }
+                              ],
+                              {
+                                "Literal": {
+                                  "Int": 8
+                                }
+                              }
+                            ]
                           }
-                        },
+                        ],
                         {
-                          "Reference": {
-                            "UserName": "z"
-                          }
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
                         }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 8
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "FlatSumGeq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      [
-                        {
-                          "Reference": {
-                            "UserName": "y"
-                          }
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "z"
-                          }
-                        }
-                      ],
-                      {
-                        "Literal": {
-                          "Int": 8
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -223,8 +261,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 536,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
@@ -4,6 +4,11 @@ find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
 
 such that
 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1)
 
@@ -15,6 +20,11 @@ find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
 
 such that
 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1)
 

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.eprime
@@ -4,11 +4,11 @@ find a: matrix indexed by [int(1..3),int(1..2)] of int(1..3)
 
 such that
 
-$ allDiff(a[..,1]), 
-$ allDiff(a[..,2]), 
-$ allDiff(a[1,..]), 
-$ allDiff(a[2,..]), 
-$ allDiff(a[3,..]),
+allDiff(a[..,1]), 
+allDiff(a[..,2]), 
+allDiff(a[1,..]), 
+allDiff(a[2,..]), 
+allDiff(a[3,..]),
 
 $ symmetry breaking
 a[1,1] = 1,

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.expected-parse.serialised.json
@@ -7,6 +7,231 @@
       },
       [
         {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
           "Eq": [
             {
               "clean": false,

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input.expected-rewrite.serialised.json
@@ -7,6 +7,231 @@
       },
       [
         {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
           "Eq": [
             {
               "clean": false,

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
@@ -5,14 +5,29 @@ find a: MATRIX
 
 such that
 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1)
 
 --
 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1), 
    ~~> substitute_domain_lettings ([("Base", 5000)]) 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1) 
 
@@ -25,6 +40,11 @@ find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..3)
 
 such that
 
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[..,3]),
 (a[[1, 1]] = 1),
 (a[[2, 2]] = 1)
 

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.eprime
@@ -7,11 +7,11 @@ find a: MATRIX
 
 such that
 
-$allDiff(a[..,1]),
-$allDiff(a[..,2]),
-$allDiff(a[1,..]),
-$allDiff(a[2,..]),
-$allDiff(a[3,..]),
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[3,..]),
 
 $ symmetry breaking
 a[1,1] = 1,

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.expected-parse.serialised.json
@@ -7,6 +7,231 @@
       },
       [
         {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
           "Eq": [
             {
               "clean": false,

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input.expected-rewrite.serialised.json
@@ -7,6 +7,231 @@
       },
       [
         {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  null
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "AllDiff": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeSlice": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  null,
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
           "Eq": [
             {
               "clean": false,

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/config.toml
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/config.toml
@@ -1,0 +1,2 @@
+enable_native_parser=false
+solve_with_minion=false

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input-expected-rule-trace-human.txt
@@ -1,0 +1,49 @@
+Model before rewriting:
+
+letting a be [[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)]
+find b: int(1..10)
+
+such that
+
+(b > a[[3, 3]])
+
+--
+
+(b > a[[3, 3]]), 
+   ~~> gt_to_geq ([("Minion", 8400)]) 
+(Sum([b, -1]) >= a[[3, 3]]) 
+
+--
+
+a, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+[[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)] 
+
+--
+
+(Sum([b, -1]) >= [[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)][[3, 3]]), 
+   ~~> flatten_generic ([("Minion", 4200)]) 
+(__0 >= [[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)][[3, 3]]) 
+new variables:
+  find __0: int(0..9)
+new constraints:
+  __0 =aux Sum([b, -1])
+--
+
+__0 =aux Sum([b, -1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([b, -1], __0),SumGeq([b, -1], __0);int(1..)]) 
+
+--
+
+Final model:
+
+letting a be [[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)]
+find b: int(1..10)
+find __0: int(0..9)
+
+such that
+
+(__0 >= [[1,2,3;int(1..)],[4,5,6;int(1..)],[7,8,9;int(1..)];int(1..)][[3, 3]]),
+and([SumLeq([b, -1], __0),SumGeq([b, -1], __0);int(1..)])
+

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.eprime
@@ -1,0 +1,8 @@
+language ESSENCE' 1.0
+
+letting a be [[1,2,3],[4,5,6],[7,8,9]]
+find b: int(1..10)
+
+such that
+
+b > a[3,3]

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.expected-parse.serialised.json
@@ -1,0 +1,329 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Gt": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 98,
+          "kind": {
+            "ValueLetting": {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 4
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 5
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 6
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 7
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 8
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 9
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "b"
+        },
+        {
+          "id": 99,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      10
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "b"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input.expected-rewrite.serialised.json
@@ -1,0 +1,621 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Geq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "MachineName": 0
+                  }
+                }
+              ]
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 1
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 2
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 3
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 4
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 5
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 6
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 7
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 8
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 9
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "UnboundedR": 1
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 1,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 98,
+          "kind": {
+            "ValueLetting": {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 4
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 5
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 6
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 7
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 8
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 9
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "b"
+        },
+        {
+          "id": 99,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      10
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "b"
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 0
+        },
+        {
+          "id": 100,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      0,
+                      9
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 0
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/parsed.json
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/parsed.json
@@ -1,0 +1,67 @@
+{"mInfo":
+     {"finds": [], "givens": [], "enumGivens": [], "enumLettings": [], "lettings": [], "unnameds": [],
+      "strategyQ": {"Auto": {"Interactive": []}}, "strategyA": {"Auto": {"Interactive": []}}, "trailCompact": [],
+      "nameGenState": [], "nbExtraGivens": 0, "representations": [], "representationsTree": [], "originalDomains": [],
+      "trailGeneralised": [], "trailVerbose": [], "trailRewrites": []},
+ "mLanguage": {"language": {"Name": "ESSENCE'"}, "version": [1, 0]},
+ "mStatements":
+     [{"Declaration":
+           {"Letting":
+                [{"Name": "a"},
+                 {"Constant":
+                      {"ConstantAbstract":
+                           {"AbsLitMatrix":
+                                [{"DomainInt":
+                                      [{"TagInt": []},
+                                       [{"RangeBounded":
+                                             [{"ConstantInt": [{"TagInt": []}, 1]},
+                                              {"ConstantInt": [{"TagInt": []}, 3]}]}]]},
+                                 [{"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeBounded":
+                                                         [{"ConstantInt": [{"TagInt": []}, 1]},
+                                                          {"ConstantInt": [{"TagInt": []}, 3]}]}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 1]},
+                                              {"ConstantInt": [{"TagInt": []}, 2]},
+                                              {"ConstantInt": [{"TagInt": []}, 3]}]]}},
+                                  {"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeBounded":
+                                                         [{"ConstantInt": [{"TagInt": []}, 1]},
+                                                          {"ConstantInt": [{"TagInt": []}, 3]}]}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 4]},
+                                              {"ConstantInt": [{"TagInt": []}, 5]},
+                                              {"ConstantInt": [{"TagInt": []}, 6]}]]}},
+                                  {"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeBounded":
+                                                         [{"ConstantInt": [{"TagInt": []}, 1]},
+                                                          {"ConstantInt": [{"TagInt": []}, 3]}]}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 7]},
+                                              {"ConstantInt": [{"TagInt": []}, 8]},
+                                              {"ConstantInt": [{"TagInt": []}, 9]}]]}}]]}}}]}},
+      {"Declaration":
+           {"FindOrGiven":
+                ["Find", {"Name": "b"},
+                 {"DomainInt":
+                      [{"TagInt": []},
+                       [{"RangeBounded":
+                             [{"Constant": {"ConstantInt": [{"TagInt": []}, 1]}},
+                              {"Constant": {"ConstantInt": [{"TagInt": []}, 10]}}]}]]}]}},
+      {"SuchThat":
+           [{"Op":
+                 {"MkOpGt":
+                      [{"Reference": [{"Name": "b"}, null]},
+                       {"Op":
+                            {"MkOpIndexing":
+                                 [{"Op":
+                                       {"MkOpIndexing":
+                                            [{"Reference": [{"Name": "a"}, null]},
+                                             {"Constant": {"ConstantInt": [{"TagInt": []}, 3]}}]}},
+                                  {"Constant": {"ConstantInt": [{"TagInt": []}, 3]}}]}}]}}]}]}

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/config.toml
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/config.toml
@@ -1,0 +1,2 @@
+enable_native_parser=false
+solve_with_minion=false

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input-expected-rule-trace-human.txt
@@ -1,0 +1,32 @@
+Model before rewriting:
+
+letting a be [[1,2,3;int(1..)],[1,3,2;int(1..)],[3,2,1;int(1..)];int(1..)]
+find b: int(1..5)
+
+such that
+
+(b < a[[0, 1]])
+
+--
+
+(b < a[[0, 1]]), 
+   ~~> lt_to_leq ([("Minion", 8400)]) 
+(b <= Sum([a[[0, 1]], -1])) 
+
+--
+
+a, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+[[1,2,3;int(1..)],[1,3,2;int(1..)],[3,2,1;int(1..)];int(1..)] 
+
+--
+
+Final model:
+
+letting a be [[1,2,3;int(1..)],[1,3,2;int(1..)],[3,2,1;int(1..)];int(1..)]
+find b: int(1..5)
+
+such that
+
+(b <= Sum([[[1,2,3;int(1..)],[1,3,2;int(1..)],[3,2,1;int(1..)];int(1..)][[0, 1]], -1]))
+

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.eprime
@@ -1,0 +1,11 @@
+$ a value letting with explicit index domains
+$
+$ see savile row manual 2.1.3
+language ESSENCE' 1.0
+
+letting a be [ [ 1,2,3 ; int(1,2,4) ], [ 1,3,2 ; int(1,2,4) ], [ 3,2,1 ; int(1,2,4) ] ; int(-2..0) ]
+find b: int(1..5)
+
+such that
+
+b < a[1,0]

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.expected-parse.serialised.json
@@ -1,0 +1,329 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Lt": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 0
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 101,
+          "kind": {
+            "ValueLetting": {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "b"
+        },
+        {
+          "id": 102,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "b"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input.expected-rewrite.serialised.json
@@ -1,0 +1,540 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Leq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "b"
+                  }
+                }
+              ]
+            },
+            {
+              "Sum": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                [
+                  {
+                    "UnsafeIndex": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "AbstractLiteral": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Matrix": [
+                                        [
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 1
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 2
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 3
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        {
+                                          "IntDomain": [
+                                            {
+                                              "UnboundedR": 1
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "AbstractLiteral": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Matrix": [
+                                        [
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 1
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 3
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 2
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        {
+                                          "IntDomain": [
+                                            {
+                                              "UnboundedR": 1
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "AbstractLiteral": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Matrix": [
+                                        [
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 3
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 2
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "Atomic": [
+                                              {
+                                                "clean": false,
+                                                "etype": null
+                                              },
+                                              {
+                                                "Literal": {
+                                                  "Int": 1
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        {
+                                          "IntDomain": [
+                                            {
+                                              "UnboundedR": 1
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      [
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 0
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "Atomic": [
+                            {
+                              "clean": false,
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": -1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 101,
+          "kind": {
+            "ValueLetting": {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 3
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 2
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 1
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "b"
+        },
+        {
+          "id": 102,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "b"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/parsed.json
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/parsed.json
@@ -1,0 +1,67 @@
+{"mInfo":
+     {"finds": [], "givens": [], "enumGivens": [], "enumLettings": [], "lettings": [], "unnameds": [],
+      "strategyQ": {"Auto": {"Interactive": []}}, "strategyA": {"Auto": {"Interactive": []}}, "trailCompact": [],
+      "nameGenState": [], "nbExtraGivens": 0, "representations": [], "representationsTree": [], "originalDomains": [],
+      "trailGeneralised": [], "trailVerbose": [], "trailRewrites": []},
+ "mLanguage": {"language": {"Name": "ESSENCE'"}, "version": [1, 0]},
+ "mStatements":
+     [{"Declaration":
+           {"Letting":
+                [{"Name": "a"},
+                 {"Constant":
+                      {"ConstantAbstract":
+                           {"AbsLitMatrix":
+                                [{"DomainInt":
+                                      [{"TagInt": []},
+                                       [{"RangeBounded":
+                                             [{"ConstantInt": [{"TagInt": []}, -2]},
+                                              {"ConstantInt": [{"TagInt": []}, 0]}]}]]},
+                                 [{"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeSingle": {"ConstantInt": [{"TagInt": []}, 1]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 2]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 4]}}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 1]},
+                                              {"ConstantInt": [{"TagInt": []}, 2]},
+                                              {"ConstantInt": [{"TagInt": []}, 3]}]]}},
+                                  {"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeSingle": {"ConstantInt": [{"TagInt": []}, 1]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 2]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 4]}}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 1]},
+                                              {"ConstantInt": [{"TagInt": []}, 3]},
+                                              {"ConstantInt": [{"TagInt": []}, 2]}]]}},
+                                  {"ConstantAbstract":
+                                       {"AbsLitMatrix":
+                                            [{"DomainInt":
+                                                  [{"TagInt": []},
+                                                   [{"RangeSingle": {"ConstantInt": [{"TagInt": []}, 1]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 2]}},
+                                                    {"RangeSingle": {"ConstantInt": [{"TagInt": []}, 4]}}]]},
+                                             [{"ConstantInt": [{"TagInt": []}, 3]},
+                                              {"ConstantInt": [{"TagInt": []}, 2]},
+                                              {"ConstantInt": [{"TagInt": []}, 1]}]]}}]]}}}]}},
+      {"Declaration":
+           {"FindOrGiven":
+                ["Find", {"Name": "b"},
+                 {"DomainInt":
+                      [{"TagInt": []},
+                       [{"RangeBounded":
+                             [{"Constant": {"ConstantInt": [{"TagInt": []}, 1]}},
+                              {"Constant": {"ConstantInt": [{"TagInt": []}, 5]}}]}]]}]}},
+      {"SuchThat":
+           [{"Op":
+                 {"MkOpLt":
+                      [{"Reference": [{"Name": "b"}, null]},
+                       {"Op":
+                            {"MkOpIndexing":
+                                 [{"Op":
+                                       {"MkOpIndexing":
+                                            [{"Reference": [{"Name": "a"}, null]},
+                                             {"Constant": {"ConstantInt": [{"TagInt": []}, 1]}}]}},
+                                  {"Constant": {"ConstantInt": [{"TagInt": []}, 0]}}]}}]}}]}]}

--- a/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/max/02/input-expected-rule-trace-human.txt
@@ -4,11 +4,17 @@ find a: int(0..3)
 
 such that
 
-(Max([2, a]) <= 2)
+(max([2,a;int(1..2)]) <= 2)
 
 --
 
-Max([2, a]), 
+max([2,a;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+max([2,a;int(1..)]) 
+
+--
+
+max([2,a;int(1..)]), 
    ~~> max_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -16,7 +22,7 @@ new variables:
 new constraints:
   (__0 >= 2)
   (__0 >= a)
-  Or([(__0 = 2), (__0 = a)])
+  or([(__0 = 2),(__0 = a);int(1..)])
 --
 
 (__0 <= 2), 
@@ -47,5 +53,5 @@ such that
 Ineq(__0, 2, 0),
 Ineq(2, __0, 0),
 Ineq(a, __0, 0),
-Or([(__0 = 2), (__0 = a)])
+or([(__0 = 2),(__0 = a);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 91,
+          "id": 103,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
@@ -180,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 98,
+          "id": 103,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -205,7 +205,7 @@
           "MachineName": 0
         },
         {
-          "id": 99,
+          "id": 104,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/max/02/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 91,
+          "id": 98,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "MachineName": 0
         },
         {
-          "id": 92,
+          "id": 99,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/max/02/parsed.json
+++ b/conjure_oxide/tests/integration/basic/max/02/parsed.json
@@ -1,0 +1,30 @@
+{"mInfo":
+     {"finds": [], "givens": [], "enumGivens": [], "enumLettings": [], "lettings": [], "unnameds": [],
+      "strategyQ": {"Auto": {"Interactive": []}}, "strategyA": {"Auto": {"Interactive": []}}, "trailCompact": [],
+      "nameGenState": [], "nbExtraGivens": 0, "representations": [], "representationsTree": [], "originalDomains": [],
+      "trailGeneralised": [], "trailVerbose": [], "trailRewrites": []},
+ "mLanguage": {"language": {"Name": "Essence"}, "version": [1, 3]},
+ "mStatements":
+     [{"Declaration":
+           {"FindOrGiven":
+                ["Find", {"Name": "a"},
+                 {"DomainInt":
+                      [{"TagInt": []},
+                       [{"RangeBounded":
+                             [{"Constant": {"ConstantInt": [{"TagInt": []}, 0]}},
+                              {"Constant": {"ConstantInt": [{"TagInt": []}, 3]}}]}]]}]}},
+      {"SuchThat":
+           [{"Op":
+                 {"MkOpLeq":
+                      [{"Op":
+                            {"MkOpMax":
+                                 {"AbstractLiteral":
+                                      {"AbsLitMatrix":
+                                           [{"DomainInt":
+                                                 [{"TagInt": []},
+                                                  [{"RangeBounded":
+                                                        [{"Constant": {"ConstantInt": [{"TagInt": []}, 1]}},
+                                                         {"Constant": {"ConstantInt": [{"TagInt": []}, 2]}}]}]]},
+                                            [{"Constant": {"ConstantInt": [{"TagInt": []}, 2]}},
+                                             {"Reference": [{"Name": "a"}, null]}]]}}}},
+                       {"Constant": {"ConstantInt": [{"TagInt": []}, 2]}}]}}]}]}

--- a/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/01/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(1..3)
 
 such that
 
-(Min([a, b]) >= 3)
+(min([a,b;int(1..2)]) >= 3)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 >= 3), 
@@ -49,5 +55,5 @@ such that
 Ineq(3, __0, 0),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 93,
+          "id": 105,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -101,7 +124,7 @@
           "UserName": "b"
         },
         {
-          "id": 94,
+          "id": 106,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
@@ -180,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 100,
+          "id": 105,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -205,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 101,
+          "id": 106,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -230,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 102,
+          "id": 107,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/01/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 93,
+          "id": 100,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 94,
+          "id": 101,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -210,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 95,
+          "id": 102,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/02/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(1..3)
 
 such that
 
-(Min([a, b]) <= 2)
+(min([a,b;int(1..2)]) <= 2)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 <= 2), 
@@ -49,5 +55,5 @@ such that
 Ineq(__0, 2, 0),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 96,
+          "id": 108,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -101,7 +124,7 @@
           "UserName": "b"
         },
         {
-          "id": 97,
+          "id": 109,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/02/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 96,
+          "id": 103,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 97,
+          "id": 104,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -210,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 98,
+          "id": 105,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/03/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(2..4)
 
 such that
 
-(Min([a, b]) <= 2)
+(min([a,b;int(1..2)]) <= 2)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 <= 2), 
@@ -49,5 +55,5 @@ such that
 Ineq(__0, 2, 0),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 99,
+          "id": 111,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -101,7 +124,7 @@
           "UserName": "b"
         },
         {
-          "id": 100,
+          "id": 112,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/03/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 99,
+          "id": 106,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 100,
+          "id": 107,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -210,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 101,
+          "id": 108,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/04/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(4..7)
 
 such that
 
-(Min([a, b]) >= 3)
+(min([a,b;int(1..2)]) >= 3)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 >= 3), 
@@ -49,5 +55,5 @@ such that
 Ineq(3, __0, 0),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 102,
+          "id": 114,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -101,7 +124,7 @@
           "UserName": "b"
         },
         {
-          "id": 103,
+          "id": 115,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
@@ -180,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 109,
+          "id": 114,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -205,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 110,
+          "id": 115,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -230,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 111,
+          "id": 116,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/04/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 102,
+          "id": 109,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 103,
+          "id": 110,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -210,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 104,
+          "id": 111,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/min/05/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(2..4)
 
 such that
 
-(Min([a, b]) <= 2)
+(min([a,b;int(1..2)]) <= 2)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 <= 2), 
@@ -49,5 +55,5 @@ such that
 Ineq(__0, 2, 0),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -66,6 +88,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -76,7 +99,7 @@
           "UserName": "a"
         },
         {
-          "id": 105,
+          "id": 117,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -101,7 +124,7 @@
           "UserName": "b"
         },
         {
-          "id": 106,
+          "id": 118,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/min/05/input.expected-rewrite.serialised.json
@@ -75,83 +75,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 193,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -160,7 +180,7 @@
           "UserName": "a"
         },
         {
-          "id": 105,
+          "id": 112,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -185,7 +205,7 @@
           "UserName": "b"
         },
         {
-          "id": 106,
+          "id": 113,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -210,7 +230,7 @@
           "MachineName": 0
         },
         {
-          "id": 107,
+          "id": 114,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
@@ -17,17 +17,17 @@ a % b,
 
 ({SafeMod(a,b) @ (b != 0)} = 1), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(a,b) = 1) @ And([(b != 0)])} 
+{(SafeMod(a,b) = 1) @ and([(b != 0);int(1..)])} 
 
 --
 
-{(SafeMod(a,b) = 1) @ And([(b != 0)])}, 
+{(SafeMod(a,b) = 1) @ and([(b != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(a,b) = 1), And([(b != 0)])]) 
+and([(SafeMod(a,b) = 1),and([(b != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(b != 0)]), 
+and([(b != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (b != 0) 
 
@@ -46,5 +46,5 @@ find b: int(0..3)
 
 such that
 
-And([ModEq(a, b, 1), (b != 0)])
+and([ModEq(a, b, 1),(b != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/mod/01/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/01/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 1
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 1
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "b"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "a"
         },
         {
-          "id": 108,
+          "id": 115,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -111,7 +131,7 @@
           "UserName": "b"
         },
         {
-          "id": 109,
+          "id": 116,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
@@ -16,17 +16,17 @@ such that
 
 (2 = {SafeMod(8,a) @ (a != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(2 = SafeMod(8,a)) @ And([(a != 0)])} 
+{(2 = SafeMod(8,a)) @ and([(a != 0);int(1..)])} 
 
 --
 
-{(2 = SafeMod(8,a)) @ And([(a != 0)])}, 
+{(2 = SafeMod(8,a)) @ and([(a != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(2 = SafeMod(8,a)), And([(a != 0)])]) 
+and([(2 = SafeMod(8,a)),and([(a != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(a != 0)]), 
+and([(a != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (a != 0) 
 
@@ -44,5 +44,5 @@ find a: int(0..9)
 
 such that
 
-And([ModEq(8, a, 2), (a != 0)])
+and([ModEq(8, a, 2),(a != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/mod/03/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/03/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 8
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 8
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "a"
         },
         {
-          "id": 112,
+          "id": 119,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
@@ -18,25 +18,25 @@ b % c,
 
 (a = {SafeMod(b,c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeMod(b,c)) @ And([(c != 0)])} 
+{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a = SafeMod(b,c)) @ And([(c != 0)])}, 
+{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a = SafeMod(b,c)), And([(c != 0)])]) 
+and([(a = SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
 --
 
-Not(And([(a = SafeMod(b,c)), (c != 0)])), 
+Not(and([(a = SafeMod(b,c)),(c != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeMod(b,c))), Not((c != 0))]) 
+or([Not((a = SafeMod(b,c))),Not((c != 0));int(1..)]) 
 
 --
 
@@ -76,6 +76,6 @@ find __0: int(0..2)
 
 such that
 
-Or([(a != __0), (c = 0)]),
+or([(a != __0),(c = 0);int(1..)]),
 ModEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/mod/04/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/04/input.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 158,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -120,7 +140,7 @@
           "UserName": "a"
         },
         {
-          "id": 114,
+          "id": 121,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -145,7 +165,7 @@
           "UserName": "b"
         },
         {
-          "id": 115,
+          "id": 122,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -170,7 +190,7 @@
           "UserName": "c"
         },
         {
-          "id": 116,
+          "id": 123,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -195,7 +215,7 @@
           "MachineName": 0
         },
         {
-          "id": 117,
+          "id": 124,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
@@ -18,17 +18,17 @@ b % c,
 
 (a != {SafeMod(b,c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a != SafeMod(b,c)) @ And([(c != 0)])} 
+{(a != SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a != SafeMod(b,c)) @ And([(c != 0)])}, 
+{(a != SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a != SafeMod(b,c)), And([(c != 0)])]) 
+and([(a != SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
@@ -58,6 +58,6 @@ find __0: int(0..2)
 
 such that
 
-And([(a != __0), (c != 0)]),
+and([(a != __0),(c != 0);int(1..)]),
 ModEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 127,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -120,7 +140,7 @@
           "UserName": "a"
         },
         {
-          "id": 118,
+          "id": 125,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -145,7 +165,7 @@
           "UserName": "b"
         },
         {
-          "id": 119,
+          "id": 126,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -170,7 +190,7 @@
           "UserName": "c"
         },
         {
-          "id": 120,
+          "id": 127,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -195,7 +215,7 @@
           "MachineName": 0
         },
         {
-          "id": 121,
+          "id": 128,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
@@ -18,25 +18,25 @@ b % c,
 
 (a = {SafeMod(b,c) @ (c != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeMod(b,c)) @ And([(c != 0)])} 
+{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
 
 --
 
-{(a = SafeMod(b,c)) @ And([(c != 0)])}, 
+{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(a = SafeMod(b,c)), And([(c != 0)])]) 
+and([(a = SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(c != 0)]), 
+and([(c != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (c != 0) 
 
 --
 
-Not(And([(a = SafeMod(b,c)), (c != 0)])), 
+Not(and([(a = SafeMod(b,c)),(c != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((a = SafeMod(b,c))), Not((c != 0))]) 
+or([Not((a = SafeMod(b,c))),Not((c != 0));int(1..)]) 
 
 --
 
@@ -76,6 +76,6 @@ find __0: int(0..2)
 
 such that
 
-Or([(a != __0), (c = 0)]),
+or([(a != __0),(c = 0);int(1..)]),
 ModEq(b, c, __0)
 

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06.expected-rewrite.serialised.json
@@ -12,76 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -110,8 +129,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 158,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -120,7 +140,7 @@
           "UserName": "a"
         },
         {
-          "id": 122,
+          "id": 129,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -145,7 +165,7 @@
           "UserName": "b"
         },
         {
-          "id": 123,
+          "id": 130,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -170,7 +190,7 @@
           "UserName": "c"
         },
         {
-          "id": 124,
+          "id": 131,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -195,7 +215,7 @@
           "MachineName": 0
         },
         {
-          "id": 125,
+          "id": 132,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
@@ -18,17 +18,17 @@ UnsafeDiv(-(y), z),
 
 (x = {SafeDiv(-(y), z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = SafeDiv(-(y), z)) @ And([(z != 0)])} 
+{(x = SafeDiv(-(y), z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-{(x = SafeDiv(-(y), z)) @ And([(z != 0)])}, 
+{(x = SafeDiv(-(y), z)) @ and([(z != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x = SafeDiv(-(y), z)), And([(z != 0)])]) 
+and([(x = SafeDiv(-(y), z)),and([(z != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -64,6 +64,6 @@ find __0: int(-1..1)
 
 such that
 
-And([DivEq(__0, z, x), (z != 0)]),
+and([DivEq(__0, z, x),(z != 0);int(1..)]),
 MinusEq(__0,y)
 

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input.expected-rewrite.serialised.json
@@ -12,65 +12,84 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "z"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -94,8 +113,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 172,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -104,7 +124,7 @@
           "UserName": "x"
         },
         {
-          "id": 128,
+          "id": 135,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -129,7 +149,7 @@
           "UserName": "y"
         },
         {
-          "id": 129,
+          "id": 136,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -154,7 +174,7 @@
           "UserName": "z"
         },
         {
-          "id": 130,
+          "id": 137,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -179,7 +199,7 @@
           "MachineName": 0
         },
         {
-          "id": 132,
+          "id": 139,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ UnsafeDiv(y, z),
 
 -({SafeDiv(y, z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(y, z)) @ And([(z != 0)])} 
+{-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-(x = {-(SafeDiv(y, z)) @ And([(z != 0)])}), 
+(x = {-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = -(SafeDiv(y, z))) @ And([And([(z != 0)])])} 
+{(x = -(SafeDiv(y, z))) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(x = -(SafeDiv(y, z))) @ And([And([(z != 0)])])}, 
+{(x = -(SafeDiv(y, z))) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x = -(SafeDiv(y, z))), And([And([(z != 0)])])]) 
+and([(x = -(SafeDiv(y, z))),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -76,6 +76,6 @@ find __0: int(-1..1)
 
 such that
 
-And([MinusEq(x,__0), (z != 0)]),
+and([MinusEq(x,__0),(z != 0);int(1..)]),
 DivEq(y, z, __0)
 

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input.expected-rewrite.serialised.json
@@ -12,60 +12,79 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatMinusEq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "FlatMinusEq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "z"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -94,8 +113,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 187,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -104,7 +124,7 @@
           "UserName": "x"
         },
         {
-          "id": 134,
+          "id": 141,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -129,7 +149,7 @@
           "UserName": "y"
         },
         {
-          "id": 135,
+          "id": 142,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -154,7 +174,7 @@
           "UserName": "z"
         },
         {
-          "id": 136,
+          "id": 143,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -179,7 +199,7 @@
           "MachineName": 0
         },
         {
-          "id": 138,
+          "id": 145,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
@@ -18,41 +18,41 @@ UnsafeDiv(y, z),
 
 -({SafeDiv(y, z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(y, z)) @ And([(z != 0)])} 
+{-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-UnsafeDiv({-(SafeDiv(y, z)) @ And([(z != 0)])}, z), 
+UnsafeDiv({-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])}, z), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(-(SafeDiv(y, z)), z) @ And([And([(z != 0)])])} 
+{UnsafeDiv(-(SafeDiv(y, z)), z) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-(x = {UnsafeDiv(-(SafeDiv(y, z)), z) @ And([And([(z != 0)])])}), 
+(x = {UnsafeDiv(-(SafeDiv(y, z)), z) @ and([and([(z != 0);int(1..)]);int(1..)])}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ And([And([And([(z != 0)])])])} 
+{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)])} 
 
 --
 
-{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ And([And([And([(z != 0)])])])}, 
+{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x = UnsafeDiv(-(SafeDiv(y, z)), z)), And([And([And([(z != 0)])])])]) 
+and([(x = UnsafeDiv(-(SafeDiv(y, z)), z)),and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([And([(z != 0)])])]), 
+and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([And([(z != 0)])]) 
+and([and([(z != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -66,19 +66,19 @@ UnsafeDiv(-(SafeDiv(y, z)), z),
 
 (x = {SafeDiv(-(SafeDiv(y, z)), z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ And([(z != 0)])} 
+{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ And([(z != 0)])}, 
+{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x = SafeDiv(-(SafeDiv(y, z)), z)), And([(z != 0)])]) 
+and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(x = SafeDiv(-(SafeDiv(y, z)), z)), And([(z != 0)])]), (z != 0)]), 
+and([and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(x = SafeDiv(-(SafeDiv(y, z)), z)), (z != 0), (z != 0)]) 
+and([(x = SafeDiv(-(SafeDiv(y, z)), z)),(z != 0),(z != 0);int(1..)]) 
 
 --
 
@@ -128,7 +128,7 @@ find __1: int(-1..1)
 
 such that
 
-And([DivEq(__0, z, x), (z != 0), (z != 0)]),
+and([DivEq(__0, z, x),(z != 0),(z != 0);int(1..)]),
 MinusEq(__0,__1),
 DivEq(y, z, __1)
 

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input.expected-rewrite.serialised.json
@@ -12,99 +12,118 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -151,8 +170,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 385,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -161,7 +181,7 @@
           "UserName": "x"
         },
         {
-          "id": 139,
+          "id": 146,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -186,7 +206,7 @@
           "UserName": "y"
         },
         {
-          "id": 140,
+          "id": 147,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -211,7 +231,7 @@
           "UserName": "z"
         },
         {
-          "id": 141,
+          "id": 148,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -236,7 +256,7 @@
           "MachineName": 0
         },
         {
-          "id": 143,
+          "id": 150,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -261,7 +281,7 @@
           "MachineName": 1
         },
         {
-          "id": 145,
+          "id": 152,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input-expected-rule-trace-human.txt
@@ -12,7 +12,7 @@ such that
 
 (x = Sum([-(y), z])), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([FlatWeightedSumLeq([-1, 1],[y, z],x), FlatWeightedSumGeq([-1, 1],[y, z],x)]) 
+and([FlatWeightedSumLeq([-1, 1],[y, z],x),FlatWeightedSumGeq([-1, 1],[y, z],x);int(1..)]) 
 
 --
 
@@ -24,5 +24,5 @@ find z: int(-1..1)
 
 such that
 
-And([FlatWeightedSumLeq([-1, 1],[y, z],x), FlatWeightedSumGeq([-1, 1],[y, z],x)])
+and([FlatWeightedSumLeq([-1, 1],[y, z],x),FlatWeightedSumGeq([-1, 1],[y, z],x);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/05-sum/input.expected-rewrite.serialised.json
@@ -12,81 +12,101 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWeightedSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": 1
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatWeightedSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": 1
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 28,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -95,7 +115,7 @@
           "UserName": "x"
         },
         {
-          "id": 146,
+          "id": 153,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -120,7 +140,7 @@
           "UserName": "y"
         },
         {
-          "id": 147,
+          "id": 154,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -145,7 +165,7 @@
           "UserName": "z"
         },
         {
-          "id": 148,
+          "id": 155,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
@@ -56,7 +56,7 @@ a
 
 (x = Sum([-(y), -(z), -1, a, b])), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([FlatWeightedSumLeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x), FlatWeightedSumGeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x)]) 
+and([FlatWeightedSumLeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x),FlatWeightedSumGeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x);int(1..)]) 
 
 --
 
@@ -70,5 +70,5 @@ find z: int(-1..1)
 
 such that
 
-And([FlatWeightedSumLeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x), FlatWeightedSumGeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x)])
+and([FlatWeightedSumLeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x),FlatWeightedSumGeq([-1, -1, 1, 1, 1],[y, z, -1, a, b],x);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input.expected-rewrite.serialised.json
@@ -12,129 +12,149 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWeightedSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Int": -1
-                    },
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": -1
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatWeightedSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 1
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": -1
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 104,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -143,7 +163,7 @@
           "UserName": "a"
         },
         {
-          "id": 152,
+          "id": 159,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -168,7 +188,7 @@
           "UserName": "b"
         },
         {
-          "id": 153,
+          "id": 160,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -193,7 +213,7 @@
           "UserName": "x"
         },
         {
-          "id": 149,
+          "id": 156,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -218,7 +238,7 @@
           "UserName": "y"
         },
         {
-          "id": 150,
+          "id": 157,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -243,7 +263,7 @@
           "UserName": "z"
         },
         {
-          "id": 151,
+          "id": 158,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input-expected-rule-trace-human.txt
@@ -11,25 +11,25 @@ such that
 
 UnsafePow(x, y), 
    ~~> pow_to_bubble ([("Bubble", 6000)]) 
-{SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} 
+{SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-({SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} = 4), 
+({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 4), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 4) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])} 
+{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 4) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])}, 
+{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafePow(x, y) = 4), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]) 
+and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([(SafePow(x, y) = 4), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]), 
+and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafePow(x, y) = 4), Or([(x != 0), (y != 0)]), (y >= 0)]) 
+and([(SafePow(x, y) = 4),or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 
 
 --
 
@@ -52,5 +52,5 @@ find y: int(2..5)
 
 such that
 
-And([MinionPow(x,y,4), Or([(x != 0), (y != 0)]), Ineq(0, y, 0)])
+and([MinionPow(x,y,4),or([(x != 0),(y != 0);int(1..)]),Ineq(0, y, 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
@@ -12,137 +12,176 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionPow": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionPow": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "x"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "y"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Neq": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "x"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neq": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 147,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -151,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 154,
+          "id": 161,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -176,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 155,
+          "id": 162,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input.expected-rewrite.serialised.json
@@ -190,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 161,
+          "id": 166,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -215,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 162,
+          "id": 167,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input-expected-rule-trace-human.txt
@@ -11,25 +11,25 @@ such that
 
 UnsafePow(x, y), 
    ~~> pow_to_bubble ([("Bubble", 6000)]) 
-{SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} 
+{SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-({SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} = 4), 
+({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 4), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 4) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])} 
+{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 4) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])}, 
+{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafePow(x, y) = 4), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]) 
+and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([(SafePow(x, y) = 4), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]), 
+and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafePow(x, y) = 4), Or([(x != 0), (y != 0)]), (y >= 0)]) 
+and([(SafePow(x, y) = 4),or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 
 
 --
 
@@ -52,5 +52,5 @@ find y: int(0..5)
 
 such that
 
-And([MinionPow(x,y,4), Or([(x != 0), (y != 0)]), Ineq(0, y, 0)])
+and([MinionPow(x,y,4),or([(x != 0),(y != 0);int(1..)]),Ineq(0, y, 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
@@ -190,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 164,
+          "id": 169,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -215,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 165,
+          "id": 170,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input.expected-rewrite.serialised.json
@@ -12,137 +12,176 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionPow": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionPow": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "x"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "y"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Neq": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "x"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neq": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 147,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -151,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 157,
+          "id": 164,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -176,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 158,
+          "id": 165,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input-expected-rule-trace-human.txt
@@ -11,25 +11,25 @@ such that
 
 UnsafePow(x, y), 
    ~~> pow_to_bubble ([("Bubble", 6000)]) 
-{SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} 
+{SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-({SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} = 2), 
+({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 2), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 2) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])} 
+{(SafePow(x, y) = 2) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 2) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])}, 
+{(SafePow(x, y) = 2) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafePow(x, y) = 2), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]) 
+and([(SafePow(x, y) = 2),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([(SafePow(x, y) = 2), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]), 
+and([(SafePow(x, y) = 2),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafePow(x, y) = 2), Or([(x != 0), (y != 0)]), (y >= 0)]) 
+and([(SafePow(x, y) = 2),or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 
 
 --
 
@@ -52,5 +52,5 @@ find y: int(-5..5)
 
 such that
 
-And([MinionPow(x,y,2), Or([(x != 0), (y != 0)]), Ineq(0, y, 0)])
+and([MinionPow(x,y,2),or([(x != 0),(y != 0);int(1..)]),Ineq(0, y, 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
@@ -190,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 167,
+          "id": 172,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -215,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 168,
+          "id": 173,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input.expected-rewrite.serialised.json
@@ -12,137 +12,176 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionPow": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionPow": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "x"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "y"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Neq": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "x"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neq": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 147,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -151,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 160,
+          "id": 167,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -176,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 161,
+          "id": 168,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
@@ -23,11 +23,11 @@ true
 
 UnsafePow(Sum([x, 2]), {SafeDiv(y, 2) @ true}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) @ And([true])} 
+{UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -35,11 +35,11 @@ true
 
 ({UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) @ true} = 4), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ And([true])} 
+{(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -47,17 +47,17 @@ true
 
 {(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4), true]) 
+and([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4),true;int(1..)]) 
 
 --
 
-And([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4), true]), 
+and([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4)]) 
+and([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4);int(1..)]) 
 
 --
 
-And([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4)]), 
+and([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) 
 
@@ -65,25 +65,25 @@ And([(UnsafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4)]),
 
 UnsafePow(Sum([x, 2]), SafeDiv(y, 2)), 
    ~~> pow_to_bubble ([("Bubble", 6000)]) 
-{SafePow(Sum([x, 2]), SafeDiv(y, 2)) @ And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])} 
+{SafePow(Sum([x, 2]), SafeDiv(y, 2)) @ and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)])} 
 
 --
 
-({SafePow(Sum([x, 2]), SafeDiv(y, 2)) @ And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])} = 4), 
+({SafePow(Sum([x, 2]), SafeDiv(y, 2)) @ and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)])} = 4), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ And([And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])])} 
+{(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ and([and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)])} 
 
 --
 
-{(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ And([And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])])}, 
+{(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4) @ and([and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4), And([And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])])]) 
+and([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4),and([and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4), And([And([Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)])])]), 
+and([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4),and([and([or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4), Or([(Sum([x, 2]) != 0), (SafeDiv(y, 2) != 0)]), (SafeDiv(y, 2) >= 0)]) 
+and([(SafePow(Sum([x, 2]), SafeDiv(y, 2)) = 4),or([(Sum([x, 2]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]) 
 
 --
 
@@ -100,7 +100,7 @@ new constraints:
 
 __0 =aux Sum([x, 2]), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, 2], __0), SumGeq([x, 2], __0)]) 
+and([SumLeq([x, 2], __0),SumGeq([x, 2], __0);int(1..)]) 
 
 --
 
@@ -121,7 +121,7 @@ new constraints:
 
 __2 =aux Sum([x, 2]), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, 2], __2), SumGeq([x, 2], __2)]) 
+and([SumLeq([x, 2], __2),SumGeq([x, 2], __2);int(1..)]) 
 
 --
 
@@ -179,10 +179,10 @@ find __4: int(0..10)
 
 such that
 
-And([MinionPow(__0,__1,4), Or([(__2 != 0), (__3 != 0)]), Ineq(0, __4, 0)]),
-And([SumLeq([x, 2], __0), SumGeq([x, 2], __0)]),
+and([MinionPow(__0,__1,4),or([(__2 != 0),(__3 != 0);int(1..)]),Ineq(0, __4, 0);int(1..)]),
+and([SumLeq([x, 2], __0),SumGeq([x, 2], __0);int(1..)]),
 DivEq(y, 2, __1),
-And([SumLeq([x, 2], __2), SumGeq([x, 2], __2)]),
+and([SumLeq([x, 2], __2),SumGeq([x, 2], __2);int(1..)]),
 DivEq(y, 2, __3),
 DivEq(y, 2, __4)
 

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
@@ -417,7 +417,7 @@
           "UserName": "x"
         },
         {
-          "id": 170,
+          "id": 175,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -442,7 +442,7 @@
           "UserName": "y"
         },
         {
-          "id": 171,
+          "id": 176,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -467,7 +467,7 @@
           "MachineName": 0
         },
         {
-          "id": 173,
+          "id": 178,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -492,7 +492,7 @@
           "MachineName": 1
         },
         {
-          "id": 174,
+          "id": 179,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -517,7 +517,7 @@
           "MachineName": 2
         },
         {
-          "id": 176,
+          "id": 181,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -542,7 +542,7 @@
           "MachineName": 3
         },
         {
-          "id": 177,
+          "id": 182,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -567,7 +567,7 @@
           "MachineName": 4
         },
         {
-          "id": 178,
+          "id": 183,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input.expected-rewrite.serialised.json
@@ -12,130 +12,168 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionPow": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 1
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionPow": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "MachineName": 2
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "MachineName": 3
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 4
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Neq": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "MachineName": 2
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neq": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "MachineName": 3
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 4
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -144,58 +182,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Literal": {
-                        "Int": 2
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -227,58 +284,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Literal": {
-                        "Int": 2
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 2
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 2
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 2
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -330,8 +406,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 982,
+    "id": 0,
     "next_machine_name": 5,
     "parent": null,
     "table": [
@@ -340,7 +417,7 @@
           "UserName": "x"
         },
         {
-          "id": 163,
+          "id": 170,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -365,7 +442,7 @@
           "UserName": "y"
         },
         {
-          "id": 164,
+          "id": 171,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -390,7 +467,7 @@
           "MachineName": 0
         },
         {
-          "id": 166,
+          "id": 173,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -415,7 +492,7 @@
           "MachineName": 1
         },
         {
-          "id": 167,
+          "id": 174,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -440,7 +517,7 @@
           "MachineName": 2
         },
         {
-          "id": 169,
+          "id": 176,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -465,7 +542,7 @@
           "MachineName": 3
         },
         {
-          "id": 170,
+          "id": 177,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -490,7 +567,7 @@
           "MachineName": 4
         },
         {
-          "id": 171,
+          "id": 178,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input-expected-rule-trace-human.txt
@@ -12,25 +12,25 @@ such that
 
 UnsafePow(x, y), 
    ~~> pow_to_bubble ([("Bubble", 6000)]) 
-{SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} 
+{SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-({SafePow(x, y) @ And([Or([(x != 0), (y != 0)]), (y >= 0)])} = z), 
+({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = z), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = z) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])} 
+{(SafePow(x, y) = z) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = z) @ And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])}, 
+{(SafePow(x, y) = z) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafePow(x, y) = z), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]) 
+and([(SafePow(x, y) = z),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([(SafePow(x, y) = z), And([And([Or([(x != 0), (y != 0)]), (y >= 0)])])]), 
+and([(SafePow(x, y) = z),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafePow(x, y) = z), Or([(x != 0), (y != 0)]), (y >= 0)]) 
+and([(SafePow(x, y) = z),or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 
 
 --
 
@@ -54,5 +54,5 @@ find z: int(-10..-1)
 
 such that
 
-And([MinionPow(x,y,z), Or([(x != 0), (y != 0)]), Ineq(0, y, 0)])
+and([MinionPow(x,y,z),or([(x != 0),(y != 0);int(1..)]),Ineq(0, y, 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
@@ -12,137 +12,176 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionPow": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionPow": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "x"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Neq": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Reference": {
+                                                "UserName": "y"
+                                              }
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "Atomic": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Literal": {
+                                                "Int": 0
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Neq": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "x"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Neq": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "y"
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 0
-                              }
-                            }
-                          ]
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 147,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -151,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 172,
+          "id": 179,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -176,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 173,
+          "id": 180,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -201,7 +240,7 @@
           "UserName": "z"
         },
         {
-          "id": 174,
+          "id": 181,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input.expected-rewrite.serialised.json
@@ -190,7 +190,7 @@
           "UserName": "x"
         },
         {
-          "id": 179,
+          "id": 184,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -215,7 +215,7 @@
           "UserName": "y"
         },
         {
-          "id": 180,
+          "id": 185,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -240,7 +240,7 @@
           "UserName": "z"
         },
         {
-          "id": 181,
+          "id": 186,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input-expected-rule-trace-human.txt
@@ -20,7 +20,7 @@ Sum([a, b, c, d, e])
 
 (Sum([a, b, c, d, e]) = 5), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([a, b, c, d, e], 5), SumGeq([a, b, c, d, e], 5)]) 
+and([SumLeq([a, b, c, d, e], 5),SumGeq([a, b, c, d, e], 5);int(1..)]) 
 
 --
 
@@ -34,5 +34,5 @@ find e: int(1)
 
 such that
 
-And([SumLeq([a, b, c, d, e], 5), SumGeq([a, b, c, d, e], 5)])
+and([SumLeq([a, b, c, d, e], 5),SumGeq([a, b, c, d, e], 5);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/01-deeply-nested/input.expected-rewrite.serialised.json
@@ -12,95 +12,115 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "d"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "e"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 5
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "d"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "e"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 5
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "d"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "e"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "d"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "e"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 40,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -109,7 +129,7 @@
           "UserName": "a"
         },
         {
-          "id": 181,
+          "id": 188,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -131,7 +151,7 @@
           "UserName": "b"
         },
         {
-          "id": 182,
+          "id": 189,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -153,7 +173,7 @@
           "UserName": "c"
         },
         {
-          "id": 183,
+          "id": 190,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -175,7 +195,7 @@
           "UserName": "d"
         },
         {
-          "id": 184,
+          "id": 191,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -197,7 +217,7 @@
           "UserName": "e"
         },
         {
-          "id": 185,
+          "id": 192,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
@@ -25,17 +25,17 @@ UnsafeDiv(Sum([x, y, z]), a),
 
 ({SafeDiv(Sum([x, y, z]), a) @ (a != 0)} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(Sum([x, y, z]), a) = 3) @ And([(a != 0)])} 
+{(SafeDiv(Sum([x, y, z]), a) = 3) @ and([(a != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(Sum([x, y, z]), a) = 3) @ And([(a != 0)])}, 
+{(SafeDiv(Sum([x, y, z]), a) = 3) @ and([(a != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(Sum([x, y, z]), a) = 3), And([(a != 0)])]) 
+and([(SafeDiv(Sum([x, y, z]), a) = 3),and([(a != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(a != 0)]), 
+and([(a != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (a != 0) 
 
@@ -52,7 +52,7 @@ new constraints:
 
 __0 =aux Sum([x, y, z]), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, y, z], __0), SumGeq([x, y, z], __0)]) 
+and([SumLeq([x, y, z], __0),SumGeq([x, y, z], __0);int(1..)]) 
 
 --
 
@@ -72,6 +72,6 @@ find __0: int(6..14)
 
 such that
 
-And([DivEq(__0, a, 3), (a != 0)]),
-And([SumLeq([x, y, z], __0), SumGeq([x, y, z], __0)])
+and([DivEq(__0, a, 3),(a != 0);int(1..)]),
+and([SumLeq([x, y, z], __0),SumGeq([x, y, z], __0);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input.expected-rewrite.serialised.json
@@ -12,65 +12,84 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -79,75 +98,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "z"
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "z"
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 191,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -156,7 +195,7 @@
           "UserName": "a"
         },
         {
-          "id": 189,
+          "id": 196,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -181,7 +220,7 @@
           "UserName": "x"
         },
         {
-          "id": 186,
+          "id": 193,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -206,7 +245,7 @@
           "UserName": "y"
         },
         {
-          "id": 187,
+          "id": 194,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -231,7 +270,7 @@
           "UserName": "z"
         },
         {
-          "id": 188,
+          "id": 195,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -256,7 +295,7 @@
           "MachineName": 0
         },
         {
-          "id": 191,
+          "id": 198,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input-expected-rule-trace-human.txt
@@ -11,7 +11,7 @@ such that
 
 (Sum([Product([2, x]), Product([3, y])]) = 12), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([FlatWeightedSumLeq([2, 3],[x, y],12), FlatWeightedSumGeq([2, 3],[x, y],12)]) 
+and([FlatWeightedSumLeq([2, 3],[x, y],12),FlatWeightedSumGeq([2, 3],[x, y],12);int(1..)]) 
 
 --
 
@@ -22,5 +22,5 @@ find y: int(2..4)
 
 such that
 
-And([FlatWeightedSumLeq([2, 3],[x, y],12), FlatWeightedSumGeq([2, 3],[x, y],12)])
+and([FlatWeightedSumLeq([2, 3],[x, y],12),FlatWeightedSumGeq([2, 3],[x, y],12);int(1..)])
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/03-simple-eq/input.expected-rewrite.serialised.json
@@ -12,81 +12,101 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWeightedSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": 2
-                    },
-                    {
-                      "Int": 3
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 3
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 12
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 3
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 12
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "y"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 12
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatWeightedSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Int": 2
-                    },
-                    {
-                      "Int": 3
-                    }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 12
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 33,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -95,7 +115,7 @@
           "UserName": "x"
         },
         {
-          "id": 198,
+          "id": 205,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -120,7 +140,7 @@
           "UserName": "y"
         },
         {
-          "id": 199,
+          "id": 206,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
@@ -35,29 +35,29 @@ UnsafeDiv(e, f),
 
 Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), {SafeDiv(e, f) @ (f != 0)}, Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ And([(f != 0)])} 
+{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ and([(f != 0);int(1..)])} 
 
 --
 
-({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ And([(f != 0)])} <= 18), 
+({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ and([(f != 0);int(1..)])} <= 18), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ And([And([(f != 0)])])} 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ and([and([(f != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ And([And([(f != 0)])])}, 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ and([and([(f != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18), And([And([(f != 0)])])]) 
+and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, UnsafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18),and([and([(f != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(f != 0)])]), 
+and([and([(f != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(f != 0)]) 
+and([(f != 0);int(1..)]) 
 
 --
 
-And([(f != 0)]), 
+and([(f != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (f != 0) 
 
@@ -71,31 +71,31 @@ UnsafeDiv(g, h),
 
 Product([6, {SafeDiv(g, h) @ (h != 0)}]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Product([6, SafeDiv(g, h)]) @ And([(h != 0)])} 
+{Product([6, SafeDiv(g, h)]) @ and([(h != 0);int(1..)])} 
 
 --
 
-Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), {Product([6, SafeDiv(g, h)]) @ And([(h != 0)])}, -(a), -(UnsafeDiv(g, h))]), 
+Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), {Product([6, SafeDiv(g, h)]) @ and([(h != 0);int(1..)])}, -(a), -(UnsafeDiv(g, h))]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ And([And([(h != 0)])])} 
+{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ and([and([(h != 0);int(1..)]);int(1..)])} 
 
 --
 
-({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ And([And([(h != 0)])])} <= 18), 
+({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) @ and([and([(h != 0);int(1..)]);int(1..)])} <= 18), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ And([And([And([(h != 0)])])])} 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])} 
 
 --
 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ And([And([And([(h != 0)])])])}, 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18), And([And([And([(h != 0)])])])]) 
+and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18),and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18), And([And([And([(h != 0)])])])]), (f != 0)]), 
+and([and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18),and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),(f != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18), (h != 0), (f != 0)]) 
+and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(UnsafeDiv(g, h))]) <= 18),(h != 0),(f != 0);int(1..)]) 
 
 --
 
@@ -107,31 +107,31 @@ UnsafeDiv(g, h),
 
 -({SafeDiv(g, h) @ (h != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(g, h)) @ And([(h != 0)])} 
+{-(SafeDiv(g, h)) @ and([(h != 0);int(1..)])} 
 
 --
 
-Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), {-(SafeDiv(g, h)) @ And([(h != 0)])}]), 
+Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), {-(SafeDiv(g, h)) @ and([(h != 0);int(1..)])}]), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) @ And([And([(h != 0)])])} 
+{Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) @ and([and([(h != 0);int(1..)]);int(1..)])} 
 
 --
 
-({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) @ And([And([(h != 0)])])} <= 18), 
+({Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) @ and([and([(h != 0);int(1..)]);int(1..)])} <= 18), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18) @ And([And([And([(h != 0)])])])} 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])} 
 
 --
 
-{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18) @ And([And([And([(h != 0)])])])}, 
+{(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18), And([And([And([(h != 0)])])])]) 
+and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18),and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18), And([And([And([(h != 0)])])])]), (h != 0), (f != 0)]), 
+and([and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18),and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),(h != 0),(f != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18), (h != 0), (h != 0), (f != 0)]) 
+and([(Sum([Product([2, a]), Product([2, b]), Product([3, c, d]), SafeDiv(e, f), Product([6, SafeDiv(g, h)]), -(a), -(SafeDiv(g, h))]) <= 18),(h != 0),(h != 0),(f != 0);int(1..)]) 
 
 --
 
@@ -191,7 +191,7 @@ find __3: int(0..5)
 
 such that
 
-And([FlatWeightedSumLeq([2, 2, 3, 1, 6, -1, -1],[a, b, __0, __1, __2, a, __3],18), (h != 0), (h != 0), (f != 0)]),
+and([FlatWeightedSumLeq([2, 2, 3, 1, 6, -1, -1],[a, b, __0, __1, __2, a, __3],18),(h != 0),(h != 0),(f != 0);int(1..)]),
 FlatProductEq(d,c,__0),
 DivEq(e, f, __1),
 DivEq(g, h, __2),

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input.expected-rewrite.serialised.json
@@ -12,183 +12,202 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatWeightedSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 3
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 6
+                            },
+                            {
+                              "Int": -1
+                            },
+                            {
+                              "Int": -1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 0
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 3
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 18
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "h"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "h"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "f"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
                     {
-                      "Int": 2
-                    },
-                    {
-                      "Int": 2
-                    },
-                    {
-                      "Int": 3
-                    },
-                    {
-                      "Int": 1
-                    },
-                    {
-                      "Int": 6
-                    },
-                    {
-                      "Int": -1
-                    },
-                    {
-                      "Int": -1
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 0
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 1
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 2
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "MachineName": 3
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 18
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "h"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "h"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "f"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -286,8 +305,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 585,
+    "id": 0,
     "next_machine_name": 4,
     "parent": null,
     "table": [
@@ -296,7 +316,7 @@
           "UserName": "a"
         },
         {
-          "id": 203,
+          "id": 210,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -321,7 +341,7 @@
           "UserName": "b"
         },
         {
-          "id": 204,
+          "id": 211,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -346,7 +366,7 @@
           "UserName": "c"
         },
         {
-          "id": 205,
+          "id": 212,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -371,7 +391,7 @@
           "UserName": "d"
         },
         {
-          "id": 206,
+          "id": 213,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -396,7 +416,7 @@
           "UserName": "e"
         },
         {
-          "id": 207,
+          "id": 214,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -421,7 +441,7 @@
           "UserName": "f"
         },
         {
-          "id": 208,
+          "id": 215,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -446,7 +466,7 @@
           "UserName": "g"
         },
         {
-          "id": 209,
+          "id": 216,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -471,7 +491,7 @@
           "UserName": "h"
         },
         {
-          "id": 210,
+          "id": 217,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -496,7 +516,7 @@
           "MachineName": 0
         },
         {
-          "id": 211,
+          "id": 218,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -521,7 +541,7 @@
           "MachineName": 1
         },
         {
-          "id": 212,
+          "id": 219,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -546,7 +566,7 @@
           "MachineName": 2
         },
         {
-          "id": 213,
+          "id": 220,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -571,7 +591,7 @@
           "MachineName": 3
         },
         {
-          "id": 214,
+          "id": 221,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input-expected-rule-trace-human.txt
@@ -4,11 +4,11 @@ find a: int(1..5)
 
 such that
 
-Or([])
+or([;int(1..)])
 
 --
 
-Or([]), 
+or([;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 false 
 

--- a/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input.expected-parse.serialised.json
@@ -12,12 +12,32 @@
               "clean": false,
               "etype": null
             },
-            []
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -28,7 +48,7 @@
           "UserName": "a"
         },
         {
-          "id": 215,
+          "id": 222,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input-expected-rule-trace-human.txt
@@ -5,11 +5,17 @@ find b: int(1..7)
 
 such that
 
-(Sum([Min([a, b]), 6]) <= 10)
+(Sum([min([a,b;int(1..2)]), 6]) <= 10)
 
 --
 
-Min([a, b]), 
+min([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+min([a,b;int(1..)]) 
+
+--
+
+min([a,b;int(1..)]), 
    ~~> min_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -17,7 +23,7 @@ new variables:
 new constraints:
   (__0 <= a)
   (__0 <= b)
-  Or([(__0 = a), (__0 = b)])
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (Sum([__0, 6]) <= 10), 
@@ -49,5 +55,5 @@ such that
 SumLeq([__0, 6], 10),
 Ineq(__0, a, 0),
 Ineq(__0, b, 0),
-Or([(__0 = a), (__0 = b)])
+or([(__0 = a),(__0 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-parse.serialised.json
@@ -25,34 +25,56 @@
                         "clean": false,
                         "etype": null
                       },
-                      [
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "a"
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Reference": {
+                                        "UserName": "a"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Reference": {
+                                        "UserName": "b"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "Bounded": [
+                                      1,
+                                      2
+                                    ]
+                                  }
+                                ]
                               }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "b"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                            ]
+                          }
+                        ]
+                      }
                     ]
                   },
                   {
@@ -89,6 +111,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -99,7 +122,7 @@
           "UserName": "a"
         },
         {
-          "id": 216,
+          "id": 228,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -124,7 +147,7 @@
           "UserName": "b"
         },
         {
-          "id": 217,
+          "id": 229,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/sm600-non-terminating-min/input.expected-rewrite.serialised.json
@@ -79,83 +79,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 178,
+    "id": 0,
     "next_machine_name": 1,
     "parent": null,
     "table": [
@@ -164,7 +184,7 @@
           "UserName": "a"
         },
         {
-          "id": 216,
+          "id": 223,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -189,7 +209,7 @@
           "UserName": "b"
         },
         {
-          "id": 217,
+          "id": 224,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -214,7 +234,7 @@
           "MachineName": 0
         },
         {
-          "id": 218,
+          "id": 225,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
@@ -4,11 +4,11 @@ find c: int(1..7)
 
 such that
 
-(Sum([Min([5, 7]), c]) <= 10)
+(Sum([min([5,7;int(1..)]), c]) <= 10)
 
 --
 
-Min([5, 7]), 
+min([5,7;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 5 
 

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input.expected-parse.serialised.json
@@ -25,34 +25,53 @@
                         "clean": false,
                         "etype": null
                       },
-                      [
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 5
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 5
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Literal": {
+                                        "Int": 7
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "UnboundedR": 1
+                                  }
+                                ]
                               }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Literal": {
-                                "Int": 7
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                            ]
+                          }
+                        ]
+                      }
                     ]
                   },
                   {
@@ -89,6 +108,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -99,7 +119,7 @@
           "UserName": "c"
         },
         {
-          "id": 219,
+          "id": 226,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input-expected-rule-trace-human.txt
@@ -7,28 +7,46 @@ find d: bool
 
 such that
 
-Or([a, b]),
-Or([Not(c), And([b, d])]),
+or([a,b;int(1..2)]),
+or([Not(c),and([b,d;int(1..2)]);int(1..2)]),
 b,
-Or([d, c])
+or([d,c;int(1..2)])
 
 --
 
-Or([Not(c), And([b, d])]), 
+Not(c), 
+   ~~> not_literal_to_wliteral ([("Minion", 4100)]) 
+WatchedLiteral(c,false) 
+
+--
+
+or([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([a,b;int(1..)]) 
+
+--
+
+or([WatchedLiteral(c,false),and([b,d;int(1..2)]);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([WatchedLiteral(c,false),and([b,d;int(1..2)]);int(1..)]) 
+
+--
+
+and([b,d;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+and([b,d;int(1..)]) 
+
+--
+
+or([WatchedLiteral(c,false),and([b,d;int(1..)]);int(1..)]), 
    ~~> distribute_or_over_and ([("Base", 8400)]) 
-And([Or([Not(c), b]), Or([Not(c), d])]) 
+and([or([WatchedLiteral(c,false),b;int(1..)]),or([WatchedLiteral(c,false),d;int(1..)]);int(1..)]) 
 
 --
 
-Not(c), 
-   ~~> not_literal_to_wliteral ([("Minion", 4100)]) 
-WatchedLiteral(c,false) 
-
---
-
-Not(c), 
-   ~~> not_literal_to_wliteral ([("Minion", 4100)]) 
-WatchedLiteral(c,false) 
+or([d,c;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([d,c;int(1..)]) 
 
 --
 
@@ -41,8 +59,8 @@ find d: bool
 
 such that
 
-Or([a, b]),
-And([Or([WatchedLiteral(c,false), b]), Or([WatchedLiteral(c,false), d])]),
+or([a,b;int(1..)]),
+and([or([WatchedLiteral(c,false),b;int(1..)]),or([WatchedLiteral(c,false),d;int(1..)]);int(1..)]),
 b,
-Or([d, c])
+or([d,c;int(1..)])
 

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-parse.serialised.json
@@ -12,34 +12,56 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -48,65 +70,109 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Not": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Not": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "c"
-                        }
+                        "And": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "d"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
-              },
-              {
-                "And": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "d"
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -128,39 +194,62 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "d"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -171,7 +260,7 @@
           "UserName": "a"
         },
         {
-          "id": 220,
+          "id": 226,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -187,7 +276,7 @@
           "UserName": "b"
         },
         {
-          "id": 221,
+          "id": 227,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -203,7 +292,7 @@
           "UserName": "c"
         },
         {
-          "id": 222,
+          "id": 228,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -219,7 +308,7 @@
           "UserName": "d"
         },
         {
-          "id": 223,
+          "id": 229,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/bool/literals-to-wlit-1/input.expected-rewrite.serialised.json
@@ -12,34 +12,53 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -48,82 +67,139 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "FlatWatchedLiteral": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "UserName": "c"
-                        },
-                        {
-                          "Bool": false
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "FlatWatchedLiteral": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "UserName": "c"
+                                        },
+                                        {
+                                          "Bool": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
+                        ]
+                      },
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "FlatWatchedLiteral": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "UserName": "c"
+                                        },
+                                        {
+                                          "Bool": false
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "d"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "FlatWatchedLiteral": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "UserName": "c"
-                        },
-                        {
-                          "Bool": false
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "d"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -145,41 +221,61 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "d"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 119,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -188,7 +284,7 @@
           "UserName": "a"
         },
         {
-          "id": 220,
+          "id": 233,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -204,7 +300,7 @@
           "UserName": "b"
         },
         {
-          "id": 221,
+          "id": 234,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -220,7 +316,7 @@
           "UserName": "c"
         },
         {
-          "id": 222,
+          "id": 235,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -236,7 +332,7 @@
           "UserName": "d"
         },
         {
-          "id": 223,
+          "id": 236,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ Sum([x, y, 35])
 
 (Sum([x, y, 35]) = 100), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, y, 35], 100), SumGeq([x, y, 35], 100)]) 
+and([SumLeq([x, y, 35], 100),SumGeq([x, y, 35], 100);int(1..)]) 
 
 --
 
@@ -34,5 +34,5 @@ find y: int(1..50)
 
 such that
 
-And([SumLeq([x, y, 35], 100), SumGeq([x, y, 35], 100)])
+and([SumLeq([x, y, 35], 100),SumGeq([x, y, 35], 100);int(1..)])
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-01-add/input.expected-rewrite.serialised.json
@@ -12,75 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 35
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 100
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 35
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 100
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 35
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 100
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 35
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 100
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 44,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -89,7 +109,7 @@
           "UserName": "x"
         },
         {
-          "id": 224,
+          "id": 232,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -114,7 +134,7 @@
           "UserName": "y"
         },
         {
-          "id": 225,
+          "id": 233,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input-expected-rule-trace-human.txt
@@ -6,46 +6,70 @@ find c: bool
 
 such that
 
-Or([Or([a, b]), false]),
-Or([AllDiff([1, 2, 3]), true]),
-And([c, true])
+or([or([a,b;int(1..2)]),false;int(1..2)]),
+or([allDiff([1,2,3;int(1..)]),true;int(1..2)]),
+and([c,true;int(1..2)])
 
 --
 
-Or([AllDiff([1, 2, 3]), true]), 
+allDiff([1,2,3;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
 --
 
-Or([Or([a, b]), false]),
-true,
-And([c, true]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b]), false]),
-And([c, true]) 
-
---
-
-Or([Or([a, b]), false]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b])]) 
-
---
-
-And([c, true]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-And([c]) 
-
---
-
-Or([Or([a, b])]), 
+or([or([a,b;int(1..2)]),false;int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-Or([a, b]) 
+or([a,b,false;int(1..2)]) 
 
 --
 
-And([c]), 
+or([a,b,false;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([a,b,false;int(1..)]) 
+
+--
+
+or([a,b,false;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+or([a,b;int(1..)]) 
+
+--
+
+or([true,true;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([true,true;int(1..)]) 
+
+--
+
+or([true,true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+or([a,b;int(1..)]),
+true,
+and([c,true;int(1..2)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+or([a,b;int(1..)]),
+and([c,true;int(1..2)]) 
+
+--
+
+and([c,true;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+and([c,true;int(1..)]) 
+
+--
+
+and([c,true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([c;int(1..)]) 
+
+--
+
+and([c;int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 c 
 
@@ -59,6 +83,6 @@ find c: bool
 
 such that
 
-Or([a, b]),
+or([a,b;int(1..)]),
 c
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-parse.serialised.json
@@ -12,57 +12,101 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "a"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": false
+                            }
                           }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": false
-                    }
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -71,70 +115,111 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "AllDiff": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 1
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AllDiff": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 1
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 2
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 3
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": true
+                            }
                           }
-                        }
-                      ]
-                    },
+                        ]
+                      }
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 3
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": true
-                    }
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -143,39 +228,62 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": true
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": true
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -186,7 +294,7 @@
           "UserName": "a"
         },
         {
-          "id": 226,
+          "id": 232,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -202,7 +310,7 @@
           "UserName": "b"
         },
         {
-          "id": 227,
+          "id": 233,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -218,7 +326,7 @@
           "UserName": "c"
         },
         {
-          "id": 228,
+          "id": 234,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-02-or-and/input.expected-rewrite.serialised.json
@@ -12,34 +12,53 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -58,8 +77,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 48,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -68,7 +88,7 @@
           "UserName": "a"
         },
         {
-          "id": 226,
+          "id": 239,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -84,7 +104,7 @@
           "UserName": "b"
         },
         {
-          "id": 227,
+          "id": 240,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -100,7 +120,7 @@
           "UserName": "c"
         },
         {
-          "id": 228,
+          "id": 241,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ Sum([x, y, 35])
 
 (Sum([x, y, 35]) = 100), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([x, y, 35], 100), SumGeq([x, y, 35], 100)]) 
+and([SumLeq([x, y, 35], 100),SumGeq([x, y, 35], 100);int(1..)]) 
 
 --
 
@@ -34,5 +34,5 @@ find y: int(1..50)
 
 such that
 
-And([SumLeq([x, y, 35], 100), SumGeq([x, y, 35], 100)])
+and([SumLeq([x, y, 35], 100),SumGeq([x, y, 35], 100);int(1..)])
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-add/input.expected-rewrite.serialised.json
@@ -12,75 +12,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 35
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 100
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "x"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "y"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 35
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 100
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 35
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 100
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "x"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "y"
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 35
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 100
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 44,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -89,7 +109,7 @@
           "UserName": "x"
         },
         {
-          "id": 229,
+          "id": 237,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -114,7 +134,7 @@
           "UserName": "y"
         },
         {
-          "id": 230,
+          "id": 238,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input-expected-rule-trace-human.txt
@@ -6,46 +6,70 @@ find c: bool
 
 such that
 
-Or([Or([a, b]), false]),
-Or([AllDiff([1, 2, 3]), true]),
-And([c, true])
+or([or([a,b;int(1..2)]),false;int(1..2)]),
+or([allDiff([1,2,3;int(1..)]),true;int(1..2)]),
+and([c,true;int(1..2)])
 
 --
 
-Or([AllDiff([1, 2, 3]), true]), 
+allDiff([1,2,3;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
 --
 
-Or([Or([a, b]), false]),
-true,
-And([c, true]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b]), false]),
-And([c, true]) 
-
---
-
-Or([Or([a, b]), false]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([Or([a, b])]) 
-
---
-
-And([c, true]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-And([c]) 
-
---
-
-Or([Or([a, b])]), 
+or([or([a,b;int(1..2)]),false;int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-Or([a, b]) 
+or([a,b,false;int(1..2)]) 
 
 --
 
-And([c]), 
+or([a,b,false;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([a,b,false;int(1..)]) 
+
+--
+
+or([a,b,false;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+or([a,b;int(1..)]) 
+
+--
+
+or([true,true;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([true,true;int(1..)]) 
+
+--
+
+or([true,true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+or([a,b;int(1..)]),
+true,
+and([c,true;int(1..2)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+or([a,b;int(1..)]),
+and([c,true;int(1..2)]) 
+
+--
+
+and([c,true;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+and([c,true;int(1..)]) 
+
+--
+
+and([c,true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([c;int(1..)]) 
+
+--
+
+and([c;int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 c 
 
@@ -59,6 +83,6 @@ find c: bool
 
 such that
 
-Or([a, b]),
+or([a,b;int(1..)]),
 c
 

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-parse.serialised.json
@@ -12,57 +12,101 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Or": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "a"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": false
+                            }
                           }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": false
-                    }
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -71,70 +115,111 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "AllDiff": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 1
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "AllDiff": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 1
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 2
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Literal": {
+                                            "Int": 3
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "UnboundedR": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
-                        }
-                      ]
-                    },
-                    {
-                      "Atomic": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 2
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": true
+                            }
                           }
-                        }
-                      ]
-                    },
+                        ]
+                      }
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Literal": {
-                            "Int": 3
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": true
-                    }
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -143,39 +228,62 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "c"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Bool": true
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Literal": {
-                      "Bool": true
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -186,7 +294,7 @@
           "UserName": "a"
         },
         {
-          "id": 231,
+          "id": 237,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -202,7 +310,7 @@
           "UserName": "b"
         },
         {
-          "id": 232,
+          "id": 238,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -218,7 +326,7 @@
           "UserName": "c"
         },
         {
-          "id": 233,
+          "id": 239,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/partial-eval-or-and/input.expected-rewrite.serialised.json
@@ -12,34 +12,53 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -58,8 +77,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 48,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -68,7 +88,7 @@
           "UserName": "a"
         },
         {
-          "id": 231,
+          "id": 244,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -84,7 +104,7 @@
           "UserName": "b"
         },
         {
-          "id": 232,
+          "id": 245,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -100,7 +120,7 @@
           "UserName": "c"
         },
         {
-          "id": 233,
+          "id": 246,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input-expected-rule-trace-human.txt
@@ -19,7 +19,7 @@ Sum([a, b, c])
 
 (Sum([a, b, c]) = 4), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]) 
+and([SumLeq([a, b, c], 4),SumGeq([a, b, c], 4);int(1..)]) 
 
 --
 
@@ -37,6 +37,6 @@ find c: int(1..3)
 
 such that
 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]),
+and([SumLeq([a, b, c], 4),SumGeq([a, b, c], 4);int(1..)]),
 Ineq(b, a, 0)
 

--- a/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/eprime-minion/xyz/input.expected-rewrite.serialised.json
@@ -12,68 +12,87 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -100,8 +119,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 78,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -110,7 +130,7 @@
           "UserName": "a"
         },
         {
-          "id": 234,
+          "id": 242,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -135,7 +155,7 @@
           "UserName": "b"
         },
         {
-          "id": 235,
+          "id": 243,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -160,7 +180,7 @@
           "UserName": "c"
         },
         {
-          "id": 236,
+          "id": 244,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input-expected-rule-trace-human.txt
@@ -6,12 +6,18 @@ find x: int(1..4)
 
 such that
 
-(Max([a, b]) >= 2),
-(x = Sum([Max([a, b]), 1]))
+(max([a,b;int(1..2)]) >= 2),
+(x = Sum([max([a,b;int(1..2)]), 1]))
 
 --
 
-Max([a, b]), 
+max([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+max([a,b;int(1..)]) 
+
+--
+
+max([a,b;int(1..)]), 
    ~~> max_to_var ([("Base", 6000)]) 
 __0 
 new variables:
@@ -19,24 +25,7 @@ new variables:
 new constraints:
   (__0 >= a)
   (__0 >= b)
-  Or([(__0 = a), (__0 = b)])
---
-
-Max([a, b]), 
-   ~~> max_to_var ([("Base", 6000)]) 
-__1 
-new variables:
-  find __1: int(1..4)
-new constraints:
-  (__1 >= a)
-  (__1 >= b)
-  Or([(__1 = a), (__1 = b)])
---
-
-(x = Sum([__1, 1])), 
-   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([__1, 1], x), SumGeq([__1, 1], x)]) 
-
+  or([(__0 = a),(__0 = b);int(1..)])
 --
 
 (__0 >= 2), 
@@ -54,6 +43,29 @@ Ineq(a, __0, 0)
 (__0 >= b), 
    ~~> geq_to_ineq ([("Minion", 4100)]) 
 Ineq(b, __0, 0) 
+
+--
+
+max([a,b;int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+max([a,b;int(1..)]) 
+
+--
+
+max([a,b;int(1..)]), 
+   ~~> max_to_var ([("Base", 6000)]) 
+__1 
+new variables:
+  find __1: int(1..4)
+new constraints:
+  (__1 >= a)
+  (__1 >= b)
+  or([(__1 = a),(__1 = b);int(1..)])
+--
+
+(x = Sum([__1, 1])), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([__1, 1], x),SumGeq([__1, 1], x);int(1..)]) 
 
 --
 
@@ -80,11 +92,11 @@ find __1: int(1..4)
 such that
 
 Ineq(2, __0, 0),
-And([SumLeq([__1, 1], x), SumGeq([__1, 1], x)]),
+and([SumLeq([__1, 1], x),SumGeq([__1, 1], x);int(1..)]),
 Ineq(a, __0, 0),
 Ineq(b, __0, 0),
-Or([(__0 = a), (__0 = b)]),
+or([(__0 = a),(__0 = b);int(1..)]),
 Ineq(a, __1, 0),
 Ineq(b, __1, 0),
-Or([(__1 = a), (__1 = b)])
+or([(__1 = a),(__1 = b);int(1..)])
 

--- a/conjure_oxide/tests/integration/experiment/works/max2/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input.expected-parse.serialised.json
@@ -18,34 +18,56 @@
                   "clean": false,
                   "etype": null
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                {
+                  "AbstractLiteral": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Matrix": [
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        {
+                          "IntDomain": [
+                            {
+                              "Bounded": [
+                                1,
+                                2
+                              ]
+                            }
+                          ]
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
+                      ]
+                    }
+                  ]
+                }
               ]
             },
             {
@@ -95,34 +117,56 @@
                         "clean": false,
                         "etype": null
                       },
-                      [
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "a"
+                      {
+                        "AbstractLiteral": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Matrix": [
+                              [
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Reference": {
+                                        "UserName": "a"
+                                      }
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Atomic": [
+                                    {
+                                      "clean": false,
+                                      "etype": null
+                                    },
+                                    {
+                                      "Reference": {
+                                        "UserName": "b"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              {
+                                "IntDomain": [
+                                  {
+                                    "Bounded": [
+                                      1,
+                                      2
+                                    ]
+                                  }
+                                ]
                               }
-                            }
-                          ]
-                        },
-                        {
-                          "Atomic": [
-                            {
-                              "clean": false,
-                              "etype": null
-                            },
-                            {
-                              "Reference": {
-                                "UserName": "b"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                            ]
+                          }
+                        ]
+                      }
                     ]
                   },
                   {
@@ -146,6 +190,7 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -156,7 +201,7 @@
           "UserName": "a"
         },
         {
-          "id": 237,
+          "id": 250,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -181,7 +226,7 @@
           "UserName": "b"
         },
         {
-          "id": 238,
+          "id": 251,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -206,7 +251,7 @@
           "UserName": "x"
         },
         {
-          "id": 239,
+          "id": 252,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/experiment/works/max2/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/experiment/works/max2/input.expected-rewrite.serialised.json
@@ -33,58 +33,77 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 1
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Literal": {
-                        "Int": 1
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "MachineName": 1
-                      }
-                    },
-                    {
-                      "Literal": {
-                        "Int": 1
-                      }
-                    }
-                  ],
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -135,76 +154,95 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -255,83 +293,103 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 1
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 1
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 597,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -340,7 +398,7 @@
           "UserName": "a"
         },
         {
-          "id": 237,
+          "id": 245,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -365,7 +423,7 @@
           "UserName": "b"
         },
         {
-          "id": 238,
+          "id": 246,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -390,7 +448,7 @@
           "UserName": "x"
         },
         {
-          "id": 239,
+          "id": 247,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -415,7 +473,7 @@
           "MachineName": 0
         },
         {
-          "id": 240,
+          "id": 248,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -440,7 +498,7 @@
           "MachineName": 1
         },
         {
-          "id": 241,
+          "id": 249,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -17,17 +17,17 @@ UnsafeDiv(x, y),
 
 ({SafeDiv(x, y) @ (y != 0)} = 5), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, y) = 5) @ And([(y != 0)])} 
+{(SafeDiv(x, y) = 5) @ and([(y != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(x, y) = 5) @ And([(y != 0)])}, 
+{(SafeDiv(x, y) = 5) @ and([(y != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(x, y) = 5), And([(y != 0)])]) 
+and([(SafeDiv(x, y) = 5),and([(y != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(y != 0)]), 
+and([(y != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
 
@@ -46,5 +46,5 @@ find y: int(2..4)
 
 such that
 
-And([DivEq(x, y, 5), (y != 0)])
+and([DivEq(x, y, 5),(y != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 5
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 5
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "y"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "x"
         },
         {
-          "id": 244,
+          "id": 252,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -111,7 +131,7 @@
           "UserName": "y"
         },
         {
-          "id": 245,
+          "id": 253,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -18,17 +18,17 @@ UnsafeDiv(x, y),
 
 ({SafeDiv(x, y) @ (y != 0)} = z), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, y) = z) @ And([(y != 0)])} 
+{(SafeDiv(x, y) = z) @ and([(y != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(x, y) = z) @ And([(y != 0)])}, 
+{(SafeDiv(x, y) = z) @ and([(y != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(x, y) = z), And([(y != 0)])]) 
+and([(SafeDiv(x, y) = z),and([(y != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(y != 0)]), 
+and([(y != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
 
@@ -48,5 +48,5 @@ find z: int(1..2)
 
 such that
 
-And([DivEq(x, y, z), (y != 0)])
+and([DivEq(x, y, z),(y != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "y"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "x"
         },
         {
-          "id": 247,
+          "id": 255,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -111,7 +131,7 @@
           "UserName": "y"
         },
         {
-          "id": 248,
+          "id": 256,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -136,7 +156,7 @@
           "UserName": "z"
         },
         {
-          "id": 249,
+          "id": 257,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ UnsafeDiv(y, z),
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} 
+{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} = 10), 
+({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ And([And([(z != 0)])])} 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ And([And([(z != 0)])])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(UnsafeDiv(x, SafeDiv(y, z)) = 10), And([And([(z != 0)])])]) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,19 +54,19 @@ UnsafeDiv(x, SafeDiv(y, z)),
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ And([(SafeDiv(y, z) != 0)])} 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ And([(SafeDiv(y, z) != 0)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]), (z != 0)]), 
+and([and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0),(z != 0);int(1..)]) 
 
 --
 
@@ -116,7 +116,7 @@ find __1: int(0..5)
 
 such that
 
-And([DivEq(x, __0, 10), (__1 != 0), (z != 0)]),
+and([DivEq(x, __0, 10),(__1 != 0),(z != 0);int(1..)]),
 DivEq(y, z, __0),
 DivEq(y, z, __1)
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input.expected-rewrite.serialised.json
@@ -12,99 +12,118 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 10
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 10
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 1
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -156,8 +175,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 376,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -166,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 251,
+          "id": 259,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -191,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 252,
+          "id": 260,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -216,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 253,
+          "id": 261,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -241,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 255,
+          "id": 263,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -266,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 257,
+          "id": 265,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ UnsafeDiv(y, z),
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} 
+{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} != 10), 
+({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} != 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ And([And([(z != 0)])])} 
+{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ And([And([(z != 0)])])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(UnsafeDiv(x, SafeDiv(y, z)) != 10), And([And([(z != 0)])])]) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) != 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,19 +54,19 @@ UnsafeDiv(x, SafeDiv(y, z)),
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} != 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) != 10) @ And([(SafeDiv(y, z) != 0)])} 
+{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) != 10) @ And([(SafeDiv(y, z) != 0)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) != 10), And([(SafeDiv(y, z) != 0)])]) 
+and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeDiv(x, SafeDiv(y, z)) != 10), And([(SafeDiv(y, z) != 0)])]), (z != 0)]), 
+and([and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) != 10), (SafeDiv(y, z) != 0), (z != 0)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) != 10),(SafeDiv(y, z) != 0),(z != 0);int(1..)]) 
 
 --
 
@@ -126,7 +126,7 @@ find __2: int(0..5)
 
 such that
 
-And([(__0 != 10), (__1 != 0), (z != 0)]),
+and([(__0 != 10),(__1 != 0),(z != 0);int(1..)]),
 DivEq(x, __2, __0),
 DivEq(y, z, __1),
 DivEq(y, z, __2)

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
@@ -12,110 +12,129 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 10
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 10
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 1
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -190,8 +209,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 486,
+    "id": 0,
     "next_machine_name": 3,
     "parent": null,
     "table": [
@@ -200,7 +220,7 @@
           "UserName": "x"
         },
         {
-          "id": 258,
+          "id": 266,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -225,7 +245,7 @@
           "UserName": "y"
         },
         {
-          "id": 259,
+          "id": 267,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -250,7 +270,7 @@
           "UserName": "z"
         },
         {
-          "id": 260,
+          "id": 268,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -275,7 +295,7 @@
           "MachineName": 0
         },
         {
-          "id": 261,
+          "id": 269,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -300,7 +320,7 @@
           "MachineName": 1
         },
         {
-          "id": 262,
+          "id": 270,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -325,7 +345,7 @@
           "MachineName": 2
         },
         {
-          "id": 263,
+          "id": 271,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ UnsafeDiv(y, z),
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} 
+{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ And([(z != 0)])} = 10), 
+({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ And([And([(z != 0)])])} 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ And([And([(z != 0)])])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(UnsafeDiv(x, SafeDiv(y, z)) = 10), And([And([(z != 0)])])]) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,25 +54,25 @@ UnsafeDiv(x, SafeDiv(y, z)),
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} = 10), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ And([(SafeDiv(y, z) != 0)])} 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ And([(SafeDiv(y, z) != 0)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeDiv(x, SafeDiv(y, z)) = 10), And([(SafeDiv(y, z) != 0)])]), (z != 0)]), 
+and([and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0),(z != 0);int(1..)]) 
 
 --
 
-Not(And([(SafeDiv(x, SafeDiv(y, z)) = 10), (SafeDiv(y, z) != 0), (z != 0)])), 
+Not(and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0),(z != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)), Not((SafeDiv(y, z) != 0)), Not((z != 0))]) 
+or([Not((SafeDiv(x, SafeDiv(y, z)) = 10)),Not((SafeDiv(y, z) != 0)),Not((z != 0));int(1..)]) 
 
 --
 
@@ -140,7 +140,7 @@ find __1: int(0..5)
 
 such that
 
-Or([(__0 != 10), DivEq(y, z, 0), (z = 0)]),
+or([(__0 != 10),DivEq(y, z, 0),(z = 0);int(1..)]),
 DivEq(x, __1, __0),
 DivEq(y, z, __1)
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -186,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 272,
+          "id": 277,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -211,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 273,
+          "id": 278,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -236,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 274,
+          "id": 279,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -261,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 275,
+          "id": 280,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -286,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 277,
+          "id": 282,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -12,99 +12,118 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 10
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
+                        "MinionDivEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 10
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
-              },
-              {
-                "MinionDivEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -156,8 +175,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 422,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -166,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 264,
+          "id": 272,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -191,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 265,
+          "id": 273,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -216,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 266,
+          "id": 274,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -241,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 267,
+          "id": 275,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -266,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 269,
+          "id": 277,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -17,17 +17,17 @@ x % y,
 
 ({SafeMod(x,y) @ (y != 0)} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,y) = 3) @ And([(y != 0)])} 
+{(SafeMod(x,y) = 3) @ and([(y != 0);int(1..)])} 
 
 --
 
-{(SafeMod(x,y) = 3) @ And([(y != 0)])}, 
+{(SafeMod(x,y) = 3) @ and([(y != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(x,y) = 3), And([(y != 0)])]) 
+and([(SafeMod(x,y) = 3),and([(y != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(y != 0)]), 
+and([(y != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
 
@@ -46,5 +46,5 @@ find y: int(2..4)
 
 such that
 
-And([ModEq(x, y, 3), (y != 0)])
+and([ModEq(x, y, 3),(y != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "y"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "x"
         },
         {
-          "id": 284,
+          "id": 292,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -111,7 +131,7 @@
           "UserName": "y"
         },
         {
-          "id": 285,
+          "id": 293,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -18,17 +18,17 @@ x % y,
 
 ({SafeMod(x,y) @ (y != 0)} = z), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,y) = z) @ And([(y != 0)])} 
+{(SafeMod(x,y) = z) @ and([(y != 0);int(1..)])} 
 
 --
 
-{(SafeMod(x,y) = z) @ And([(y != 0)])}, 
+{(SafeMod(x,y) = z) @ and([(y != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(x,y) = z), And([(y != 0)])]) 
+and([(SafeMod(x,y) = z),and([(y != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([(y != 0)]), 
+and([(y != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (y != 0) 
 
@@ -48,5 +48,5 @@ find z: int(1..2)
 
 such that
 
-And([ModEq(x, y, z), (y != 0)])
+and([ModEq(x, y, z),(y != 0);int(1..)])
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input.expected-rewrite.serialised.json
@@ -12,72 +12,92 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "y"
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "y"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 80,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -86,7 +106,7 @@
           "UserName": "x"
         },
         {
-          "id": 287,
+          "id": 295,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -111,7 +131,7 @@
           "UserName": "y"
         },
         {
-          "id": 288,
+          "id": 296,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -136,7 +156,7 @@
           "UserName": "z"
         },
         {
-          "id": 289,
+          "id": 297,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ y % z,
 
 x % {SafeMod(y,z) @ (z != 0)}, 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ And([(z != 0)])} 
+{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
 
 --
 
-({x % SafeMod(y,z) @ And([(z != 0)])} = 3), 
+({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) = 3) @ And([And([(z != 0)])])} 
+{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(x % SafeMod(y,z) = 3) @ And([And([(z != 0)])])}, 
+{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x % SafeMod(y,z) = 3), And([And([(z != 0)])])]) 
+and([(x % SafeMod(y,z) = 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,19 +54,19 @@ x % SafeMod(y,z),
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ And([(SafeMod(y,z) != 0)])} 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ And([(SafeMod(y,z) != 0)])}, 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]), (z != 0)]), 
+and([and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0),(z != 0);int(1..)]) 
 
 --
 
@@ -116,7 +116,7 @@ find __1: int(0..5)
 
 such that
 
-And([ModEq(x, __0, 3), (__1 != 0), (z != 0)]),
+and([ModEq(x, __0, 3),(__1 != 0),(z != 0);int(1..)]),
 ModEq(y, z, __0),
 ModEq(y, z, __1)
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input.expected-rewrite.serialised.json
@@ -12,99 +12,118 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "x"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "x"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 3
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 0
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 3
-                    }
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 1
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -156,8 +175,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 376,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -166,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 291,
+          "id": 299,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -191,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 292,
+          "id": 300,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -216,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 293,
+          "id": 301,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -241,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 295,
+          "id": 303,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -266,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 297,
+          "id": 305,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ y % z,
 
 x % {SafeMod(y,z) @ (z != 0)}, 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ And([(z != 0)])} 
+{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
 
 --
 
-({x % SafeMod(y,z) @ And([(z != 0)])} != 3), 
+({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} != 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) != 3) @ And([And([(z != 0)])])} 
+{(x % SafeMod(y,z) != 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(x % SafeMod(y,z) != 3) @ And([And([(z != 0)])])}, 
+{(x % SafeMod(y,z) != 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x % SafeMod(y,z) != 3), And([And([(z != 0)])])]) 
+and([(x % SafeMod(y,z) != 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,19 +54,19 @@ x % SafeMod(y,z),
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} != 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) != 3) @ And([(SafeMod(y,z) != 0)])} 
+{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) != 3) @ And([(SafeMod(y,z) != 0)])}, 
+{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) != 3), And([(SafeMod(y,z) != 0)])]) 
+and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeMod(x,SafeMod(y,z)) != 3), And([(SafeMod(y,z) != 0)])]), (z != 0)]), 
+and([and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) != 3), (SafeMod(y,z) != 0), (z != 0)]) 
+and([(SafeMod(x,SafeMod(y,z)) != 3),(SafeMod(y,z) != 0),(z != 0);int(1..)]) 
 
 --
 
@@ -126,7 +126,7 @@ find __2: int(0..3)
 
 such that
 
-And([(__0 != 3), (__1 != 0), (z != 0)]),
+and([(__0 != 3),(__1 != 0),(z != 0);int(1..)]),
 ModEq(x, __2, __0),
 ModEq(y, z, __1),
 ModEq(y, z, __2)

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input.expected-rewrite.serialised.json
@@ -12,110 +12,129 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 1
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 3
-                        }
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "MachineName": 1
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -190,8 +209,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 486,
+    "id": 0,
     "next_machine_name": 3,
     "parent": null,
     "table": [
@@ -200,7 +220,7 @@
           "UserName": "x"
         },
         {
-          "id": 298,
+          "id": 306,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -225,7 +245,7 @@
           "UserName": "y"
         },
         {
-          "id": 299,
+          "id": 307,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -250,7 +270,7 @@
           "UserName": "z"
         },
         {
-          "id": 300,
+          "id": 308,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -275,7 +295,7 @@
           "MachineName": 0
         },
         {
-          "id": 301,
+          "id": 309,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -300,7 +320,7 @@
           "MachineName": 1
         },
         {
-          "id": 302,
+          "id": 310,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -325,7 +345,7 @@
           "MachineName": 2
         },
         {
-          "id": 303,
+          "id": 311,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -18,29 +18,29 @@ y % z,
 
 x % {SafeMod(y,z) @ (z != 0)}, 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ And([(z != 0)])} 
+{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
 
 --
 
-({x % SafeMod(y,z) @ And([(z != 0)])} = 3), 
+({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) = 3) @ And([And([(z != 0)])])} 
+{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
 
 --
 
-{(x % SafeMod(y,z) = 3) @ And([And([(z != 0)])])}, 
+{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(x % SafeMod(y,z) = 3), And([And([(z != 0)])])]) 
+and([(x % SafeMod(y,z) = 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(z != 0)])]), 
+and([and([(z != 0);int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
-And([(z != 0)]) 
+and([(z != 0);int(1..)]) 
 
 --
 
-And([(z != 0)]), 
+and([(z != 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (z != 0) 
 
@@ -54,25 +54,25 @@ x % SafeMod(y,z),
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} = 3), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ And([(SafeMod(y,z) != 0)])} 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ And([(SafeMod(y,z) != 0)])}, 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
 
 --
 
-And([And([(SafeMod(x,SafeMod(y,z)) = 3), And([(SafeMod(y,z) != 0)])]), (z != 0)]), 
+and([and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0),(z != 0);int(1..)]) 
 
 --
 
-Not(And([(SafeMod(x,SafeMod(y,z)) = 3), (SafeMod(y,z) != 0), (z != 0)])), 
+Not(and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0),(z != 0);int(1..)])), 
    ~~> distribute_not_over_and ([("Base", 8400)]) 
-Or([Not((SafeMod(x,SafeMod(y,z)) = 3)), Not((SafeMod(y,z) != 0)), Not((z != 0))]) 
+or([Not((SafeMod(x,SafeMod(y,z)) = 3)),Not((SafeMod(y,z) != 0)),Not((z != 0));int(1..)]) 
 
 --
 
@@ -140,7 +140,7 @@ find __1: int(0..3)
 
 such that
 
-Or([(__0 != 3), ModEq(y, z, 0), (z = 0)]),
+or([(__0 != 3),ModEq(y, z, 0),(z = 0);int(1..)]),
 ModEq(x, __1, __0),
 ModEq(y, z, __1)
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -12,99 +12,118 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Neq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Neq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "MachineName": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "MachineName": 0
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
+                        "MinionModuloEqUndefZero": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "y"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Literal": {
+                              "Int": 0
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 3
-                        }
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
-              },
-              {
-                "MinionModuloEqUndefZero": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "y"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "z"
-                    }
-                  },
-                  {
-                    "Literal": {
-                      "Int": 0
-                    }
-                  }
-                ]
-              },
-              {
-                "Eq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -156,8 +175,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 422,
+    "id": 0,
     "next_machine_name": 2,
     "parent": null,
     "table": [
@@ -166,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 304,
+          "id": 312,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -191,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 305,
+          "id": 313,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -216,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 306,
+          "id": 314,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -241,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 307,
+          "id": 315,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -266,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 309,
+          "id": 317,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input.expected-rewrite.serialised.json
@@ -186,7 +186,7 @@
           "UserName": "x"
         },
         {
-          "id": 312,
+          "id": 317,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -211,7 +211,7 @@
           "UserName": "y"
         },
         {
-          "id": 313,
+          "id": 318,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -236,7 +236,7 @@
           "UserName": "z"
         },
         {
-          "id": 314,
+          "id": 319,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -261,7 +261,7 @@
           "MachineName": 0
         },
         {
-          "id": 315,
+          "id": 320,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -286,7 +286,7 @@
           "MachineName": 1
         },
         {
-          "id": 317,
+          "id": 322,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
@@ -19,18 +19,18 @@ find z: bool
 such that
 
 (x) -> (x),
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))]),
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)]),
 ((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+or([((n < 6)) -> ((m % 2 = 0)),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
+or([or([or([((n < 6)) -> ((m % 2 = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
 (o = n),
 (d = (n < 6)),
 (p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))])
+or([((o < 6)) -> ((p = 0)),((m % 2 = 0)) -> (d);int(1..2)]),
+or([or([or([((o < 6)) -> ((p = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> (d);int(1..2)]),
+or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]),
+or([or([or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a;int(1..2)]),b;int(1..2)]),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)])
 
 --
 
@@ -41,113 +41,49 @@ true
 --
 
 true,
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))]),
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)]),
 ((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+or([((n < 6)) -> ((m % 2 = 0)),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
+or([or([or([((n < 6)) -> ((m % 2 = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
 (o = n),
 (d = (n < 6)),
 (p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
+or([((o < 6)) -> ((p = 0)),((m % 2 = 0)) -> (d);int(1..2)]),
+or([or([or([((o < 6)) -> ((p = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> (d);int(1..2)]),
+or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]),
+or([or([or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a;int(1..2)]),b;int(1..2)]),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-Or([(a) -> (z), (z) -> (a)]),
-Or([(b) -> (c), (b) -> (Not(c))]),
+or([(a) -> (z),(z) -> (a);int(1..2)]),
+or([(b) -> (c),(b) -> (Not(c));int(1..2)]),
 ((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
+or([((n < 6)) -> ((m % 2 = 0)),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
+or([or([or([((n < 6)) -> ((m % 2 = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> ((n < 6));int(1..2)]),
 (o = n),
 (d = (n < 6)),
 (p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
+or([((o < 6)) -> ((p = 0)),((m % 2 = 0)) -> (d);int(1..2)]),
+or([or([or([((o < 6)) -> ((p = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> (d);int(1..2)]),
+or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]),
+or([or([or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a;int(1..2)]),b;int(1..2)]),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]) 
 
 --
 
-Or([(a) -> (z), (z) -> (a)]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-true 
-
---
-
-true,
-Or([(b) -> (c), (b) -> (Not(c))]),
-((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
-(o = n),
-(d = (n < 6)),
-(p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-Or([(b) -> (c), (b) -> (Not(c))]),
-((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
-(o = n),
-(d = (n < 6)),
-(p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
-
---
-
-Or([(b) -> (c), (b) -> (Not(c))]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-true 
-
---
-
-true,
-((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
-(o = n),
-(d = (n < 6)),
-(p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
-   ~~> partial_evaluator ([("Base", 9000)]) 
-((l = 10)) -> ((l = 10)),
-Or([((n < 6)) -> ((m % 2 = 0)), ((m % 2 = 0)) -> ((n < 6))]),
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]),
-(o = n),
-(d = (n < 6)),
-(p = m % 2),
-Or([((o < 6)) -> ((p = 0)), ((m % 2 = 0)) -> (d)]),
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]),
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]),
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
-
---
-
-Or([Or([Or([((n < 6)) -> ((m % 2 = 0)), a]), b]), ((m % 2 = 0)) -> ((n < 6))]), 
+or([or([or([((n < 6)) -> ((m % 2 = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> ((n < 6));int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-Or([((n < 6)) -> ((m % 2 = 0)), a, b, ((m % 2 = 0)) -> ((n < 6))]) 
+or([((n < 6)) -> ((m % 2 = 0)),a,b,((m % 2 = 0)) -> ((n < 6));int(1..2)]) 
 
 --
 
-Or([Or([Or([((o < 6)) -> ((p = 0)), a]), b]), ((m % 2 = 0)) -> (d)]), 
+or([or([or([((o < 6)) -> ((p = 0)),a;int(1..2)]),b;int(1..2)]),((m % 2 = 0)) -> (d);int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-Or([((o < 6)) -> ((p = 0)), a, b, ((m % 2 = 0)) -> (d)]) 
+or([((o < 6)) -> ((p = 0)),a,b,((m % 2 = 0)) -> (d);int(1..2)]) 
 
 --
 
-Or([Or([Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a]), b]), ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]), 
+or([or([or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a;int(1..2)]),b;int(1..2)]),((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
-Or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)), a, b, ((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)))]) 
+or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a,b,((UnsafeDiv(q, 2) = r)) -> (Not((n < 6)));int(1..2)]) 
 
 --
 
@@ -297,11 +233,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -309,17 +245,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -339,11 +275,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -351,17 +287,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -381,11 +317,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -393,17 +329,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -423,11 +359,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -435,17 +371,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -465,11 +401,11 @@ true
 
 (p = {SafeMod(m,2) @ true}), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(p = SafeMod(m,2)) @ And([true])} 
+{(p = SafeMod(m,2)) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -477,17 +413,17 @@ true
 
 {(p = SafeMod(m,2)) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(p = SafeMod(m,2)), true]) 
+and([(p = SafeMod(m,2)),true;int(1..)]) 
 
 --
 
-And([(p = SafeMod(m,2)), true]), 
+and([(p = SafeMod(m,2)),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(p = SafeMod(m,2))]) 
+and([(p = SafeMod(m,2));int(1..)]) 
 
 --
 
-And([(p = SafeMod(m,2))]), 
+and([(p = SafeMod(m,2));int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (p = SafeMod(m,2)) 
 
@@ -507,11 +443,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -519,17 +455,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -549,11 +485,11 @@ true
 
 ({SafeMod(m,2) @ true} = 0), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(m,2) = 0) @ And([true])} 
+{(SafeMod(m,2) = 0) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -561,17 +497,17 @@ true
 
 {(SafeMod(m,2) = 0) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeMod(m,2) = 0), true]) 
+and([(SafeMod(m,2) = 0),true;int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0), true]), 
+and([(SafeMod(m,2) = 0),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeMod(m,2) = 0)]) 
+and([(SafeMod(m,2) = 0);int(1..)]) 
 
 --
 
-And([(SafeMod(m,2) = 0)]), 
+and([(SafeMod(m,2) = 0);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeMod(m,2) = 0) 
 
@@ -591,11 +527,11 @@ true
 
 ({SafeDiv(q, 2) @ true} = r), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(q, 2) = r) @ And([true])} 
+{(SafeDiv(q, 2) = r) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -603,17 +539,17 @@ true
 
 {(SafeDiv(q, 2) = r) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(q, 2) = r), true]) 
+and([(SafeDiv(q, 2) = r),true;int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r), true]), 
+and([(SafeDiv(q, 2) = r),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeDiv(q, 2) = r)]) 
+and([(SafeDiv(q, 2) = r);int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r)]), 
+and([(SafeDiv(q, 2) = r);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeDiv(q, 2) = r) 
 
@@ -633,11 +569,11 @@ true
 
 ({SafeDiv(q, 2) @ true} = r), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(q, 2) = r) @ And([true])} 
+{(SafeDiv(q, 2) = r) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -645,17 +581,17 @@ true
 
 {(SafeDiv(q, 2) = r) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(q, 2) = r), true]) 
+and([(SafeDiv(q, 2) = r),true;int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r), true]), 
+and([(SafeDiv(q, 2) = r),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeDiv(q, 2) = r)]) 
+and([(SafeDiv(q, 2) = r);int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r)]), 
+and([(SafeDiv(q, 2) = r);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeDiv(q, 2) = r) 
 
@@ -675,11 +611,11 @@ true
 
 ({SafeDiv(q, 2) @ true} = r), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(q, 2) = r) @ And([true])} 
+{(SafeDiv(q, 2) = r) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -687,17 +623,17 @@ true
 
 {(SafeDiv(q, 2) = r) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(q, 2) = r), true]) 
+and([(SafeDiv(q, 2) = r),true;int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r), true]), 
+and([(SafeDiv(q, 2) = r),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeDiv(q, 2) = r)]) 
+and([(SafeDiv(q, 2) = r);int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r)]), 
+and([(SafeDiv(q, 2) = r);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeDiv(q, 2) = r) 
 
@@ -717,11 +653,11 @@ true
 
 ({SafeDiv(q, 2) @ true} = r), 
    ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(q, 2) = r) @ And([true])} 
+{(SafeDiv(q, 2) = r) @ and([true;int(1..)])} 
 
 --
 
-And([true]), 
+and([true;int(1..)]), 
    ~~> apply_eval_constant ([("Constant", 9001)]) 
 true 
 
@@ -729,19 +665,43 @@ true
 
 {(SafeDiv(q, 2) = r) @ true}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-And([(SafeDiv(q, 2) = r), true]) 
+and([(SafeDiv(q, 2) = r),true;int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r), true]), 
+and([(SafeDiv(q, 2) = r),true;int(1..)]), 
    ~~> partial_evaluator ([("Base", 9000)]) 
-And([(SafeDiv(q, 2) = r)]) 
+and([(SafeDiv(q, 2) = r);int(1..)]) 
 
 --
 
-And([(SafeDiv(q, 2) = r)]), 
+and([(SafeDiv(q, 2) = r);int(1..)]), 
    ~~> remove_unit_vector_and ([("Base", 8800)]) 
 (SafeDiv(q, 2) = r) 
+
+--
+
+(a) -> (z), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(a, z, 0) 
+
+--
+
+(z) -> (a), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(z, a, 0) 
+
+--
+
+(b) -> (c), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+Ineq(b, c, 0) 
+
+--
+
+(b) -> (Not(c)), 
+   ~~> introduce_reifyimply_ineq_from_imply ([("Minion", 4400)]) 
+ReifyImply(Not(c), b) 
 
 --
 
@@ -1120,6 +1080,12 @@ DivEq(q, 2, r)
 
 --
 
+Not(c), 
+   ~~> not_literal_to_wliteral ([("Minion", 4100)]) 
+WatchedLiteral(c,false) 
+
+--
+
 (n <= 5), 
    ~~> leq_to_ineq ([("Minion", 4100)]) 
 Ineq(n, 5, 0) 
@@ -1198,6 +1164,54 @@ Ineq(n, 5, 0)
 
 --
 
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..)]) 
+
+--
+
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..)]) 
+
+--
+
+or([ReifyImply(ModEq(m, 2, 0), __1),ReifyImply(Ineq(n, 5, 0), __2);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply(ModEq(m, 2, 0), __1),ReifyImply(Ineq(n, 5, 0), __2);int(1..)]) 
+
+--
+
+or([ReifyImply(ModEq(m, 2, 0), __3),a,b,ReifyImply(Ineq(n, 5, 0), __4);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply(ModEq(m, 2, 0), __3),a,b,ReifyImply(Ineq(n, 5, 0), __4);int(1..)]) 
+
+--
+
+or([ReifyImply((p = 0), __5),Ineq(__6, d, 0);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply((p = 0), __5),Ineq(__6, d, 0);int(1..)]) 
+
+--
+
+or([ReifyImply((p = 0), __7),a,b,Ineq(__8, d, 0);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply((p = 0), __7),a,b,Ineq(__8, d, 0);int(1..)]) 
+
+--
+
+or([ReifyImply(Ineq(n, 5, 0), __9),ReifyImply(WatchedLiteral(__11,false), __10);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply(Ineq(n, 5, 0), __9),ReifyImply(WatchedLiteral(__11,false), __10);int(1..)]) 
+
+--
+
+or([ReifyImply(Ineq(n, 5, 0), __12),a,b,ReifyImply(WatchedLiteral(__14,false), __13);int(1..2)]), 
+   ~~> matrix_to_list ([("Base", 2000)]) 
+or([ReifyImply(Ineq(n, 5, 0), __12),a,b,ReifyImply(WatchedLiteral(__14,false), __13);int(1..)]) 
+
+--
+
 Final model:
 
 find a: bool
@@ -1233,16 +1247,18 @@ find __14: bool
 
 such that
 
+or([Ineq(a, z, 0),Ineq(z, a, 0);int(1..)]),
+or([Ineq(b, c, 0),ReifyImply(WatchedLiteral(c,false), b);int(1..)]),
 ReifyImply((l = 10), __0),
-Or([ReifyImply(ModEq(m, 2, 0), __1), ReifyImply(Ineq(n, 5, 0), __2)]),
-Or([ReifyImply(ModEq(m, 2, 0), __3), a, b, ReifyImply(Ineq(n, 5, 0), __4)]),
+or([ReifyImply(ModEq(m, 2, 0), __1),ReifyImply(Ineq(n, 5, 0), __2);int(1..)]),
+or([ReifyImply(ModEq(m, 2, 0), __3),a,b,ReifyImply(Ineq(n, 5, 0), __4);int(1..)]),
 (o = n),
 Reify(Ineq(n, 5, 0), d),
 ModEq(m, 2, p),
-Or([ReifyImply((p = 0), __5), Ineq(__6, d, 0)]),
-Or([ReifyImply((p = 0), __7), a, b, Ineq(__8, d, 0)]),
-Or([ReifyImply(Ineq(n, 5, 0), __9), ReifyImply(WatchedLiteral(__11,false), __10)]),
-Or([ReifyImply(Ineq(n, 5, 0), __12), a, b, ReifyImply(WatchedLiteral(__14,false), __13)]),
+or([ReifyImply((p = 0), __5),Ineq(__6, d, 0);int(1..)]),
+or([ReifyImply((p = 0), __7),a,b,Ineq(__8, d, 0);int(1..)]),
+or([ReifyImply(Ineq(n, 5, 0), __9),ReifyImply(WatchedLiteral(__11,false), __10);int(1..)]),
+or([ReifyImply(Ineq(n, 5, 0), __12),a,b,ReifyImply(WatchedLiteral(__14,false), __13);int(1..)]),
 Reify((l = 10), __0),
 Reify(Ineq(n, 5, 0), __1),
 Reify(ModEq(m, 2, 0), __2),

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-parse.serialised.json
@@ -46,76 +46,98 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "a"
-                        }
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "z"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "z"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "a"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -124,84 +146,106 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "c"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "b"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "Not": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
+                        "Imply": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "c"
-                            }
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "c"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "b"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Not": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "c"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
                           }
                         ]
                       }
-                    ]
-                  }
-                ]
-              }
-            ]
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -286,233 +330,63 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Lt": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "n"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 6
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeMod": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "m"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeMod": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "m"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Lt": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "n"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 6
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
             {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Or": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Imply": [
                           {
-                            "Imply": [
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Lt": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Lt": [
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "n"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 6
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeMod": [
                                   {
                                     "clean": false,
                                     "etype": null
@@ -525,7 +399,7 @@
                                       },
                                       {
                                         "Reference": {
-                                          "UserName": "n"
+                                          "UserName": "m"
                                         }
                                       }
                                     ]
@@ -538,7 +412,7 @@
                                       },
                                       {
                                         "Literal": {
-                                          "Int": 6
+                                          "Int": 2
                                         }
                                       }
                                     ]
@@ -546,42 +420,50 @@
                                 ]
                               },
                               {
-                                "Eq": [
+                                "Atomic": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   {
-                                    "UnsafeMod": [
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeMod": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
                                       {
                                         "clean": false,
                                         "etype": null
                                       },
                                       {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Reference": {
-                                              "UserName": "m"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Literal": {
-                                              "Int": 2
-                                            }
-                                          }
-                                        ]
+                                        "Reference": {
+                                          "UserName": "m"
+                                        }
                                       }
                                     ]
                                   },
@@ -593,145 +475,395 @@
                                       },
                                       {
                                         "Literal": {
-                                          "Int": 0
+                                          "Int": 2
                                         }
                                       }
                                     ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
                                   }
                                 ]
                               }
                             ]
                           },
                           {
-                            "Atomic": [
+                            "Lt": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Reference": {
-                                  "UserName": "a"
-                                }
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "n"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 6
+                                    }
+                                  }
+                                ]
                               }
                             ]
                           }
                         ]
-                      ]
-                    },
+                      }
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeMod": [
+                        "Or": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Atomic": [
+                            "AbstractLiteral": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Reference": {
-                                  "UserName": "m"
-                                }
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Or": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "AbstractLiteral": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Matrix": [
+                                                [
+                                                  {
+                                                    "Imply": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Lt": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Reference": {
+                                                                  "UserName": "n"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Literal": {
+                                                                  "Int": 6
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Eq": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "UnsafeMod": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Atomic": [
+                                                                  {
+                                                                    "clean": false,
+                                                                    "etype": null
+                                                                  },
+                                                                  {
+                                                                    "Reference": {
+                                                                      "UserName": "m"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "Atomic": [
+                                                                  {
+                                                                    "clean": false,
+                                                                    "etype": null
+                                                                  },
+                                                                  {
+                                                                    "Literal": {
+                                                                      "Int": 2
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Literal": {
+                                                                  "Int": 0
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "Atomic": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Reference": {
+                                                          "UserName": "a"
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                {
+                                                  "IntDomain": [
+                                                    {
+                                                      "Bounded": [
+                                                        1,
+                                                        2
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
                           },
                           {
-                            "Atomic": [
+                            "Eq": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Literal": {
-                                  "Int": 2
-                                }
+                                "UnsafeMod": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "m"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 2
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Lt": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "n"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 6
+                                    }
+                                  }
+                                ]
                               }
                             ]
                           }
                         ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Lt": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "n"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 6
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -884,191 +1016,105 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Lt": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "o"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 6
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "p"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeMod": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "m"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "d"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
             {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Or": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Imply": [
                           {
-                            "Imply": [
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Lt": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Lt": [
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "o"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 6
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "p"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeMod": [
                                   {
                                     "clean": false,
                                     "etype": null
@@ -1081,7 +1127,7 @@
                                       },
                                       {
                                         "Reference": {
-                                          "UserName": "o"
+                                          "UserName": "m"
                                         }
                                       }
                                     ]
@@ -1094,7 +1140,7 @@
                                       },
                                       {
                                         "Literal": {
-                                          "Int": 6
+                                          "Int": 2
                                         }
                                       }
                                     ]
@@ -1102,36 +1148,15 @@
                                 ]
                               },
                               {
-                                "Eq": [
+                                "Atomic": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   {
-                                    "Atomic": [
-                                      {
-                                        "clean": false,
-                                        "etype": null
-                                      },
-                                      {
-                                        "Reference": {
-                                          "UserName": "p"
-                                        }
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "Atomic": [
-                                      {
-                                        "clean": false,
-                                        "etype": null
-                                      },
-                                      {
-                                        "Literal": {
-                                          "Int": 0
-                                        }
-                                      }
-                                    ]
+                                    "Literal": {
+                                      "Int": 0
+                                    }
                                   }
                                 ]
                               }
@@ -1145,107 +1170,28 @@
                               },
                               {
                                 "Reference": {
-                                  "UserName": "a"
+                                  "UserName": "d"
                                 }
                               }
                             ]
                           }
                         ]
-                      ]
-                    },
+                      }
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeMod": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "m"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Atomic": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "d"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -1254,276 +1200,209 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeDiv": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "q"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "r"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Lt": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "n"
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 6
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeDiv": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "q"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "r"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Not": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Lt": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "n"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 6
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
             {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "Or": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Or": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Or": [
                           {
-                            "Imply": [
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "AbstractLiteral": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Eq": [
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Or": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "AbstractLiteral": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Matrix": [
+                                                [
+                                                  {
+                                                    "Imply": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Lt": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Reference": {
+                                                                  "UserName": "o"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Literal": {
+                                                                  "Int": 6
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Eq": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Reference": {
+                                                                  "UserName": "p"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Literal": {
+                                                                  "Int": 0
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "Atomic": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Reference": {
+                                                          "UserName": "a"
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                {
+                                                  "IntDomain": [
+                                                    {
+                                                      "Bounded": [
+                                                        1,
+                                                        2
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeMod": [
                                   {
                                     "clean": false,
                                     "etype": null
                                   },
                                   {
-                                    "UnsafeDiv": [
+                                    "Atomic": [
                                       {
                                         "clean": false,
                                         "etype": null
                                       },
                                       {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Reference": {
-                                              "UserName": "q"
-                                            }
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "Atomic": [
-                                          {
-                                            "clean": false,
-                                            "etype": null
-                                          },
-                                          {
-                                            "Literal": {
-                                              "Int": 2
-                                            }
-                                          }
-                                        ]
+                                        "Reference": {
+                                          "UserName": "m"
+                                        }
                                       }
                                     ]
                                   },
@@ -1534,13 +1413,239 @@
                                         "etype": null
                                       },
                                       {
-                                        "Reference": {
-                                          "UserName": "r"
+                                        "Literal": {
+                                          "Int": 2
                                         }
                                       }
                                     ]
                                   }
                                 ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "d"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeDiv": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "q"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 2
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "r"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Lt": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "n"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 6
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "Imply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeDiv": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "q"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 2
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "r"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Not": [
+                              {
+                                "clean": false,
+                                "etype": null
                               },
                               {
                                 "Lt": [
@@ -1577,150 +1682,354 @@
                                 ]
                               }
                             ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "a"
-                                }
-                              }
-                            ]
                           }
                         ]
-                      ]
-                    },
+                      }
+                    ],
                     {
-                      "Atomic": [
+                      "IntDomain": [
                         {
-                          "clean": false,
-                          "etype": null
-                        },
-                        {
-                          "Reference": {
-                            "UserName": "b"
-                          }
+                          "Bounded": [
+                            1,
+                            2
+                          ]
                         }
                       ]
                     }
                   ]
-                ]
-              },
-              {
-                "Imply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeDiv": [
+                        "Or": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Atomic": [
+                            "AbstractLiteral": [
                               {
                                 "clean": false,
                                 "etype": null
                               },
                               {
-                                "Reference": {
-                                  "UserName": "q"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 2
-                                }
+                                "Matrix": [
+                                  [
+                                    {
+                                      "Or": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "AbstractLiteral": [
+                                            {
+                                              "clean": false,
+                                              "etype": null
+                                            },
+                                            {
+                                              "Matrix": [
+                                                [
+                                                  {
+                                                    "Imply": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Eq": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "UnsafeDiv": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Atomic": [
+                                                                  {
+                                                                    "clean": false,
+                                                                    "etype": null
+                                                                  },
+                                                                  {
+                                                                    "Reference": {
+                                                                      "UserName": "q"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "Atomic": [
+                                                                  {
+                                                                    "clean": false,
+                                                                    "etype": null
+                                                                  },
+                                                                  {
+                                                                    "Literal": {
+                                                                      "Int": 2
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Reference": {
+                                                                  "UserName": "r"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      },
+                                                      {
+                                                        "Lt": [
+                                                          {
+                                                            "clean": false,
+                                                            "etype": null
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Reference": {
+                                                                  "UserName": "n"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "Atomic": [
+                                                              {
+                                                                "clean": false,
+                                                                "etype": null
+                                                              },
+                                                              {
+                                                                "Literal": {
+                                                                  "Int": 6
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "Atomic": [
+                                                      {
+                                                        "clean": false,
+                                                        "etype": null
+                                                      },
+                                                      {
+                                                        "Reference": {
+                                                          "UserName": "a"
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ],
+                                                {
+                                                  "IntDomain": [
+                                                    {
+                                                      "Bounded": [
+                                                        1,
+                                                        2
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "Atomic": [
+                                        {
+                                          "clean": false,
+                                          "etype": null
+                                        },
+                                        {
+                                          "Reference": {
+                                            "UserName": "b"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  {
+                                    "IntDomain": [
+                                      {
+                                        "Bounded": [
+                                          1,
+                                          2
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
                               }
                             ]
                           }
                         ]
                       },
                       {
-                        "Atomic": [
+                        "Imply": [
                           {
                             "clean": false,
                             "etype": null
                           },
                           {
-                            "Reference": {
-                              "UserName": "r"
-                            }
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UnsafeDiv": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "q"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 2
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "r"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Not": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Lt": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Reference": {
+                                          "UserName": "n"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "Atomic": [
+                                      {
+                                        "clean": false,
+                                        "etype": null
+                                      },
+                                      {
+                                        "Literal": {
+                                          "Int": 6
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
                           }
                         ]
                       }
-                    ]
-                  },
-                  {
-                    "Not": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Lt": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Reference": {
-                                  "UserName": "n"
-                                }
-                              }
-                            ]
-                          },
-                          {
-                            "Atomic": [
-                              {
-                                "clean": false,
-                                "etype": null
-                              },
-                              {
-                                "Literal": {
-                                  "Int": 6
-                                }
-                              }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
     "id": 0,
     "next_machine_name": 0,
@@ -1731,7 +2040,7 @@
           "UserName": "a"
         },
         {
-          "id": 319,
+          "id": 323,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1747,7 +2056,7 @@
           "UserName": "b"
         },
         {
-          "id": 320,
+          "id": 324,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1763,7 +2072,7 @@
           "UserName": "c"
         },
         {
-          "id": 321,
+          "id": 325,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1779,7 +2088,7 @@
           "UserName": "d"
         },
         {
-          "id": 322,
+          "id": 326,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1795,7 +2104,7 @@
           "UserName": "e"
         },
         {
-          "id": 323,
+          "id": 327,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1811,7 +2120,7 @@
           "UserName": "l"
         },
         {
-          "id": 324,
+          "id": 328,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1836,7 +2145,7 @@
           "UserName": "m"
         },
         {
-          "id": 325,
+          "id": 329,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1861,7 +2170,7 @@
           "UserName": "n"
         },
         {
-          "id": 326,
+          "id": 330,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1886,7 +2195,7 @@
           "UserName": "o"
         },
         {
-          "id": 327,
+          "id": 331,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1911,7 +2220,7 @@
           "UserName": "p"
         },
         {
-          "id": 328,
+          "id": 332,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1936,7 +2245,7 @@
           "UserName": "q"
         },
         {
-          "id": 329,
+          "id": 333,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1961,7 +2270,7 @@
           "UserName": "r"
         },
         {
-          "id": 330,
+          "id": 334,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1986,7 +2295,7 @@
           "UserName": "x"
         },
         {
-          "id": 316,
+          "id": 320,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -2002,7 +2311,7 @@
           "UserName": "y"
         },
         {
-          "id": 317,
+          "id": 321,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -2018,7 +2327,7 @@
           "UserName": "z"
         },
         {
-          "id": 318,
+          "id": 322,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input.expected-rewrite.serialised.json
@@ -7,6 +7,154 @@
       },
       [
         {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "z"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "c"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      },
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatWatchedLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "UserName": "c"
+                              },
+                              {
+                                "Bool": false
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
           "MinionReifyImply": [
             {
               "clean": false,
@@ -59,78 +207,97 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "MinionModuloEqUndefZero": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "MinionModuloEqUndefZero": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "m"
-                        }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 2
-                        }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 0
-                        }
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatIneq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 5
+                                }
+                              },
+                              {
+                                "Int": 0
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 1
-                    }
-                  }
-                ]
-              },
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatIneq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 5
-                        }
-                      },
-                      {
-                        "Int": 0
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 2
+                      ]
                     }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -139,104 +306,123 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "MinionModuloEqUndefZero": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "MinionModuloEqUndefZero": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "m"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 0
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 3
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Reference": {
-                          "UserName": "m"
-                        }
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 2
-                        }
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
                       },
                       {
-                        "Literal": {
-                          "Int": 0
-                        }
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatIneq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 5
+                                }
+                              },
+                              {
+                                "Int": 0
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 4
+                            }
+                          }
+                        ]
                       }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 3
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatIneq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 5
-                        }
-                      },
-                      {
-                        "Int": 0
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 4
+                      ]
                     }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -336,18 +522,158 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "p"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 5
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 6
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "d"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Eq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Reference": {
+                                      "UserName": "p"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "Atomic": [
+                                  {
+                                    "clean": false,
+                                    "etype": null
+                                  },
+                                  {
+                                    "Literal": {
+                                      "Int": 0
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 7
+                            }
+                          }
+                        ]
                       },
                       {
                         "Atomic": [
@@ -357,75 +683,10 @@
                           },
                           {
                             "Reference": {
-                              "UserName": "p"
+                              "UserName": "a"
                             }
                           }
                         ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Literal": {
-                              "Int": 0
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 5
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 6
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Eq": [
-                      {
-                        "clean": false,
-                        "etype": null
                       },
                       {
                         "Atomic": [
@@ -435,7 +696,181 @@
                           },
                           {
                             "Reference": {
-                              "UserName": "p"
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatIneq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 8
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "d"
+                            }
+                          },
+                          {
+                            "Int": 0
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatIneq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 5
+                                }
+                              },
+                              {
+                                "Int": 0
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 9
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatWatchedLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "MachineName": 11
+                              },
+                              {
+                                "Bool": false
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 10
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Or": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatIneq": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "n"
+                                }
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 5
+                                }
+                              },
+                              {
+                                "Int": 0
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 12
                             }
                           }
                         ]
@@ -447,237 +882,64 @@
                             "etype": null
                           },
                           {
-                            "Literal": {
-                              "Int": 0
+                            "Reference": {
+                              "UserName": "a"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "b"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "MinionReifyImply": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "FlatWatchedLiteral": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "MachineName": 14
+                              },
+                              {
+                                "Bool": false
+                              }
+                            ]
+                          },
+                          {
+                            "Reference": {
+                              "MachineName": 13
                             }
                           }
                         ]
                       }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 7
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatIneq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 8
-                    }
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "d"
-                    }
-                  },
-                  {
-                    "Int": 0
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatIneq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
                         }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 5
-                        }
-                      },
-                      {
-                        "Int": 0
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 9
+                      ]
                     }
-                  }
-                ]
-              },
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatWatchedLiteral": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "MachineName": 11
-                      },
-                      {
-                        "Bool": false
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 10
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
-        {
-          "Or": [
-            {
-              "clean": false,
-              "etype": null
-            },
-            [
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatIneq": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "UserName": "n"
-                        }
-                      },
-                      {
-                        "Literal": {
-                          "Int": 5
-                        }
-                      },
-                      {
-                        "Int": 0
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 12
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "a"
-                    }
-                  }
-                ]
-              },
-              {
-                "Atomic": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "Reference": {
-                      "UserName": "b"
-                    }
-                  }
-                ]
-              },
-              {
-                "MinionReifyImply": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  {
-                    "FlatWatchedLiteral": [
-                      {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "MachineName": 14
-                      },
-                      {
-                        "Bool": false
-                      }
-                    ]
-                  },
-                  {
-                    "Reference": {
-                      "MachineName": 13
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -1222,8 +1484,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 20145,
+    "id": 0,
     "next_machine_name": 15,
     "parent": null,
     "table": [
@@ -1232,7 +1495,7 @@
           "UserName": "a"
         },
         {
-          "id": 319,
+          "id": 332,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1248,7 +1511,7 @@
           "UserName": "b"
         },
         {
-          "id": 320,
+          "id": 333,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1264,7 +1527,7 @@
           "UserName": "c"
         },
         {
-          "id": 321,
+          "id": 334,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1280,7 +1543,7 @@
           "UserName": "d"
         },
         {
-          "id": 322,
+          "id": 335,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1296,7 +1559,7 @@
           "UserName": "e"
         },
         {
-          "id": 323,
+          "id": 336,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1312,7 +1575,7 @@
           "UserName": "l"
         },
         {
-          "id": 324,
+          "id": 337,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1337,7 +1600,7 @@
           "UserName": "m"
         },
         {
-          "id": 325,
+          "id": 338,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1362,7 +1625,7 @@
           "UserName": "n"
         },
         {
-          "id": 326,
+          "id": 339,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1387,7 +1650,7 @@
           "UserName": "o"
         },
         {
-          "id": 327,
+          "id": 340,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1412,7 +1675,7 @@
           "UserName": "p"
         },
         {
-          "id": 328,
+          "id": 341,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1437,7 +1700,7 @@
           "UserName": "q"
         },
         {
-          "id": 329,
+          "id": 342,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1462,7 +1725,7 @@
           "UserName": "r"
         },
         {
-          "id": 330,
+          "id": 343,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1487,7 +1750,7 @@
           "UserName": "x"
         },
         {
-          "id": 316,
+          "id": 329,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1503,7 +1766,7 @@
           "UserName": "y"
         },
         {
-          "id": 317,
+          "id": 330,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1519,7 +1782,7 @@
           "UserName": "z"
         },
         {
-          "id": 318,
+          "id": 331,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1535,7 +1798,7 @@
           "MachineName": 0
         },
         {
-          "id": 331,
+          "id": 344,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1551,7 +1814,7 @@
           "MachineName": 1
         },
         {
-          "id": 332,
+          "id": 345,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1567,7 +1830,7 @@
           "MachineName": 2
         },
         {
-          "id": 334,
+          "id": 347,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1583,7 +1846,7 @@
           "MachineName": 3
         },
         {
-          "id": 335,
+          "id": 348,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1599,7 +1862,7 @@
           "MachineName": 4
         },
         {
-          "id": 337,
+          "id": 350,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1615,7 +1878,7 @@
           "MachineName": 5
         },
         {
-          "id": 339,
+          "id": 352,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1631,7 +1894,7 @@
           "MachineName": 6
         },
         {
-          "id": 340,
+          "id": 353,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1647,7 +1910,7 @@
           "MachineName": 7
         },
         {
-          "id": 341,
+          "id": 354,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1663,7 +1926,7 @@
           "MachineName": 8
         },
         {
-          "id": 342,
+          "id": 355,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1679,7 +1942,7 @@
           "MachineName": 9
         },
         {
-          "id": 343,
+          "id": 356,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1695,7 +1958,7 @@
           "MachineName": 10
         },
         {
-          "id": 344,
+          "id": 357,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1711,7 +1974,7 @@
           "MachineName": 11
         },
         {
-          "id": 345,
+          "id": 358,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1727,7 +1990,7 @@
           "MachineName": 12
         },
         {
-          "id": 346,
+          "id": 359,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1743,7 +2006,7 @@
           "MachineName": 13
         },
         {
-          "id": 347,
+          "id": 360,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"
@@ -1759,7 +2022,7 @@
           "MachineName": 14
         },
         {
-          "id": 348,
+          "id": 361,
           "kind": {
             "DecisionVariable": {
               "domain": "BoolDomain"

--- a/conjure_oxide/tests/integration/xyz/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/xyz/input-expected-rule-trace-human.txt
@@ -19,7 +19,7 @@ Sum([a, b, c])
 
 (Sum([a, b, c]) = 4), 
    ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]) 
+and([SumLeq([a, b, c], 4),SumGeq([a, b, c], 4);int(1..)]) 
 
 --
 
@@ -37,6 +37,6 @@ find c: int(1..3)
 
 such that
 
-And([SumLeq([a, b, c], 4), SumGeq([a, b, c], 4)]),
+and([SumLeq([a, b, c], 4),SumGeq([a, b, c], 4);int(1..)]),
 Ineq(b, a, 0)
 

--- a/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/xyz/input.expected-rewrite.serialised.json
@@ -12,68 +12,87 @@
               "clean": false,
               "etype": null
             },
-            [
-              {
-                "FlatSumLeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "a"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "b"
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "UserName": "c"
+                              }
+                            }
+                          ],
+                          {
+                            "Literal": {
+                              "Int": 4
+                            }
+                          }
+                        ]
                       }
-                    },
+                    ],
                     {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
                     }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "FlatSumGeq": [
-                  {
-                    "clean": false,
-                    "etype": null
-                  },
-                  [
-                    {
-                      "Reference": {
-                        "UserName": "a"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "b"
-                      }
-                    },
-                    {
-                      "Reference": {
-                        "UserName": "c"
-                      }
-                    }
-                  ],
-                  {
-                    "Literal": {
-                      "Int": 4
-                    }
-                  }
-                ]
-              }
-            ]
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -100,8 +119,9 @@
       ]
     ]
   },
+  "dominance": null,
   "symbols": {
-    "id": 78,
+    "id": 0,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -110,7 +130,7 @@
           "UserName": "a"
         },
         {
-          "id": 358,
+          "id": 366,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -135,7 +155,7 @@
           "UserName": "b"
         },
         {
-          "id": 359,
+          "id": 367,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -160,7 +180,7 @@
           "UserName": "c"
         },
         {
-          "id": 360,
+          "id": 368,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/conjure_oxide/tests/parser_tests/mod.rs
+++ b/conjure_oxide/tests/parser_tests/mod.rs
@@ -1,6 +1,7 @@
 use conjure_core::{
     ast::{Atom, Expression},
     context::Context,
+    matrix_expr,
 };
 use conjure_oxide::{utils::essence_parser::parse_essence_file_native, Metadata};
 use pretty_assertions::assert_eq;
@@ -17,10 +18,10 @@ fn test_parse_dominance() {
         Metadata::new(),
         Box::new(Expression::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::And(
                     Metadata::new(),
-                    vec![
+                    Box::new(matrix_expr![
                         Expression::Leq(
                             Metadata::new(),
                             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("cost"))),
@@ -46,11 +47,11 @@ fn test_parse_dominance() {
                                 )),
                             )),
                         ),
-                    ],
+                    ]),
                 ),
                 Expression::Or(
                     Metadata::new(),
-                    vec![
+                    Box::new(matrix_expr![
                         Expression::Lt(
                             Metadata::new(),
                             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("cost"))),
@@ -76,9 +77,9 @@ fn test_parse_dominance() {
                                 )),
                             )),
                         ),
-                    ],
+                    ]),
                 ),
-            ],
+            ]),
         )),
     ));
 

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::process::exit;
 use std::rc::Rc;
 
+use conjure_core::matrix_expr;
 use conjure_core::rule_engine::rewrite_naive;
 use conjure_core::solver::SolverFamily;
 use conjure_core::{rule_engine::get_all_rules, rules::eval_constant};
@@ -389,17 +390,17 @@ fn remove_trivial_and_or() {
 
     let mut expr_and = Expression::And(
         Metadata::new(),
-        vec![Expression::Atomic(
+        Box::new(matrix_expr![Expression::Atomic(
             Metadata::new(),
             Atom::Literal(Literal::Bool(true)),
-        )],
+        )]),
     );
     let mut expr_or = Expression::Or(
         Metadata::new(),
-        vec![Expression::Atomic(
+        Box::new(matrix_expr![Expression::Atomic(
             Metadata::new(),
             Atom::Literal(Literal::Bool(false)),
-        )],
+        )]),
     );
 
     expr_and = remove_trivial_and
@@ -429,7 +430,7 @@ fn rule_distribute_not_over_and() {
         Metadata::new(),
         Box::new(Expression::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::Atomic(
                     Metadata::new(),
                     Atom::Reference(Name::UserName(String::from("a"))),
@@ -438,7 +439,7 @@ fn rule_distribute_not_over_and() {
                     Metadata::new(),
                     Atom::Reference(Name::UserName(String::from("b"))),
                 ),
-            ],
+            ]),
         )),
     );
 
@@ -451,7 +452,7 @@ fn rule_distribute_not_over_and() {
         expr,
         Expression::Or(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::Not(
                     Metadata::new(),
                     Box::new(Expression::Atomic(
@@ -466,7 +467,7 @@ fn rule_distribute_not_over_and() {
                         Atom::Reference(Name::UserName(String::from("b")))
                     ))
                 ),
-            ]
+            ])
         )
     );
 }
@@ -479,7 +480,7 @@ fn rule_distribute_not_over_or() {
         Metadata::new(),
         Box::new(Expression::Or(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::Atomic(
                     Metadata::new(),
                     Atom::Reference(Name::UserName(String::from("a"))),
@@ -488,7 +489,7 @@ fn rule_distribute_not_over_or() {
                     Metadata::new(),
                     Atom::Reference(Name::UserName(String::from("b"))),
                 ),
-            ],
+            ]),
         )),
     );
 
@@ -501,7 +502,7 @@ fn rule_distribute_not_over_or() {
         expr,
         Expression::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::Not(
                     Metadata::new(),
                     Box::new(Expression::Atomic(
@@ -516,7 +517,7 @@ fn rule_distribute_not_over_or() {
                         Atom::Reference(Name::UserName(String::from("b")))
                     ))
                 ),
-            ]
+            ])
         )
     );
 }
@@ -561,16 +562,16 @@ fn rule_distribute_or_over_and() {
 
     let expr = Expression::Or(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Expression::And(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(1))),
                     Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(2))),
-                ],
+                ]),
             ),
             Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(3))),
-        ],
+        ]),
     );
 
     let red = distribute_or_over_and
@@ -581,22 +582,22 @@ fn rule_distribute_or_over_and() {
         red.new_expression,
         Expression::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expression::Or(
                     Metadata::new(),
-                    vec![
+                    Box::new(matrix_expr![
                         Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(3))),
                         Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(1))),
-                    ]
+                    ])
                 ),
                 Expression::Or(
                     Metadata::new(),
-                    vec![
+                    Box::new(matrix_expr![
                         Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(3))),
                         Expression::Atomic(Metadata::new(), Atom::Reference(Name::MachineName(2))),
-                    ]
+                    ])
                 ),
-            ]
+            ])
         ),
     );
 }
@@ -633,7 +634,7 @@ fn rewrite_solve_xyz() {
     // Construct nested expression
     let nested_expr = Expression::And(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Expression::Eq(
                 Metadata::new(),
                 Box::new(Expression::Sum(
@@ -654,7 +655,7 @@ fn rewrite_solve_xyz() {
                 Box::new(Expression::Atomic(Metadata::new(), variable_a.clone())),
                 Box::new(Expression::Atomic(Metadata::new(), variable_b.clone())),
             ),
-        ],
+        ]),
     );
 
     let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &["Constant"]) {
@@ -798,10 +799,10 @@ fn eval_const_bool() {
 fn eval_const_and() {
     let expr = Expression::And(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Bool(true))),
             Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Bool(false))),
-        ],
+        ]),
     );
     let result = eval_constant(&expr);
     assert_eq!(result, Some(Literal::Bool(false)));
@@ -825,13 +826,13 @@ fn eval_const_nested_ref() {
             Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Int(1))),
             Expression::And(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Bool(true))),
                     Expression::Atomic(
                         Metadata::new(),
                         Atom::Reference(Name::UserName(String::from("a"))),
                     ),
-                ],
+                ]),
             ),
         ],
     );
@@ -907,7 +908,7 @@ fn eval_const_sum_mixed() {
 fn eval_const_sum_xyz() {
     let expr = Expression::And(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Expression::Eq(
                 Metadata::new(),
                 Box::new(Expression::Sum(
@@ -925,7 +926,7 @@ fn eval_const_sum_xyz() {
                             Metadata::new(),
                             Atom::Reference(Name::UserName(String::from("z"))),
                         ),
-                    ],
+                    ]
                 )),
                 Box::new(Expression::Atomic(
                     Metadata::new(),
@@ -943,7 +944,7 @@ fn eval_const_sum_xyz() {
                     Atom::Reference(Name::UserName(String::from("y"))),
                 )),
             ),
-        ],
+        ]),
     );
     let result = eval_constant(&expr);
     assert_eq!(result, None);
@@ -953,10 +954,10 @@ fn eval_const_sum_xyz() {
 fn eval_const_or() {
     let expr = Expression::Or(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Bool(false))),
             Expression::Atomic(Metadata::new(), Atom::Literal(Literal::Bool(false))),
-        ],
+        ]),
     );
     let result = eval_constant(&expr);
     assert_eq!(result, Some(Literal::Bool(false)));

--- a/conjure_oxide/tests/solver_adaptor_tests/sat.rs
+++ b/conjure_oxide/tests/solver_adaptor_tests/sat.rs
@@ -1,3 +1,4 @@
+use conjure_core::matrix_expr;
 use conjure_oxide::ast::{
     Atom::Reference, Declaration, Domain::BoolDomain, Domain::IntDomain, Expression::*, Name, Range,
 };
@@ -51,13 +52,13 @@ fn test_single_not() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![Or(
+            Box::new(matrix_expr![Or(
                 Metadata::new(),
-                vec![Not(
+                Box::new(matrix_expr![Not(
                     Metadata::new(),
                     Box::from(Atomic(Metadata::new(), Reference(x.clone())))
-                )]
-            )]
+                )])
+            )])
         )
     )
 }
@@ -76,10 +77,10 @@ fn test_single_or() {
     submodel.add_symbol(Declaration::new_var(y.clone(), BoolDomain));
     submodel.add_constraint(Or(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Atomic(Metadata::new(), Reference(x.clone())),
             Atomic(Metadata::new(), Reference(y.clone())),
-        ],
+        ]),
     ));
 
     let cnf: CNFModel = CNFModel::from_conjure(model).unwrap();
@@ -92,13 +93,13 @@ fn test_single_or() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![Or(
+            Box::new(matrix_expr![Or(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Atomic(Metadata::new(), Reference(x.clone())),
                     Atomic(Metadata::new(), Reference(y.clone())),
-                ],
-            )]
+                ]),
+            )])
         )
     )
 }
@@ -117,13 +118,13 @@ fn test_or_not() {
     submodel.add_symbol(Declaration::new_var(y.clone(), BoolDomain));
     submodel.add_constraint(Or(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Atomic(Metadata::new(), Reference(x.clone())),
             Not(
                 Metadata::new(),
                 Box::from(Atomic(Metadata::new(), Reference(y.clone()))),
             ),
-        ],
+        ]),
     ));
 
     let cnf: CNFModel = CNFModel::from_conjure(model).unwrap();
@@ -136,16 +137,16 @@ fn test_or_not() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![Or(
+            Box::new(matrix_expr![Or(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Atomic(Metadata::new(), Reference(x.clone())),
                     Not(
                         Metadata::new(),
                         Box::from(Atomic(Metadata::new(), Reference(y.clone())))
                     ),
-                ]
-            )]
+                ])
+            )])
         )
     )
 }
@@ -175,16 +176,16 @@ fn test_multiple() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Or(
                     Metadata::new(),
-                    vec![Atomic(Metadata::new(), Reference(x.clone()))]
+                    Box::new(matrix_expr![Atomic(Metadata::new(), Reference(x.clone()))])
                 ),
                 Or(
                     Metadata::new(),
-                    vec![Atomic(Metadata::new(), Reference(y.clone()))]
+                    Box::new(matrix_expr![Atomic(Metadata::new(), Reference(y.clone()))])
                 )
-            ]
+            ])
         )
     )
 }
@@ -203,10 +204,10 @@ fn test_and() {
     submodel.add_symbol(Declaration::new_var(y.clone(), BoolDomain));
     submodel.add_constraint(And(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Atomic(Metadata::new(), Reference(x.clone())),
             Atomic(Metadata::new(), Reference(y.clone())),
-        ],
+        ]),
     ));
 
     let cnf: CNFModel = CNFModel::from_conjure(model).unwrap();
@@ -219,16 +220,16 @@ fn test_and() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Or(
                     Metadata::new(),
-                    vec![Atomic(Metadata::new(), Reference(x.clone())),]
+                    Box::new(matrix_expr![Atomic(Metadata::new(), Reference(x.clone())),])
                 ),
                 Or(
                     Metadata::new(),
-                    vec![Atomic(Metadata::new(), Reference(y.clone())),]
+                    Box::new(matrix_expr![Atomic(Metadata::new(), Reference(y.clone())),])
                 )
-            ]
+            ])
         )
     )
 }
@@ -250,16 +251,16 @@ fn test_nested_ors() {
 
     submodel.add_constraint(Or(
         Metadata::new(),
-        vec![
+        Box::new(matrix_expr![
             Atomic(Metadata::new(), Reference(x.clone())),
             Or(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Atomic(Metadata::new(), Reference(y.clone())),
                     Atomic(Metadata::new(), Reference(z.clone())),
-                ],
+                ]),
             ),
-        ],
+        ]),
     ));
 
     let cnf: CNFModel = CNFModel::from_conjure(model).unwrap();
@@ -273,14 +274,14 @@ fn test_nested_ors() {
         cnf.as_expression().unwrap(),
         And(
             Metadata::new(),
-            vec![Or(
+            Box::new(matrix_expr![Or(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Atomic(Metadata::new(), Reference(x.clone())),
                     Atomic(Metadata::new(), Reference(y.clone())),
                     Atomic(Metadata::new(), Reference(z.clone())),
-                ]
-            )]
+                ])
+            )])
         )
     )
 }

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -14,6 +14,12 @@ where
 {
     Single(A),
     Bounded(A, A),
+
+    /// int(i..)
+    UnboundedR(A),
+
+    /// int(..i)
+    UnboundedL(A),
 }
 
 impl<A: Ord + Display> Display for Range<A> {
@@ -21,6 +27,8 @@ impl<A: Ord + Display> Display for Range<A> {
         match self {
             Range::Single(i) => write!(f, "{i}"),
             Range::Bounded(i, j) => write!(f, "{i}..{j}"),
+            Range::UnboundedR(i) => write!(f, "{i}.."),
+            Range::UnboundedL(i) => write!(f, "..{i}"),
         }
     }
 }
@@ -44,17 +52,22 @@ pub enum SetAttr {
     MinMaxSize(i32, i32),
 }
 impl Domain {
-    /// Return a list of all possible i32 values in the domain if it is an IntDomain.
+    /// Return a list of all possible i32 values in the domain if it is an IntDomain and is
+    /// bounded.
     pub fn values_i32(&self) -> Option<Vec<i32>> {
         match self {
             Domain::IntDomain(ranges) => Some(
                 ranges
                     .iter()
-                    .flat_map(|r| match r {
-                        Range::Single(i) => vec![*i],
-                        Range::Bounded(i, j) => (*i..=*j).collect(),
+                    .map(|r| match r {
+                        Range::Single(i) => Some(vec![*i]),
+                        Range::Bounded(i, j) => Some((*i..=*j).collect()),
+                        Range::UnboundedR(_) => None,
+                        Range::UnboundedL(_) => None,
                     })
-                    .collect(),
+                    .while_some()
+                    .flatten()
+                    .collect_vec(),
             ),
             _ => None,
         }
@@ -88,18 +101,12 @@ impl Display for Domain {
                 write!(f, "bool")
             }
             Domain::IntDomain(vec) => {
-                let mut domain_ranges: Vec<String> = vec![];
-                for range in vec {
-                    domain_ranges.push(match range {
-                        Range::Single(a) => a.to_string(),
-                        Range::Bounded(a, b) => format!("{}..{}", a, b),
-                    });
-                }
+                let domain_ranges: String = vec.iter().map(|x| format!("{x}")).join(",");
 
                 if domain_ranges.is_empty() {
                     write!(f, "int")
                 } else {
-                    write!(f, "int({})", domain_ranges.join(","))
+                    write!(f, "int({domain_ranges})")
                 }
             }
             Domain::DomainReference(name) => write!(f, "{}", name),

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -70,26 +70,33 @@ pub enum Expression {
     #[compatible(JsonInput)]
     Abs(Metadata, Box<Expression>),
 
+    /// `a + b + c + ...`
     #[compatible(JsonInput)]
     Sum(Metadata, Vec<Expression>),
 
+    /// `a * b * c * ...`
     #[compatible(JsonInput)]
     Product(Metadata, Vec<Expression>),
 
+    /// `min(<vec_expr>)`
     #[compatible(JsonInput)]
-    Min(Metadata, Vec<Expression>),
+    Min(Metadata, Box<Expression>),
 
+    /// `max(<vec_expr>)`
     #[compatible(JsonInput)]
-    Max(Metadata, Vec<Expression>),
+    Max(Metadata, Box<Expression>),
 
+    /// `not(a)`
     #[compatible(JsonInput, SAT)]
     Not(Metadata, Box<Expression>),
 
+    /// `or(<vec_expr>)`
     #[compatible(JsonInput, SAT)]
-    Or(Metadata, Vec<Expression>),
+    Or(Metadata, Box<Expression>),
 
+    /// `and(<vec_expr>)`
     #[compatible(JsonInput, SAT)]
-    And(Metadata, Vec<Expression>),
+    And(Metadata, Box<Expression>),
 
     /// Ensures that `a->b` (material implication).
     #[compatible(JsonInput)]
@@ -140,8 +147,9 @@ pub enum Expression {
     /// `UnsafePow` after preventing undefinedness
     SafePow(Metadata, Box<Expression>, Box<Expression>),
 
+    /// `allDiff(<vec_expr>)`
     #[compatible(JsonInput)]
-    AllDiff(Metadata, Vec<Expression>),
+    AllDiff(Metadata, Box<Expression>),
 
     /// Binary subtraction operator
     ///
@@ -323,8 +331,17 @@ fn expr_vec_to_domain_i32(
         .reduce(|a, b| a.and_then(|x| b.and_then(|y| x.apply_i32(op, &y))))
         .flatten()
 }
+fn expr_vec_lit_to_domain_i32(
+    e: &Expression,
+    op: fn(i32, i32) -> Option<i32>,
+    vars: &SymbolTable,
+) -> Option<Domain> {
+    let exprs = e.clone().unwrap_list()?;
+    expr_vec_to_domain_i32(&exprs, op, vars)
+}
 
-fn range_vec_bounds_i32(ranges: &Vec<Range<i32>>) -> (i32, i32) {
+// Returns none if unbounded
+fn range_vec_bounds_i32(ranges: &Vec<Range<i32>>) -> Option<(i32, i32)> {
     let mut min = i32::MAX;
     let mut max = i32::MIN;
     for r in ranges {
@@ -345,9 +362,10 @@ fn range_vec_bounds_i32(ranges: &Vec<Range<i32>>) -> (i32, i32) {
                     max = *j;
                 }
             }
+            Range::UnboundedR(_) | Range::UnboundedL(_) => return None,
         }
     }
-    (min, max)
+    Some((min, max))
 }
 
 impl Expression {
@@ -371,11 +389,11 @@ impl Expression {
             Expression::Product(_, exprs) => {
                 expr_vec_to_domain_i32(exprs, |x, y| Some(x * y), syms)
             }
-            Expression::Min(_, exprs) => {
-                expr_vec_to_domain_i32(exprs, |x, y| Some(if x < y { x } else { y }), syms)
+            Expression::Min(_, e) => {
+                expr_vec_lit_to_domain_i32(e, |x, y| Some(if x < y { x } else { y }), syms)
             }
-            Expression::Max(_, exprs) => {
-                expr_vec_to_domain_i32(exprs, |x, y| Some(if x > y { x } else { y }), syms)
+            Expression::Max(_, e) => {
+                expr_vec_lit_to_domain_i32(e, |x, y| Some(if x > y { x } else { y }), syms)
             }
             Expression::UnsafeDiv(_, a, b) => a.domain_of(syms)?.apply_i32(
                 // rust integer division is truncating; however, we want to always round down,
@@ -480,6 +498,8 @@ impl Expression {
                     *range = match range {
                         Range::Single(x) => Range::Single(-*x),
                         Range::Bounded(x, y) => Range::Bounded(-*y, -*x),
+                        Range::UnboundedR(i) => Range::UnboundedL(-*i),
+                        Range::UnboundedL(i) => Range::UnboundedR(-*i),
                     };
                 }
 
@@ -502,7 +522,7 @@ impl Expression {
             // TODO: (flm8) the Minion bindings currently only support single ranges for domains, so we use the min/max bounds
             // Once they support a full domain as we define it, we can remove this conversion
             Some(Domain::IntDomain(ranges)) if ranges.len() > 1 => {
-                let (min, max) = range_vec_bounds_i32(&ranges);
+                let (min, max) = range_vec_bounds_i32(&ranges)?;
                 Some(Domain::IntDomain(vec![Range::Bounded(min, max)]))
             }
             _ => ret,
@@ -632,6 +652,57 @@ impl Expression {
             false
         }
     }
+
+    /// If the expression is a list, returns the inner expressions.
+    ///
+    /// A list is any a matrix with the domain `int(1..)`. This includes matrix literals without
+    /// any explicitly specified domain.
+    pub fn unwrap_list(self) -> Option<Vec<Expression>> {
+        match self {
+            Expression::AbstractLiteral(_, matrix @ AbstractLiteral::Matrix(_, _)) => {
+                matrix.unwrap_list().cloned()
+            }
+            Expression::Atomic(
+                _,
+                Atom::Literal(Literal::AbstractLiteral(matrix @ AbstractLiteral::Matrix(_, _))),
+            ) => matrix.unwrap_list().map(|elems| {
+                elems
+                    .clone()
+                    .into_iter()
+                    .map(|x: Literal| Expression::Atomic(Metadata::new(), Atom::Literal(x)))
+                    .collect_vec()
+            }),
+            _ => None,
+        }
+    }
+
+    /// If the expression is a matrix, gets it elements and index domain.
+    ///
+    /// **Consider using the safer [`Expression::unwrap_list`] instead.**
+    ///
+    /// It is generally undefined to edit the length of a matrix unless it is a list (as defined by
+    /// [`Expression::unwrap_list`]). Users of this function should ensure that, if the matrix is
+    /// reconstructed, the index domain and the number of elements in the matrix remain the same.
+    pub fn unwrap_matrix_unchecked(self) -> Option<(Vec<Expression>, Domain)> {
+        match self {
+            Expression::AbstractLiteral(_, AbstractLiteral::Matrix(elems, domain)) => {
+                Some((elems.clone(), domain))
+            }
+            Expression::Atomic(
+                _,
+                Atom::Literal(Literal::AbstractLiteral(AbstractLiteral::Matrix(elems, domain))),
+            ) => Some((
+                elems
+                    .clone()
+                    .into_iter()
+                    .map(|x: Literal| Expression::Atomic(Metadata::new(), Atom::Literal(x)))
+                    .collect_vec(),
+                domain,
+            )),
+
+            _ => None,
+        }
+    }
 }
 
 impl From<i32> for Expression {
@@ -684,20 +755,20 @@ impl Display for Expression {
             Expression::Product(_, expressions) => {
                 write!(f, "Product({})", pretty_vec(expressions))
             }
-            Expression::Min(_, expressions) => {
-                write!(f, "Min({})", pretty_vec(expressions))
+            Expression::Min(_, e) => {
+                write!(f, "min({e})")
             }
-            Expression::Max(_, expressions) => {
-                write!(f, "Max({})", pretty_vec(expressions))
+            Expression::Max(_, e) => {
+                write!(f, "max({e})")
             }
             Expression::Not(_, expr_box) => {
                 write!(f, "Not({})", expr_box.clone())
             }
-            Expression::Or(_, expressions) => {
-                write!(f, "Or({})", pretty_vec(expressions))
+            Expression::Or(_, e) => {
+                write!(f, "or({e})")
             }
-            Expression::And(_, expressions) => {
-                write!(f, "And({})", pretty_vec(expressions))
+            Expression::And(_, e) => {
+                write!(f, "and({e})")
             }
             Expression::Imply(_, box1, box2) => {
                 write!(f, "({}) -> ({})", box1, box2)
@@ -733,8 +804,8 @@ impl Display for Expression {
                 box2.clone(),
                 box3.clone()
             ),
-            Expression::AllDiff(_, expressions) => {
-                write!(f, "AllDiff({})", pretty_vec(expressions))
+            Expression::AllDiff(_, e) => {
+                write!(f, "allDiff({e})")
             }
             Expression::Bubble(_, box1, box2) => {
                 write!(f, "{{{} @ {}}}", box1.clone(), box2.clone())

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -27,3 +27,131 @@ pub use submodel::SubModel;
 pub use symbol_table::SymbolTable;
 pub use types::*;
 pub use variables::DecisionVariable;
+
+/// Creates a new matrix [`AbstractLiteral`] optionally with some index domain.
+///
+///  - `matrix![a,b,c]`
+///  - `matrix![a,b,c;my_domain]`
+///
+/// To create one from a (Rust) vector, use [`into_matrix!`].
+#[macro_export]
+macro_rules! matrix {
+    // cases copied from the std vec! macro
+    () => (
+        $crate::into_matrix![]
+    );
+
+    (;$domain:expr) => (
+        $crate::into_matrix![;$domain]
+    );
+
+    ($x:expr) => (
+        $crate::into_matrix![std::vec![$x]]
+    );
+
+    ($x:expr;$domain:expr) => (
+        $crate::into_matrix![std::vec![$x];$domain]
+    );
+
+    ($($x:expr),*) => (
+        $crate::into_matrix![std::vec![$($x),*]]
+    );
+
+    ($($x:expr),*;$domain:expr) => (
+        $crate::into_matrix![std::vec![$($x),*];$domain]
+    );
+
+    ($($x:expr,)*) => (
+        $crate::into_matrix![std::vec![$($x),*]]
+    );
+
+    ($($x:expr,)*;$domain:expr) => (
+        $crate::into_matrix![std::vec![$($x),*];domain]
+    )
+}
+
+/// Creates a new matrix [`AbstractLiteral`] from some [`Vec`], optionally with some index domain.
+///
+///  - `matrix![my_vec]`
+///  - `matrix![my_vec;my_domain]`
+///
+/// To create one from a list of elements, use [`matrix!`].
+#[macro_export]
+macro_rules! into_matrix {
+    () => (
+        $crate::into_matrix![std::vec::Vec::new()]
+    );
+
+    (;$domain:expr) => (
+        $crate::into_matrix![std::vec::Vec::new();$domain]
+    );
+    ($x:expr) => (
+        $crate::ast::AbstractLiteral::matrix_implied_indices($x)
+    );
+    ($x:expr;$domain:expr) => (
+        $crate::ast::AbstractLiteral::Matrix($x,$domain)
+    );
+}
+
+/// Creates a new matrix as an [`Expression`], optionally with some index domain.
+///
+/// For usage details, see [`matrix!`].
+///
+/// To create a matrix expression from a [`Vec`], use [`into_matrix_expr!`].
+#[macro_export]
+macro_rules! matrix_expr {
+    () => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![])
+    );
+
+    (;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![;$domain])
+    );
+
+
+    ($x:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![$x])
+    );
+    ($x:expr;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![;$domain])
+    );
+
+    ($($x:expr),+) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![$($x),+])
+    );
+
+    ($($x:expr),+;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![$($x),+;$domain])
+    );
+
+    ($($x:expr,)+) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![$($x),+])
+    );
+
+    ($($x:expr,)+;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::matrix![$($x),+;$domain])
+    )
+}
+
+/// Creates a new matrix as an [`Expression`] from a (Rust) vector, optionally with some index
+/// domain.
+///
+/// For usage details, see [`into_matrix!`].
+///
+/// To create a matrix expression from a list of elements, use [`matrix_expr!`].
+#[macro_export]
+macro_rules! into_matrix_expr {
+    () => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::into_matrix![])
+    );
+
+    (;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::into_matrix![;$domain])
+    );
+    ($x:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::into_matrix![$x])
+    );
+    ($x:expr;$domain:expr) => (
+        $crate::ast::Expression::AbstractLiteral($crate::metadata::Metadata::new(),$crate::into_matrix![$x;$domain])
+    );
+}

--- a/crates/conjure_core/src/parse/parse_model.rs
+++ b/crates/conjure_core/src/parse/parse_model.rs
@@ -4,6 +4,9 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
+use serde_json::Value;
+use serde_json::Value as JsonValue;
+
 use crate::ast::Declaration;
 use crate::ast::{
     AbstractLiteral, Atom, Domain, Expression, Literal, Name, Range, SetAttr, SymbolTable,
@@ -11,10 +14,7 @@ use crate::ast::{
 use crate::context::Context;
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
-use crate::Model;
-use crate::{bug, error, throw_error};
-use serde_json::Value;
-use serde_json::Value as JsonValue;
+use crate::{bug, error, into_matrix_expr, throw_error, Model};
 macro_rules! parser_trace {
     ($($arg:tt)+) => {
         log::trace!(target:"jsonparser",$($arg)+)
@@ -413,19 +413,6 @@ fn parse_expression(obj: &JsonValue) -> Option<Expression> {
             "MkOpTwoBars",
             Box::new(Expression::Abs) as Box<dyn Fn(_, _) -> _>,
         ),
-    ]
-    .into_iter()
-    .collect();
-
-    let vec_operators: HashMap<&str, VecOp> = [
-        (
-            "MkOpSum",
-            Box::new(Expression::Sum) as Box<dyn Fn(_, _) -> _>,
-        ),
-        (
-            "MkOpProduct",
-            Box::new(Expression::Product) as Box<dyn Fn(_, _) -> _>,
-        ),
         (
             "MkOpAnd",
             Box::new(Expression::And) as Box<dyn Fn(_, _) -> _>,
@@ -447,20 +434,34 @@ fn parse_expression(obj: &JsonValue) -> Option<Expression> {
     .into_iter()
     .collect();
 
+    let vec_operators: HashMap<&str, VecOp> = [
+        (
+            "MkOpSum",
+            Box::new(Expression::Sum) as Box<dyn Fn(_, _) -> _>,
+        ),
+        (
+            "MkOpProduct",
+            Box::new(Expression::Product) as Box<dyn Fn(_, _) -> _>,
+        ),
+    ]
+    .into_iter()
+    .collect();
+
     let mut binary_operator_names = binary_operators.iter().map(|x| x.0);
     let mut unary_operator_names = unary_operators.iter().map(|x| x.0);
     let mut vec_operator_names = vec_operators.iter().map(|x| x.0);
 
+    #[allow(clippy::unwrap_used)]
     match obj {
         Value::Object(op) if op.contains_key("Op") => match &op["Op"] {
             Value::Object(bin_op) if binary_operator_names.any(|key| bin_op.contains_key(*key)) => {
-                parse_bin_op(bin_op, binary_operators)
+                Some(parse_bin_op(bin_op, binary_operators).unwrap())
             }
             Value::Object(un_op) if unary_operator_names.any(|key| un_op.contains_key(*key)) => {
-                parse_unary_op(un_op, unary_operators)
+                Some(parse_unary_op(un_op, unary_operators).unwrap())
             }
             Value::Object(vec_op) if vec_operator_names.any(|key| vec_op.contains_key(*key)) => {
-                parse_vec_op(vec_op, vec_operators)
+                Some(parse_vec_op(vec_op, vec_operators).unwrap())
             }
 
             Value::Object(op)
@@ -477,11 +478,25 @@ fn parse_expression(obj: &JsonValue) -> Option<Expression> {
                 Atom::Reference(Name::UserName(name.to_string())),
             ))
         }
+        Value::Object(abslit) if abslit.contains_key("AbstractLiteral") => {
+            Some(parse_abstract_matrix_as_expr(obj).unwrap())
+        }
 
-        Value::Object(constant) if constant.contains_key("Constant") => parse_constant(constant),
-        Value::Object(constant) if constant.contains_key("ConstantInt") => parse_constant(constant),
-        Value::Object(constant) if constant.contains_key("ConstantBool") => {
+        Value::Object(constant) if constant.contains_key("Constant") => Some(
             parse_constant(constant)
+                .or_else(|| parse_abstract_matrix_as_expr(obj))
+                .unwrap(),
+        ),
+
+        Value::Object(constant) if constant.contains_key("ConstantAbstract") => {
+            Some(parse_abstract_matrix_as_expr(obj).unwrap())
+        }
+
+        Value::Object(constant) if constant.contains_key("ConstantInt") => {
+            Some(parse_constant(constant).unwrap())
+        }
+        Value::Object(constant) if constant.contains_key("ConstantBool") => {
+            Some(parse_constant(constant).unwrap())
         }
         _ => None,
     }
@@ -642,6 +657,70 @@ fn parse_vec_op(
     } else {
         parser_debug!("... success!");
         Some(constructor(Metadata::new(), valid_args))
+    }
+}
+
+// Takes in { AbstractLiteral: .... }
+fn parse_abstract_matrix_as_expr(value: &serde_json::Value) -> Option<Expression> {
+    parser_trace!("trying to parse an abstract literal matrix");
+    let (values, domain_name, domain_value) =
+        if let Some(abs_lit_matrix) = value.pointer("/AbstractLiteral/AbsLitMatrix") {
+            parser_trace!(".. found JSON pointer /AbstractLiteral/AbstractLitMatrix");
+            let (domain_name, domain_value) =
+                abs_lit_matrix.pointer("/0")?.as_object()?.iter().next()?;
+            let values = abs_lit_matrix.pointer("/1")?;
+
+            Some((values, domain_name, domain_value))
+        }
+        // the input of this expression is constant - e.g. or([]), or([false]), min([2]), etc.
+        else if let Some(const_abs_lit_matrix) =
+            value.pointer("/Constant/ConstantAbstract/AbsLitMatrix")
+        {
+            parser_trace!(".. found JSON pointer /Constant/ConstantAbstract/AbsLitMatrix");
+            let (domain_name, domain_value) = const_abs_lit_matrix
+                .pointer("/0")?
+                .as_object()?
+                .iter()
+                .next()?;
+            let values = const_abs_lit_matrix.pointer("/1")?;
+
+            Some((values, domain_name, domain_value))
+        } else if let Some(const_abs_lit_matrix) = value.pointer("/ConstantAbstract/AbsLitMatrix") {
+            parser_trace!(".. found JSON pointer /ConstantAbstract/AbsLitMatrix");
+            let (domain_name, domain_value) = const_abs_lit_matrix
+                .pointer("/0")?
+                .as_object()?
+                .iter()
+                .next()?;
+            let values = const_abs_lit_matrix.pointer("/1")?;
+            Some((values, domain_name, domain_value))
+        } else {
+            None
+        }?;
+
+    parser_trace!(".. found in domain and values in JSON:");
+    parser_trace!(".. .. index domain name {domain_name}");
+    parser_trace!(".. .. values {value}");
+
+    let args_parsed = values.as_array().map(|x| {
+        x.iter()
+            .map(parse_expression)
+            .map(|x| x.expect("invalid subexpression"))
+            .collect::<Vec<Expression>>()
+    })?;
+    parser_trace!(
+        "... successfully parsed values as expressions: {}, ... ",
+        args_parsed[0]
+    );
+    match parse_domain(domain_name, domain_value) {
+        Ok(domain) => {
+            parser_trace!("... sucessfully parsed domain as {domain}");
+            Some(into_matrix_expr![args_parsed;domain])
+        }
+        Err(_) => {
+            parser_trace!("... failed to parse domain, creating a matrix without one.");
+            Some(into_matrix_expr![args_parsed])
+        }
     }
 }
 

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -139,8 +139,6 @@ fn try_rewrite_model(
 
             // Apply new symbols and top level
             result.reduction.clone().apply(submodel);
-
-            println!("{}", &submodel);
         }
     }
 

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -3,7 +3,8 @@ use std::rc::Rc;
 use conjure_core::ast::{Atom, Expression as Expr, Literal as Lit, SymbolTable};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
+    register_rule, register_rule_set, ApplicationError, ApplicationError::RuleNotApplicable,
+    ApplicationResult, Reduction,
 };
 use uniplate::Uniplate;
 
@@ -12,6 +13,7 @@ use Expr::*;
 use Lit::Bool;
 
 use crate::ast::Declaration;
+use crate::{into_matrix_expr, matrix_expr};
 
 register_rule_set!("Base", ());
 
@@ -46,6 +48,9 @@ fn remove_empty_expression(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
             | MinionReify(_, _, _)
             | MinionReifyImply(_, _, _)
             | FlatAbsEq(_, _, _)
+            | Min(_, _)
+            | Max(_, _)
+            | AllDiff(_, _)
     ) {
         return Err(ApplicationError::RuleNotApplicable);
     }
@@ -56,7 +61,7 @@ fn remove_empty_expression(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     let new_expr = match expr {
         Or(_, _) => Atomic(Metadata::new(), Literal(Bool(false))),
-        _ => And(Metadata::new(), vec![]), // TODO: (yb33) Change it to a simple vector after we refactor our model,
+        _ => And(Metadata::new(), Box::new(matrix_expr![])),
     };
 
     Ok(Reduction::pure(new_expr))
@@ -70,40 +75,48 @@ fn remove_empty_expression(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
  */
 #[register_rule(("Base", 6000))]
 fn min_to_var(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
-    match expr {
-        Min(_, exprs) => {
-            let mut symbols = symbols.clone();
-            let new_name = symbols.gensym();
+    let Expr::Min(_, inside_min_expr) = expr else {
+        return Err(RuleNotApplicable);
+    };
 
-            let mut new_top = Vec::new(); // the new variable must be less than or equal to all the other variables
-            let mut disjunction = Vec::new(); // the new variable must be equal to one of the variables
-            for e in exprs {
-                new_top.push(Leq(
-                    Metadata::new(),
-                    Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
-                    Box::new(e.clone()),
-                ));
-                disjunction.push(Eq(
-                    Metadata::new(),
-                    Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
-                    Box::new(e.clone()),
-                ));
-            }
-            new_top.push(Or(Metadata::new(), disjunction));
+    // let matrix expressions / comprehensions be unrolled first before applying this rule.
+    let Some(exprs) = inside_min_expr.as_ref().clone().unwrap_list() else {
+        return Err(RuleNotApplicable);
+    };
 
-            let domain = expr
-                .domain_of(&symbols)
-                .ok_or(ApplicationError::DomainError)?;
-            symbols.insert(Rc::new(Declaration::new_var(new_name.clone(), domain)));
+    let mut symbols = symbols.clone();
+    let new_name = symbols.gensym();
 
-            Ok(Reduction::new(
-                Atomic(Metadata::new(), Reference(new_name)),
-                new_top,
-                symbols,
-            ))
-        }
-        _ => Err(ApplicationError::RuleNotApplicable),
+    let mut new_top = Vec::new(); // the new variable must be less than or equal to all the other variables
+    let mut disjunction = Vec::new(); // the new variable must be equal to one of the variables
+    for e in exprs {
+        new_top.push(Leq(
+            Metadata::new(),
+            Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
+            Box::new(e.clone()),
+        ));
+        disjunction.push(Eq(
+            Metadata::new(),
+            Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
+            Box::new(e.clone()),
+        ));
     }
+    // TODO: deal with explicit index domains
+    new_top.push(Or(
+        Metadata::new(),
+        Box::new(into_matrix_expr![disjunction]),
+    ));
+
+    let domain = expr
+        .domain_of(&symbols)
+        .ok_or(ApplicationError::DomainError)?;
+    symbols.insert(Rc::new(Declaration::new_var(new_name.clone(), domain)));
+
+    Ok(Reduction::new(
+        Atomic(Metadata::new(), Reference(new_name)),
+        new_top,
+        symbols,
+    ))
 }
 
 /**
@@ -114,38 +127,45 @@ fn min_to_var(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
  */
 #[register_rule(("Base", 6000))]
 fn max_to_var(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
-    match expr {
-        Max(_, exprs) => {
-            let mut symbols = symbols.clone();
-            let new_name = symbols.gensym();
+    let Expr::Max(_, inside_max_expr) = expr else {
+        return Err(RuleNotApplicable);
+    };
 
-            let mut new_top = Vec::new(); // the new variable must be more than or equal to all the other variables
-            let mut disjunction = Vec::new(); // the new variable must more than or equal to one of the variables
-            for e in exprs {
-                new_top.push(Geq(
-                    Metadata::new(),
-                    Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
-                    Box::new(e.clone()),
-                ));
-                disjunction.push(Eq(
-                    Metadata::new(),
-                    Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
-                    Box::new(e.clone()),
-                ));
-            }
-            new_top.push(Or(Metadata::new(), disjunction));
+    let Some(exprs) = inside_max_expr.as_ref().clone().unwrap_list() else {
+        return Err(RuleNotApplicable);
+    };
 
-            let domain = expr
-                .domain_of(&symbols)
-                .ok_or(ApplicationError::DomainError)?;
-            symbols.insert(Rc::new(Declaration::new_var(new_name.clone(), domain)));
+    let mut symbols = symbols.clone();
+    let new_name = symbols.gensym();
 
-            Ok(Reduction::new(
-                Atomic(Metadata::new(), Reference(new_name)),
-                new_top,
-                symbols,
-            ))
-        }
-        _ => Err(ApplicationError::RuleNotApplicable),
+    let mut new_top = Vec::new(); // the new variable must be more than or equal to all the other variables
+    let mut disjunction = Vec::new(); // the new variable must more than or equal to one of the variables
+    for e in exprs {
+        new_top.push(Geq(
+            Metadata::new(),
+            Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
+            Box::new(e.clone()),
+        ));
+        disjunction.push(Eq(
+            Metadata::new(),
+            Box::new(Atomic(Metadata::new(), Reference(new_name.clone()))),
+            Box::new(e.clone()),
+        ));
     }
+    // FIXME: deal with explicitly given domains
+    new_top.push(Or(
+        Metadata::new(),
+        Box::new(into_matrix_expr![disjunction]),
+    ));
+
+    let domain = expr
+        .domain_of(&symbols)
+        .ok_or(ApplicationError::DomainError)?;
+    symbols.insert(Rc::new(Declaration::new_var(new_name.clone(), domain)));
+
+    Ok(Reduction::new(
+        Atomic(Metadata::new(), Reference(new_name)),
+        new_top,
+        symbols,
+    ))
 }

--- a/crates/conjure_core/src/rules/bubble.rs
+++ b/crates/conjure_core/src/rules/bubble.rs
@@ -7,6 +7,7 @@ use conjure_core::rule_engine::{
 use uniplate::Uniplate;
 
 use crate::ast::{Atom, Literal, SymbolTable};
+use crate::{into_matrix_expr, matrix_expr};
 
 use super::utils::is_all_constant;
 
@@ -25,7 +26,7 @@ fn expand_bubble(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
         Expression::Bubble(_, a, b) if a.return_type() == Some(ReturnType::Bool) => {
             Ok(Reduction::pure(Expression::And(
                 Metadata::new(),
-                vec![*a.clone(), *b.clone()],
+                Box::new(matrix_expr![*a.clone(), *b.clone()]),
             )))
         }
         _ => Err(ApplicationError::RuleNotApplicable),
@@ -55,7 +56,10 @@ fn bubble_up(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
     Ok(Reduction::pure(Expression::Bubble(
         Metadata::new(),
         Box::new(expr.with_children(sub)),
-        Box::new(Expression::And(Metadata::new(), bubbled_conditions)),
+        Box::new(Expression::And(
+            Metadata::new(),
+            Box::new(into_matrix_expr![bubbled_conditions]),
+        )),
     )))
 }
 
@@ -155,10 +159,10 @@ fn pow_to_bubble(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
             Box::new(Expression::SafePow(Metadata::new(), a.clone(), b.clone())),
             Box::new(Expression::And(
                 Metadata::new(),
-                vec![
+                Box::new(matrix_expr![
                     Expression::Or(
                         Metadata::new(),
-                        vec![
+                        Box::new(matrix_expr![
                             Expression::Neq(
                                 Metadata::new(),
                                 a,
@@ -169,14 +173,14 @@ fn pow_to_bubble(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
                                 b.clone(),
                                 Box::new(Atom::Literal(Literal::Int(0)).into()),
                             ),
-                        ],
+                        ]),
                     ),
                     Expression::Geq(
                         Metadata::new(),
                         b,
                         Box::new(Atom::Literal(Literal::Int(0)).into()),
                     ),
-                ],
+                ]),
             )),
         )));
     }

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::collections::HashSet;
 
 use conjure_core::ast::{Atom, Expression as Expr, Literal as Lit};

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -49,11 +49,15 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
         Expr::Not(_, expr) => un_op::<bool, bool>(|e| !e, expr).map(Lit::Bool),
 
-        Expr::And(_, exprs) => vec_op::<bool, bool>(|e| e.iter().all(|&e| e), exprs).map(Lit::Bool),
+        Expr::And(_, e) => {
+            vec_lit_op::<bool, bool>(|e| e.iter().all(|&e| e), e.as_ref()).map(Lit::Bool)
+        }
         // this is done elsewhere instead - root should return a new root with a literal inside it,
         // not a literal
         Expr::Root(_, _) => None,
-        Expr::Or(_, exprs) => vec_op::<bool, bool>(|e| e.iter().any(|&e| e), exprs).map(Lit::Bool),
+        Expr::Or(_, e) => {
+            vec_lit_op::<bool, bool>(|e| e.iter().any(|&e| e), e.as_ref()).map(Lit::Bool)
+        }
         Expr::Imply(_, box1, box2) => {
             let a: &Atom = (&**box1).try_into().ok()?;
             let b: &Atom = (&**box2).try_into().ok()?;
@@ -99,11 +103,11 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(sum >= a.try_into().ok()?))
         }
-        Expr::Min(_, exprs) => {
-            opt_vec_op::<i32, i32>(|e| e.iter().min().copied(), exprs).map(Lit::Int)
+        Expr::Min(_, e) => {
+            opt_vec_lit_op::<i32, i32>(|e| e.iter().min().copied(), e.as_ref()).map(Lit::Int)
         }
-        Expr::Max(_, exprs) => {
-            opt_vec_op::<i32, i32>(|e| e.iter().max().copied(), exprs).map(Lit::Int)
+        Expr::Max(_, e) => {
+            opt_vec_lit_op::<i32, i32>(|e| e.iter().max().copied(), e.as_ref()).map(Lit::Int)
         }
         Expr::UnsafeDiv(_, a, b) | Expr::SafeDiv(_, a, b) => {
             if unwrap_expr::<i32>(b)? == 0 {
@@ -198,7 +202,8 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             Some(Lit::Bool(a ^ b == c))
         }
 
-        Expr::AllDiff(_, es) => {
+        Expr::AllDiff(_, e) => {
+            let es = e.clone().unwrap_list()?;
             let mut lits: HashSet<Lit> = HashSet::new();
             for expr in es {
                 let Expr::Atomic(_, Atom::Literal(x)) = expr else {
@@ -206,7 +211,7 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 };
                 match x {
                     Lit::Int(_) | Lit::Bool(_) => {
-                        if lits.contains(x) {
+                        if lits.contains(&x) {
                             return Some(Lit::Bool(false));
                         } else {
                             lits.insert(x.clone());
@@ -365,10 +370,29 @@ where
     Some(f(a))
 }
 
+fn vec_lit_op<T, A>(f: fn(Vec<T>) -> A, a: &Expr) -> Option<A>
+where
+    T: TryFrom<Lit>,
+{
+    let a = a.clone().unwrap_list()?;
+    let a = a.iter().map(unwrap_expr).collect::<Option<Vec<T>>>()?;
+    Some(f(a))
+}
+
 fn opt_vec_op<T, A>(f: fn(Vec<T>) -> Option<A>, a: &[Expr]) -> Option<A>
 where
     T: TryFrom<Lit>,
 {
+    let a = a.iter().map(unwrap_expr).collect::<Option<Vec<T>>>()?;
+    f(a)
+}
+
+fn opt_vec_lit_op<T, A>(f: fn(Vec<T>) -> Option<A>, a: &Expr) -> Option<A>
+where
+    T: TryFrom<Lit>,
+{
+    let a = a.clone().unwrap_list()?;
+    // FIXME: deal with explicit matrix domains
     let a = a.iter().map(unwrap_expr).collect::<Option<Vec<T>>>()?;
     f(a)
 }

--- a/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
+++ b/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
@@ -1,0 +1,92 @@
+use std::collections::VecDeque;
+
+use conjure_core::ast::Expression as Expr;
+use conjure_core::ast::SymbolTable;
+use conjure_core::rule_engine::{
+    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+};
+use uniplate::Uniplate;
+
+use crate::ast::{Domain, Range};
+use crate::into_matrix_expr;
+
+/// Converts a matrix to a list if possible.
+///
+/// A list is a matrix with the unbounded domain `int(1..)`. Unlike matrices in general, lists can
+/// be resized; consequently, a lot more rules apply to them.
+///
+/// A matrix can be converted to a list if:
+///
+///     1. It has some contiguous domain `int(1..n)`.
+///
+///     2. It is a matrix literal (i.e. not a reference to a decision variable).
+///
+///     3. Its direct parent is a constraint, not another matrix or `AbstractLiteral`.
+///
+///       This prevents the conversion of rows in a 2d matrix from being turned into lists. If were
+///       to happen, the rows of the matrix might become different lengths, which is invalid!
+///
+///     4. The matrix is stored as `Expression` type inside (i.e. not as an `Atom` inside
+///
+/// Because of condition 4, and this rules low priority, this rule will not run post-flattening, so
+/// matrices that do not need to be converted to lists in order to get them ready for Minion will
+/// be left alone.
+
+#[register_rule(("Base", 2000))]
+fn matrix_to_list(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
+    // match on the parent: do not apply this rule to things descended from abstract literal, or
+    // special language constructs like bubble.
+    //
+    // As Minion/ flat constraints do not have expression children, they are automatically
+    // excluded.
+
+    if matches!(
+        expr,
+        Expr::AbstractLiteral(_, _)
+            | Expr::Bubble(_, _, _)
+            | Expr::Atomic(_, _)
+             // not sure if this needs to be excluded, being cautious.
+            | Expr::DominanceRelation(_, _)
+    ) {
+        return Err(RuleNotApplicable);
+    }
+
+    let mut new_children = VecDeque::new();
+    let mut any_changes = false;
+    for child in expr.children() {
+        // already a list => no change
+        if child.clone().unwrap_list().is_some() {
+            new_children.push_back(child);
+            continue;
+        }
+
+        // not a matrix => no change
+        let Some((elems, domain)) = child.clone().unwrap_matrix_unchecked() else {
+            new_children.push_back(child);
+            continue;
+        };
+
+        let Domain::IntDomain(ranges) = &domain else {
+            new_children.push_back(child);
+            continue;
+        };
+
+        // must be domain int(1..n)
+        let [Range::Bounded(1, _)] = ranges[..] else {
+            new_children.push_back(child);
+            continue;
+        };
+
+        any_changes = true;
+        new_children
+            .push_back(into_matrix_expr![elems;Domain::IntDomain(vec![Range::UnboundedR(1)])]);
+    }
+
+    let new_expr = expr.with_children(new_children);
+
+    if any_changes {
+        Ok(Reduction::pure(new_expr))
+    } else {
+        Err(RuleNotApplicable)
+    }
+}

--- a/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
+++ b/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
@@ -10,6 +10,7 @@ use uniplate::Uniplate;
 use crate::ast::{Domain, Range};
 use crate::into_matrix_expr;
 
+
 /// Converts a matrix to a list if possible.
 ///
 /// A list is a matrix with the unbounded domain `int(1..)`. Unlike matrices in general, lists can
@@ -17,21 +18,21 @@ use crate::into_matrix_expr;
 ///
 /// A matrix can be converted to a list if:
 ///
-///     1. It has some contiguous domain `int(1..n)`.
+///  1. It has some contiguous domain `int(1..n)`.
 ///
-///     2. It is a matrix literal (i.e. not a reference to a decision variable).
+///  2. It is a matrix literal (i.e. not a reference to a decision variable).
 ///
-///     3. Its direct parent is a constraint, not another matrix or `AbstractLiteral`.
+///  3. Its direct parent is a constraint, not another matrix or `AbstractLiteral`.
 ///
-///       This prevents the conversion of rows in a 2d matrix from being turned into lists. If were
-///       to happen, the rows of the matrix might become different lengths, which is invalid!
+///    This prevents the conversion of rows in a 2d matrix from being turned into lists. If were
+///    to happen, the rows of the matrix might become different lengths, which is invalid!
 ///
-///     4. The matrix is stored as `Expression` type inside (i.e. not as an `Atom` inside
+///  4. The matrix is stored as `Expression` type inside (i.e. not as an `Atom` inside a Minion
+///     constraint)
 ///
 /// Because of condition 4, and this rules low priority, this rule will not run post-flattening, so
 /// matrices that do not need to be converted to lists in order to get them ready for Minion will
 /// be left alone.
-
 #[register_rule(("Base", 2000))]
 fn matrix_to_list(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     // match on the parent: do not apply this rule to things descended from abstract literal, or

--- a/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
+++ b/crates/conjure_core/src/rules/matrix/matrix_to_list.rs
@@ -10,7 +10,6 @@ use uniplate::Uniplate;
 use crate::ast::{Domain, Range};
 use crate::into_matrix_expr;
 
-
 /// Converts a matrix to a list if possible.
 ///
 /// A list is a matrix with the unbounded domain `int(1..)`. Unlike matrices in general, lists can

--- a/crates/conjure_core/src/rules/matrix/mod.rs
+++ b/crates/conjure_core/src/rules/matrix/mod.rs
@@ -1,0 +1,1 @@
+mod matrix_to_list;

--- a/crates/conjure_core/src/rules/minion.rs
+++ b/crates/conjure_core/src/rules/minion.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use crate::ast::Declaration;
 use crate::ast::{Atom, Domain, Expression as Expr, Literal as Lit, ReturnType, SymbolTable};
 
+use crate::matrix_expr;
 use crate::metadata::Metadata;
 use crate::rule_engine::{
     register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
@@ -366,7 +367,7 @@ fn introduce_weighted_sumleq_sumgeq(expr: &Expr, symbols: &SymbolTable) -> Appli
     let new_expr: Expr = match (equality_kind, use_weighted_sum) {
         (EqualityKind::Eq, true) => Expr::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expr::FlatWeightedSumLeq(
                     Metadata::new(),
                     coefficients.clone(),
@@ -374,14 +375,14 @@ fn introduce_weighted_sumleq_sumgeq(expr: &Expr, symbols: &SymbolTable) -> Appli
                     total.clone(),
                 ),
                 Expr::FlatWeightedSumGeq(Metadata::new(), coefficients, vars, total),
-            ],
+            ]),
         ),
         (EqualityKind::Eq, false) => Expr::And(
             Metadata::new(),
-            vec![
+            Box::new(matrix_expr![
                 Expr::FlatSumLeq(Metadata::new(), vars.clone(), total.clone()),
                 Expr::FlatSumGeq(Metadata::new(), vars, total),
-            ],
+            ]),
         ),
         (EqualityKind::Leq, true) => {
             Expr::FlatWeightedSumLeq(Metadata::new(), coefficients, vars, total)

--- a/crates/conjure_core/src/rules/mod.rs
+++ b/crates/conjure_core/src/rules/mod.rs
@@ -10,6 +10,7 @@ mod base;
 mod bubble;
 mod cnf;
 mod constant_eval;
+mod matrix;
 mod minion;
 mod normalisers;
 mod partial_eval;

--- a/crates/conjure_core/src/rules/normalisers/bool.rs
+++ b/crates/conjure_core/src/rules/normalisers/bool.rs
@@ -212,7 +212,7 @@ fn remove_unit_vector_or(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     // do not conflict with unwrap_nested_or rule.
-    if !exprs.is_empty() || matches!(exprs[0], Expr::Or(_, _)) {
+    if exprs.len() != 1 || matches!(exprs[0], Expr::Or(_, _)) {
         return Err(RuleNotApplicable);
     }
 

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -197,14 +197,26 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
                 parse_atom(c)?,
             ))
         }
-        conjure_ast::Expression::Or(_metadata, exprs) => Ok(minion_ast::Constraint::WatchedOr(
-            exprs
+        conjure_ast::Expression::Or(_metadata, e) => Ok(minion_ast::Constraint::WatchedOr(
+            e.unwrap_matrix_unchecked()
+                .ok_or_else(|| {
+                    SolverError::ModelFeatureNotSupported(
+                        "The inside of an or expression is not a matrix.".to_string(),
+                    )
+                })?
+                .0
                 .iter()
                 .map(|x| parse_expr(x.to_owned()))
                 .collect::<Result<Vec<minion_ast::Constraint>, SolverError>>()?,
         )),
-        conjure_ast::Expression::And(_metadata, exprs) => Ok(minion_ast::Constraint::WatchedAnd(
-            exprs
+        conjure_ast::Expression::And(_metadata, e) => Ok(minion_ast::Constraint::WatchedAnd(
+            e.unwrap_matrix_unchecked()
+                .ok_or_else(|| {
+                    SolverError::ModelFeatureNotSupported(
+                        "The inside of an and expression is not a matrix.".to_string(),
+                    )
+                })?
+                .0
                 .iter()
                 .map(|x| parse_expr(x.to_owned()))
                 .collect::<Result<Vec<minion_ast::Constraint>, SolverError>>()?,


### PR DESCRIPTION
Change the types of most operations that take vectors to take a single matrix argument. This aligns them with Savile Row, and allows them to be used with matrix variables, as well as a literal list of items.  This excludes sum and product.

To enable this, this PR adds:

+ Parsing of matrix literals with and without explicit index domains.

+ Add macros `matrix`, `into_matrix`, `matrix_expr`, `into_matrix_expr` for the creation of matrix literals.

+ Add the concept of a list, `unwrap_list`, and the `matrix_to_list` rule.

+ Add `Range::UnboundedR` and `Range::UnboundedL` 

+ Refactor affected rules and tests to use `unwrap_list` and `matrix_expr` / `into_matrix_expr` instead of vectors.

## Lists

Many of our rules involve changing the number of arguments inside a matrix. For example, the partial evaluation of `or`:

```
or([a,b,false,false]) ~> or([a,b])
```

In general, it is not valid to change the size of a matrix as this is part of their index domain. Also, matrices can have non-contiguous index domains, and what happens to these when elements are removed are non-obvious.

For example, the transformation

```
or([a,b,false,false;int(2,4,6,8)]) ~> or([a,b;int(2,4,6,8)])
```

is invalid, as the matrix on the right has more indices than elements.

A list is a matrix with the index domain `int(1..)`. This domain is unbounded, so allows arbitrary element addition and removal.

When a matrix literal `[a,b,c]` is constructed without an explicit index domain (e.g. using `matrix_expr!`), it is assumed to be a list, and given the index domain `int(1..)`. If an explicit index domain is given (e.g. `[a,b,c;int(1,2,4)]`, that is used instead.

In rules, `unwrap_list` can be used to check if an expression is a list or not, and `matrix_expr!` / `into_matrix_expr!` can be used to construct a list from its elements.

Most rules except matrix indexing / slicing should work on lists only.

## `matrix_to_list` Rule

Conjure gives `[a,b,c]` the index domain `int(1..3)`.  Our Conjure-JSON parser inherits this behaviour.

Under our definition, this is not a list, so most rules cannot apply to it. However, as long as it is not inside another matrix (e.g. is a row in a 2d matrix), and has a single contiguous index domain `int(1..n)`, it is safe to treat it as such.

`matrix_to_rule` performs this conversion.

For example,

```
min([1,2,3,4;int(1..4)]) ~~> min([1,2,3,4;int(1..)]
```

If we instead had

```
min([[1,2,3,4;int(1..4)],[5,6,7,8;int(1..4)];int(1..2)]
```

`matrix_to_rule` would not apply to `[1,2,3,4]`; this ensures that all the rows of the matrix remain the same size. However, it could apply to the containing matrix.

For the exact conditions this rule runs under, see the doc comment for `matrix_to_rule`.
