### PR TITLE
ProTrace

### DIFF
--- a/crates/conjure_core/src/lib.rs
+++ b/crates/conjure_core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod context;
 pub mod error;
 pub mod metadata;
 pub mod parse;
+pub mod pro_trace;
 pub mod rule_engine;
 pub mod rules;
 pub mod solver;

--- a/crates/conjure_core/src/pro_trace.rs
+++ b/crates/conjure_core/src/pro_trace.rs
@@ -1,0 +1,52 @@
+use crate::ast::Expression;
+use std::fmt;
+
+pub struct RuleTrace<'a> {
+    pub initial_expression: Expression,
+    pub rule_name: String,
+    pub rule_sets: Vec<(&'a str, u16)>,
+    pub transformed_expression: Expression,
+    pub new_variables_str: String,
+    pub top_level_str: String,
+}
+impl fmt::Display for RuleTrace<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}, \n   ~~> {} ({:?}) \n{} \n{}\n{}--\n",
+            self.initial_expression,
+            self.rule_name,
+            self.rule_sets,
+            self.transformed_expression,
+            self.new_variables_str,
+            self.top_level_str
+        )?;
+
+        Ok(())
+    }
+}
+pub trait Trace<F: MessageFormatter> {
+    fn capture(&self, rule_trace: &RuleTrace);
+}
+
+pub trait MessageFormatter {
+    fn format(&self, rule_trace: &RuleTrace) -> String;
+}
+
+pub struct HumanFormatter;
+impl MessageFormatter for HumanFormatter {
+    fn format(&self, rule_trace: &RuleTrace) -> String {
+        format!("Formatted rule trace: {}", rule_trace)
+    }
+}
+
+pub struct StdoutConsumer<F: MessageFormatter> {
+    pub formatter: F,
+}
+
+impl<F: MessageFormatter> Trace<F> for StdoutConsumer<F> {
+    fn capture(&self, rule_trace: &RuleTrace) {
+        let formatted_output = self.formatter.format(rule_trace);
+        println!("{}", formatted_output);
+    }
+}

--- a/crates/conjure_core/src/rule_engine/mod.rs
+++ b/crates/conjure_core/src/rule_engine/mod.rs
@@ -72,7 +72,6 @@ pub use rule_set::RuleSet;
 mod submodel_zipper;
 
 use crate::solver::SolverFamily;
-
 mod resolve_rules;
 mod rewrite;
 mod rewrite_naive;

--- a/crates/conjure_core/src/rule_engine/rewrite.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite.rs
@@ -339,6 +339,7 @@ fn choose_rewrite<'a>(
     initial_expression: &Expression,
 ) -> Option<RuleResult<'a>> {
     //in the case where multiple rules are applicable
+
     if !results.is_empty() {
         let mut rewrite_options: Vec<RuleResult> = Vec::new();
         for (priority, group) in &results.iter().chunk_by(|result| result.rule_data.priority) {
@@ -378,7 +379,6 @@ fn choose_rewrite<'a>(
             }
             log::warn!("{}", message);
         }
-
         return Some(rewrite_options[0].clone());
     }
 

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -7,6 +7,7 @@ use crate::ast::{
     pretty::{pretty_variable_declaration, pretty_vec},
     Expression, SubModel,
 };
+use crate::pro_trace::{HumanFormatter, MessageFormatter, RuleTrace, StdoutConsumer, Trace};
 
 use itertools::Itertools;
 use serde_json::json;
@@ -98,7 +99,22 @@ pub fn log_rule_application(
         "transformed_expression": serde_json::to_value(&red.new_expression).unwrap()
     })
 
-    )
+    );
+
+    let rule_trace = RuleTrace {
+        initial_expression: initial_expression.clone(),
+        transformed_expression: red.new_expression.clone(),
+        rule_name: rule.name.to_string(),
+        rule_sets: rule.rule_sets.to_vec(),
+        new_variables_str: new_variables_str,
+        top_level_str: top_level_str,
+    };
+
+    let stdout_consumer = StdoutConsumer {
+        formatter: HumanFormatter {},
+    };
+
+    stdout_consumer.capture(&rule_trace);
 }
 
 /// Represents errors that can occur during the model rewriting process.


### PR DESCRIPTION
This pull request implements a custom tracing functionality within the `ProTrace` module. The core purpose of this functionality is to capture a `RuleTrace`, which contains detailed information about the current expression being transformed during the rewriting stage. Based on predefined filters (probably as cli arguments), the trace is formatted and outputted either to the standard output or to a file.

The primary goal of this pull request is to ensure that the tracing works seamlessly when running the project with `cargo run`.
