### PR TITLE
fix: collect run stats for naive rewriter

### DIFF
--- a/crates/conjure_core/src/stats/rewriter_stats.rs
+++ b/crates/conjure_core/src/stats/rewriter_stats.rs
@@ -71,3 +71,14 @@ pub struct RewriterStats {
     pub rewriter_rule_application_attempts: Option<usize>,
     pub rewriter_rule_applications: Option<usize>,
 }
+
+impl RewriterStats {
+    pub fn new() -> Self {
+        Self {
+            is_optimization_enabled: None,
+            rewriter_run_time: None,
+            rewriter_rule_application_attempts: None,
+            rewriter_rule_applications: None,
+        }
+    }
+}


### PR DESCRIPTION
Add missing stats (rewriter running time, number of rule applications, etc) to the naive rewriter.
These were reported by the old rewriter and used for performance testing, but the naive reporter does not currently report stats which breaks some of our performance testing code
