### PR TITLE
ci: move hygiene checks to `Makefile`, allowing them to be ran locally

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -39,11 +39,4 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - run: RUSTFLAGS="-D warnings" cargo build -vv --workspace
-
-      - run: RUSTFLAGS="-D warnings" cargo build -vv --workspace --examples
-
-      - run: cargo clippy -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
-
-      - run: cargo fmt --check
-  
+      - run: make EXTRA_CARGO_CHECK_FLAGS=-v check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Make this Makefile auto-documenting
+include tools/show-help-minified.make
+
+
+
+# Extra flags to be passed to `cargo check` (default: -q).
+EXTRA_CARGO_CHECK_FLAGS ?= -q
+
+.PHONY: check
+## Runs all hygiene checks. These are the same checks that occur in CI for PRs.
+check: 
+	RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) --workspace
+	RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) --workspace --examples
+	cargo clippy $(EXTRA_CARGO_CHECK_FLAGS) -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
+	cargo fmt --check
+
+.PHONY: fix 
+## Tries to auto-fix hygiene issues reported by `make check`. 
+## Fixes will not be applied if there are uncommitted changes: to always apply fixes, use `make fix-dirty`.
+fix: 
+	cargo fmt --all
+	cargo clippy -q --fix
+
+.PHONY: fix-dirty
+## fix, but applies fixes even when there are uncommitted changes.
+fix-dirty: 
+	cargo fmt --all 
+	cargo clippy -q --fix --allow-dirty --allow-staged
+
+.PHONY: help
+## Shows this help text
+help: show-help
+
+.DEFAULT_GOAL : help

--- a/tools/show-help-minified.make
+++ b/tools/show-help-minified.make
@@ -1,0 +1,7 @@
+# From <https://gist.github.com/klmr/575726c7e05d8780505a>.
+
+.DEFAULT_GOAL := show-help
+# See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
+.PHONY: show-help
+show-help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')


### PR DESCRIPTION
Create a Makefile containing our PR hygiene checks, and the commands necessary to fix it. Refactor the hygiene CI to call this Makefile.

This allows the running of the hygiene tests used in CI locally using `make check`. Having CI call the Makefile  ensures that the local and CI versions will always be consistent.

The fix/fix-dirty commands wrap the correct cargo clippy and cargo fmt flags to auto-fix these issues.

This Makefile is self-documenting, and help can be viewed by running `make`.
