### PR TITLE
Performance Tester

### DIFF
--- a/tools/gen_commands.sh
+++ b/tools/gen_commands.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# ROOT_DIR=$(pwd)
+WORKING_DIR="$(pwd)/tools/performance"
+TEST_DIR="${WORKING_DIR}/tests"
+DATA_DIR="${WORKING_DIR}/data"
+O0_DATA_DIR="${DATA_DIR}/O0_CN"
+O2_DATA_DIR="${DATA_DIR}/O2_CN"
+TM_DATA_DIR="${DATA_DIR}/TM_CO"
+NV_DATA_DIR="${DATA_DIR}/NV_CO"
+CMD_FILE="${WORKING_DIR}/commands.txt"
+
+rm -f ${CMD_FILE}
+touch ${CMD_FILE}
+rm -r $DATA_DIR
+mkdir $DATA_DIR
+mkdir $O0_DATA_DIR
+mkdir $O2_DATA_DIR
+mkdir $TM_DATA_DIR
+mkdir $NV_DATA_DIR
+
+pushd $TEST_DIR 
+for prob in *; do #go through all tests folders in directory
+    find $prob -name *.essence | #go through all essence files for this problem, best if only 1
+    while read essence
+    do
+        # echo "essence file name $essence" #full path to file
+        # echo "$prob" #current directory
+        essence="${essence#$prob}" #
+        essence="${essence#/}"        
+        # echo "$essence"
+        echo "writing to command file"
+        echo "./scripts/runConjure.sh ${prob} ${essence} -O0" >> ${CMD_FILE}
+        echo "./scripts/runConjure.sh ${prob} ${essence} -O2" >> ${CMD_FILE}
+        echo "./scripts/runOxide.sh ${prob} ${essence}" >>${CMD_FILE}
+
+        #treemorph rewriter flag not yet added
+        # echo "runOxide.sh ${prob} ${essence} --use-treemorph-rewriter" >>${CMD_FILE}
+
+    done
+done
+popd
+#parallel \ --no-notice z -j"${nb_cores} \ --eta --results logs/gnuparallel/modelling-results \ --joblog log/gnuparallel/modelling-joblog \ :::: ${CMD_FILE} || true

--- a/tools/gen_data.sh
+++ b/tools/gen_data.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+WORKING_DIR="$(pwd)/tools/performance"
+CMD_FILE="${WORKING_DIR}/commands.txt"
+
+pushd $WORKING_DIR
+parallel --no-notice :::: ${CMD_FILE}
+popd

--- a/tools/performance/commands.txt
+++ b/tools/performance/commands.txt
@@ -1,0 +1,3 @@
+./scripts/runConjure.sh basic basic.essence -O0
+./scripts/runConjure.sh basic basic.essence -O2
+./scripts/runOxide.sh basic basic.essence

--- a/tools/performance/data/O0_CN/basic/model000001.eprime-info
+++ b/tools/performance/data/O0_CN/basic/model000001.eprime-info
@@ -1,0 +1,10 @@
+SolverTotalTime:0.043461
+SavileRowClauseOut:0
+SolverSolveTime:0.043461
+SavileRowTotalTime:0.04
+SolverSatisfiable:1
+SavileRowTimeOut:0
+SolverNodes:3
+SolverTimeOut:0
+SolverSolutionsFound:1
+SolverSetupTime:0

--- a/tools/performance/data/O2_CN/basic/model000001.eprime-info
+++ b/tools/performance/data/O2_CN/basic/model000001.eprime-info
@@ -1,0 +1,10 @@
+SolverTotalTime:0.04372
+SavileRowClauseOut:0
+SolverSolveTime:0.043287
+SavileRowTotalTime:0.044
+SolverSatisfiable:1
+SavileRowTimeOut:0
+SolverNodes:3
+SolverTimeOut:0
+SolverSolutionsFound:1
+SolverSetupTime:6.9e-05

--- a/tools/performance/scripts/runConjure.sh
+++ b/tools/performance/scripts/runConjure.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "${1} ${2} ${3}"
+PROBLEM=$1
+ESSENCE=$2
+PARAM=$3
+
+# BASE_ESSENCE="${ESSENCE%.*}"
+WORKING_DIR="$(pwd)"
+FULL_ESSENCE="${WORKING_DIR}/tests/${PROBLEM}/${ESSENCE}"
+if [ $PARAM = "-O0" ]; then
+    DATA_DIR="$(pwd)/data/O0_CN/${PROBLEM}/"
+elif [ $PARAM = "-O2" ]; then
+    DATA_DIR="$(pwd)/data/O2_CN/${PROBLEM}/"
+else
+    echo "Optimisation mode not recognised: ${$3}"
+    exit 1
+fi
+
+rm -r $DATA_DIR
+mkdir $DATA_DIR
+conjure solve -o  $DATA_DIR $FULL_ESSENCE
+SOLUTION="${FULL_ESSENCE%.*}"
+SOLUTION="${SOLUTION}.solution"
+rm $SOLUTION
+
+rm -f $DATA_DIR/*.{eprime,eprime-solution,eprime-infor,eprime-minion}

--- a/tools/performance/scripts/runOxide.sh
+++ b/tools/performance/scripts/runOxide.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#May not be best method as requires compilation each time, which feels inefficient and messy?
+PROBLEM=$1
+ESSENCE=$2
+
+FULL_ESSENCE="$(pwd)/tests/${PROBLEM}/${ESSENCE}"
+
+DATA_DIR="$(pwd)/data/NV_CO/${PROBLEM}/"
+rm -r $DATA_DIR
+mkdir $DATA_DIR
+JSON_FILE="${DATA_DIR}/oxide-stats.json"
+
+cargo run -- --info-json-path $JSON_FILE $FULL_ESSENCE
+
+rm $(pwd)/*.log
+rm $(pwd)/conjure_oxide_log.json

--- a/tools/performance/tests/basic/basic.essence
+++ b/tools/performance/tests/basic/basic.essence
@@ -1,0 +1,2 @@
+find a,b : int(0..4)
+such that a / b = 2


### PR DESCRIPTION
## Overview

Based on issue #693, performance tester for CO. 
Completed half of Step 1:
- [ ] Runs conjure on given test
- [ ] Outputs stats file into data folder
- [ ] Runs conjure-oxide on given test
- [ ] Outputs stats file into data folder
- [ ] Data is aggregated
- [ ] Data is organised
- [ ] Data is analysed


Data is separated by type (Conjure Native (CN) -O0 | -O2; Conjure Oxide (CO) Naive | Treemorph). There is not currently a flag to enable treemorph, so this functionality will be added at a later point. 

Created four scripts:
### gen_commands.sh
Generates a list of commands, to call CN and CO, the test folder name, the test file name, and any parameter flags (for optimisation)

### gen_data.sh
runs the text file list of commands generated above using GNU parallel (I think??)

### runConjure.sh
creates variables to link to files, runs conjure, puts output in correct data subdirectory

### runOxide.sh
creates variables to link to files, run CO, puts stats file in correct data subdirectory.

## Notes: 
Must be run from user/conjure-oxide - NOT user/conjure-oxide/conjure-oxide, as stored within tools. 
eg: 
`ed237@klovia: .../ed237/Documents/VIPWork/conjure-oxide $ ./tools/gen_commands
ed237@klovia: .../ed237/Documents/VIPWork/conjure-oxide $ ./tools/gen_data`

Each call of CO requires it to recompile: feels inefficient but unsure how to go around this? Also, CO stats file appears to no longer record rewriting time - this feature is required for functionality.