### PR TITLE
 Solve matrices indexed by non-constant expressions

### DIFF
--- a/conjure_oxide/tests/integration/basic/comprehension/02/config.toml
+++ b/conjure_oxide/tests/integration/basic/comprehension/02/config.toml
@@ -1,2 +1,2 @@
-solve_with_minion=false
+solve_with_minion=true
 use_native_parser=false

--- a/conjure_oxide/tests/integration/basic/comprehension/02/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/comprehension/02/input.expected-minion.solutions.json
@@ -1,7 +1,22 @@
 [
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -33,27 +48,10 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
+    "n": {
       "AbstractLiteral": {
         "Matrix": [
           [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
             {
               "Int": 1
             },
@@ -62,6 +60,12 @@
             },
             {
               "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
             }
           ],
           {
@@ -73,58 +77,26 @@
           }
         ]
       }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
     },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
+    "__2": {
       "Int": 1
     },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -156,16 +128,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -197,16 +208,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -238,16 +288,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -279,16 +368,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -320,16 +448,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -361,24 +528,10 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
+    "n": {
       "AbstractLiteral": {
         "Matrix": [
           [
-            {
-              "Int": 1
-            },
             {
               "Int": 1
             },
@@ -389,7 +542,10 @@
               "Int": 3
             },
             {
-              "Int": 3
+              "Int": 4
+            },
+            {
+              "Int": 5
             }
           ],
           {
@@ -401,17 +557,26 @@
           }
         ]
       }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -443,16 +608,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -484,16 +688,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -525,1289 +768,7 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 5
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
-      "AbstractLiteral": {
-        "Matrix": [
-          [
-            {
-              "Int": 1
-            },
-            {
-              "Int": 2
-            },
-            {
-              "Int": 3
-            },
-            {
-              "Int": 4
-            },
-            {
-              "Int": 4
-            }
-          ],
-          {
-            "IntDomain": [
-              {
-                "UnboundedR": 1
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
-    }
-  },
-  {
-    "__0": {
-      "Int": 1
-    },
-    "m": {
+    "n": {
       "AbstractLiteral": {
         "Matrix": [
           [
@@ -1836,17 +797,3386 @@
           }
         ]
       }
-    },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -1878,16 +4208,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -1919,16 +4288,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -1960,16 +4368,295 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 2
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -2001,16 +4688,55 @@
         ]
       }
     },
-    "x": {
-      "Int": 1
-    },
-    "y": {
-      "Int": 1
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   },
   {
     "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
     },
     "m": {
       "AbstractLiteral": {
@@ -2042,11 +4768,5235 @@
         ]
       }
     },
-    "x": {
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
       "Int": 1
     },
-    "y": {
-      "Int": 2
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "__0": {
+      "Int": 0
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "__3": {
+      "Int": 5
+    },
+    "__4": {
+      "Int": 4
+    },
+    "__5": {
+      "Int": 3
+    },
+    "m": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "n": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            },
+            {
+              "Int": 4
+            },
+            {
+              "Int": 5
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 ]

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/config.toml
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/config.toml
@@ -1,0 +1,2 @@
+enable_native_parser=false
+solve_with_minion=true

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
@@ -1,0 +1,372 @@
+Model before rewriting:
+
+find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..5)
+find i: int(1..2)
+
+such that
+
+(a[i, i] = i),
+(a[1, 2] = 1),
+(a[2, 1] = 1),
+(a[3, 1] = 1),
+(a[3, 2] = 1)
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+new variables:
+  find a#matrix_to_atom_1_1: int(1..5)
+  find a#matrix_to_atom_1_2: int(1..5)
+  find a#matrix_to_atom_2_1: int(1..5)
+  find a#matrix_to_atom_2_2: int(1..5)
+  find a#matrix_to_atom_3_1: int(1..5)
+  find a#matrix_to_atom_3_2: int(1..5)
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a#matrix_to_atom[i, i], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)])} 
+
+--
+
+({a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)])} = i), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])} 
+
+--
+
+{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]), 
+   ~~> normalise_associative_commutative ([("Base", 8900)]) 
+and([(a#matrix_to_atom[i, i] = i),__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]) 
+
+--
+
+a#matrix_to_atom[1, 2], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[1, 2] @ and([__inDomain(1,int(1..3)),__inDomain(2,int(1..2));int(1..)])} 
+
+--
+
+and([__inDomain(1,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[1, 2] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[1, 2] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[1, 2] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[1, 2] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 2] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[1, 2] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 2] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[1, 2] = 1) 
+
+--
+
+a#matrix_to_atom[2, 1], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[2, 1] @ and([__inDomain(2,int(1..3)),__inDomain(1,int(1..2));int(1..)])} 
+
+--
+
+and([__inDomain(2,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[2, 1] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[2, 1] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[2, 1] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[2, 1] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 1] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[2, 1] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 1] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[2, 1] = 1) 
+
+--
+
+a#matrix_to_atom[3, 1], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[3, 1] @ and([__inDomain(3,int(1..3)),__inDomain(1,int(1..2));int(1..)])} 
+
+--
+
+and([__inDomain(3,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[3, 1] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[3, 1] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[3, 1] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[3, 1] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 1] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[3, 1] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 1] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[3, 1] = 1) 
+
+--
+
+a#matrix_to_atom[3, 2], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[3, 2] @ and([__inDomain(3,int(1..3)),__inDomain(2,int(1..2));int(1..)])} 
+
+--
+
+and([__inDomain(3,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[3, 2] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[3, 2] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[3, 2] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[3, 2] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 2] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[3, 2] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 2] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[3, 2] = 1) 
+
+--
+
+__inDomain(i,int(1..3)), 
+   ~~> introduce_wininterval_set_from_indomain ([("Minion", 4400)]) 
+__minion_w_inintervalset(i,1,3) 
+
+--
+
+__inDomain(i,int(1..2)), 
+   ~~> introduce_wininterval_set_from_indomain ([("Minion", 4400)]) 
+__minion_w_inintervalset(i,1,2) 
+
+--
+
+a#matrix_to_atom[i, i], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+[a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2;int(1..)][Sum([Product([2, (i - 1)]), Product([1, (i - 1)]), 1])] 
+
+--
+
+(i - 1), 
+   ~~> minus_to_sum ([("Base", 8400)]) 
+Sum([i, -(1)]) 
+
+--
+
+-(1), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+-1 
+
+--
+
+(i - 1), 
+   ~~> minus_to_sum ([("Base", 8400)]) 
+Sum([i, -(1)]) 
+
+--
+
+-(1), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+-1 
+
+--
+
+[a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2;int(1..)][Sum([Product([2, Sum([i, -1])]), Product([1, Sum([i, -1])]), 1])], 
+   ~~> flatten_generic ([("Minion", 4200)]) 
+[a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2;int(1..)][__0] 
+new variables:
+  find __0: int(1..4)
+new constraints:
+  __0 =aux Sum([Product([2, Sum([i, -1])]), Product([1, Sum([i, -1])]), 1])
+--
+
+__0 =aux Sum([Product([2, Sum([i, -1])]), Product([1, Sum([i, -1])]), 1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([FlatWeightedSumLeq([2, 1, 1],[__1, __2, 1],__0),FlatWeightedSumGeq([2, 1, 1],[__1, __2, 1],__0);int(1..)]) 
+new variables:
+  find __1: int(0..1)
+  find __2: int(0..1)
+new constraints:
+  __1 =aux Sum([i, -1])
+  __2 =aux Sum([i, -1])
+--
+
+__1 =aux Sum([i, -1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([i, -1], __1),SumGeq([i, -1], __1);int(1..)]) 
+
+--
+
+__2 =aux Sum([i, -1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([i, -1], __2),SumGeq([i, -1], __2);int(1..)]) 
+
+--
+
+([a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2;int(1..)][__0] = i), 
+   ~~> introduce_element_from_index ([("Minion", 4400)]) 
+__minion_element_one([a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2],__0,i) 
+
+--
+
+a#matrix_to_atom[1, 2], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_1_2 
+
+--
+
+a#matrix_to_atom[2, 1], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_2_1 
+
+--
+
+a#matrix_to_atom[3, 1], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_3_1 
+
+--
+
+a#matrix_to_atom[3, 2], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_3_2 
+
+--
+
+Final model:
+
+find a: matrix indexed by [[int(1..3), int(1..2)]] of int(1..5)
+find i: int(1..2)
+find __0: int(1..4)
+find __1: int(0..1)
+find __2: int(0..1)
+find a#matrix_to_atom_1_1: int(1..5)
+find a#matrix_to_atom_1_2: int(1..5)
+find a#matrix_to_atom_2_1: int(1..5)
+find a#matrix_to_atom_2_2: int(1..5)
+find a#matrix_to_atom_3_1: int(1..5)
+find a#matrix_to_atom_3_2: int(1..5)
+
+such that
+
+and([__minion_element_one([a#matrix_to_atom_1_1,a#matrix_to_atom_1_2,a#matrix_to_atom_2_1,a#matrix_to_atom_2_2,a#matrix_to_atom_3_1,a#matrix_to_atom_3_2],__0,i),__minion_w_inintervalset(i,1,3),__minion_w_inintervalset(i,1,2);int(1..)]),
+(a#matrix_to_atom_1_2 = 1),
+(a#matrix_to_atom_2_1 = 1),
+(a#matrix_to_atom_3_1 = 1),
+(a#matrix_to_atom_3_2 = 1),
+and([FlatWeightedSumLeq([2, 1, 1],[__1, __2, 1],__0),FlatWeightedSumGeq([2, 1, 1],[__1, __2, 1],__0);int(1..)]),
+and([SumLeq([i, -1], __1),SumGeq([i, -1], __1);int(1..)]),
+and([SumLeq([i, -1], __2),SumGeq([i, -1], __2);int(1..)])
+

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.eprime
@@ -1,0 +1,14 @@
+language ESSENCE' 1.0
+
+find a: matrix indexed by [int(1..3),int(1..2)] of int(1..5) 
+find i: int(1..2)
+
+such that
+
+a[i,i] = i, $ (1,1), (2,2)
+
+$ reduce number of solutions
+a[1,2] = 1,
+a[2,1] = 1,
+a[3,1] = 1,
+a[3,2] = 1,

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-minion.solutions.json
@@ -1,0 +1,922 @@
+[
+  {
+    "__0": {
+      "Int": 1
+    },
+    "__1": {
+      "Int": 0
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 1
+    }
+  },
+  {
+    "__0": {
+      "Int": 1
+    },
+    "__1": {
+      "Int": 0
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 1
+    }
+  },
+  {
+    "__0": {
+      "Int": 1
+    },
+    "__1": {
+      "Int": 0
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 1
+    }
+  },
+  {
+    "__0": {
+      "Int": 1
+    },
+    "__1": {
+      "Int": 0
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 4
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 1
+    }
+  },
+  {
+    "__0": {
+      "Int": 1
+    },
+    "__1": {
+      "Int": 0
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 5
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 1
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 4
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 5
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  }
+]

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-parse.serialised.json
@@ -1,0 +1,446 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "i"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "i"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "i"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 3430,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          5
+                        ]
+                      }
+                    ]
+                  },
+                  [
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            3
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "i"
+        },
+        {
+          "id": 3431,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      2
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "i"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input.expected-rewrite.serialised.json
@@ -1,0 +1,971 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionElementOne": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "1_1"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "1_2"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "2_1"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "2_2"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "3_1"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "3_2"
+                                ]
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "MinionWInIntervalSet": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          },
+                          [
+                            1,
+                            3
+                          ]
+                        ]
+                      },
+                      {
+                        "MinionWInIntervalSet": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          },
+                          [
+                            1,
+                            2
+                          ]
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "1_2"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "2_1"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "3_1"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "3_2"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 2
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 3,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 3682,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          5
+                        ]
+                      }
+                    ]
+                  },
+                  [
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            3
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "i"
+        },
+        {
+          "id": 3681,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      2
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "i"
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 0
+        },
+        {
+          "id": 3700,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      4
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 0
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 1
+        },
+        {
+          "id": 3701,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      0,
+                      1
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 1
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 2
+        },
+        {
+          "id": 3702,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      0,
+                      1
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 2
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1_1"
+          ]
+        },
+        {
+          "id": 3689,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1_1"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1_2"
+          ]
+        },
+        {
+          "id": 3690,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1_2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2_1"
+          ]
+        },
+        {
+          "id": 3691,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2_1"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2_2"
+          ]
+        },
+        {
+          "id": 3692,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2_2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3_1"
+          ]
+        },
+        {
+          "id": 3693,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3_1"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3_2"
+          ]
+        },
+        {
+          "id": 3694,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3_2"
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/config.toml
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/config.toml
@@ -1,0 +1,2 @@
+enable_native_parser=false
+solve_with_minion=true

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
@@ -1,0 +1,546 @@
+Model before rewriting:
+
+find a: matrix indexed by [[int(1..3), int(2..4)]] of int(1..5)
+find i: int(2..4)
+
+such that
+
+(a[1, 2] = 1),
+(a[1, 3] = 1),
+(a[1, 4] = 1),
+(a[2, 3] = 1),
+(a[2, 4] = 1),
+(a[3, 2] = 1),
+(a[3, 4] = 1),
+(a[i, i] = i)
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+new variables:
+  find a#matrix_to_atom_1_2: int(1..5)
+  find a#matrix_to_atom_1_3: int(1..5)
+  find a#matrix_to_atom_1_4: int(1..5)
+  find a#matrix_to_atom_2_2: int(1..5)
+  find a#matrix_to_atom_2_3: int(1..5)
+  find a#matrix_to_atom_2_4: int(1..5)
+  find a#matrix_to_atom_3_2: int(1..5)
+  find a#matrix_to_atom_3_3: int(1..5)
+  find a#matrix_to_atom_3_4: int(1..5)
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a#matrix_to_atom[1, 2], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[1, 2] @ and([__inDomain(1,int(1..3)),__inDomain(2,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(1,int(1..3)),__inDomain(2,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[1, 2] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[1, 2] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[1, 2] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[1, 2] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 2] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[1, 2] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 2] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[1, 2] = 1) 
+
+--
+
+a#matrix_to_atom[1, 3], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[1, 3] @ and([__inDomain(1,int(1..3)),__inDomain(3,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(1,int(1..3)),__inDomain(3,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[1, 3] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[1, 3] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[1, 3] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[1, 3] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 3] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[1, 3] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 3] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[1, 3] = 1) 
+
+--
+
+a#matrix_to_atom[1, 4], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[1, 4] @ and([__inDomain(1,int(1..3)),__inDomain(4,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(1,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[1, 4] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[1, 4] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[1, 4] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[1, 4] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 4] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[1, 4] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1, 4] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[1, 4] = 1) 
+
+--
+
+a#matrix_to_atom[2, 3], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[2, 3] @ and([__inDomain(2,int(1..3)),__inDomain(3,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(2,int(1..3)),__inDomain(3,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[2, 3] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[2, 3] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[2, 3] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[2, 3] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 3] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[2, 3] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 3] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[2, 3] = 1) 
+
+--
+
+a#matrix_to_atom[2, 4], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[2, 4] @ and([__inDomain(2,int(1..3)),__inDomain(4,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(2,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[2, 4] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[2, 4] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[2, 4] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[2, 4] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 4] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[2, 4] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2, 4] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[2, 4] = 1) 
+
+--
+
+a#matrix_to_atom[3, 2], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[3, 2] @ and([__inDomain(3,int(1..3)),__inDomain(2,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(3,int(1..3)),__inDomain(2,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[3, 2] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[3, 2] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[3, 2] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[3, 2] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 2] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[3, 2] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 2] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[3, 2] = 1) 
+
+--
+
+a#matrix_to_atom[3, 4], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[3, 4] @ and([__inDomain(3,int(1..3)),__inDomain(4,int(2..4));int(1..)])} 
+
+--
+
+and([__inDomain(3,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[3, 4] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[3, 4] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[3, 4] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[3, 4] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 4] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[3, 4] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3, 4] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[3, 4] = 1) 
+
+--
+
+a#matrix_to_atom[i, i], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)])} 
+
+--
+
+({a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)])} = i), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)])} 
+
+--
+
+{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)])}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]);int(1..)]), 
+   ~~> normalise_associative_commutative ([("Base", 8900)]) 
+and([(a#matrix_to_atom[i, i] = i),__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]) 
+
+--
+
+__inDomain(i,int(1..3)), 
+   ~~> introduce_wininterval_set_from_indomain ([("Minion", 4400)]) 
+__minion_w_inintervalset(i,1,3) 
+
+--
+
+__inDomain(i,int(2..4)), 
+   ~~> introduce_wininterval_set_from_indomain ([("Minion", 4400)]) 
+__minion_w_inintervalset(i,2,4) 
+
+--
+
+a#matrix_to_atom[1, 2], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_1_2 
+
+--
+
+a#matrix_to_atom[1, 3], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_1_3 
+
+--
+
+a#matrix_to_atom[1, 4], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_1_4 
+
+--
+
+a#matrix_to_atom[2, 3], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_2_3 
+
+--
+
+a#matrix_to_atom[2, 4], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_2_4 
+
+--
+
+a#matrix_to_atom[3, 2], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_3_2 
+
+--
+
+a#matrix_to_atom[3, 4], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_3_4 
+
+--
+
+a#matrix_to_atom[i, i], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+[a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4;int(1..)][Sum([Product([3, (i - 1)]), Product([1, (i - 2)]), 1])] 
+
+--
+
+(i - 1), 
+   ~~> minus_to_sum ([("Base", 8400)]) 
+Sum([i, -(1)]) 
+
+--
+
+-(1), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+-1 
+
+--
+
+(i - 2), 
+   ~~> minus_to_sum ([("Base", 8400)]) 
+Sum([i, -(2)]) 
+
+--
+
+-(2), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+-2 
+
+--
+
+[a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4;int(1..)][Sum([Product([3, Sum([i, -1])]), Product([1, Sum([i, -2])]), 1])], 
+   ~~> flatten_generic ([("Minion", 4200)]) 
+[a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4;int(1..)][__0] 
+new variables:
+  find __0: int(4..12)
+new constraints:
+  __0 =aux Sum([Product([3, Sum([i, -1])]), Product([1, Sum([i, -2])]), 1])
+--
+
+__0 =aux Sum([Product([3, Sum([i, -1])]), Product([1, Sum([i, -2])]), 1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([FlatWeightedSumLeq([3, 1, 1],[__1, __2, 1],__0),FlatWeightedSumGeq([3, 1, 1],[__1, __2, 1],__0);int(1..)]) 
+new variables:
+  find __1: int(1..3)
+  find __2: int(0..2)
+new constraints:
+  __1 =aux Sum([i, -1])
+  __2 =aux Sum([i, -2])
+--
+
+__1 =aux Sum([i, -1]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([i, -1], __1),SumGeq([i, -1], __1);int(1..)]) 
+
+--
+
+__2 =aux Sum([i, -2]), 
+   ~~> introduce_weighted_sumleq_sumgeq ([("Minion", 4600)]) 
+and([SumLeq([i, -2], __2),SumGeq([i, -2], __2);int(1..)]) 
+
+--
+
+([a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4;int(1..)][__0] = i), 
+   ~~> introduce_element_from_index ([("Minion", 4400)]) 
+__minion_element_one([a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4],__0,i) 
+
+--
+
+Final model:
+
+find a: matrix indexed by [[int(1..3), int(2..4)]] of int(1..5)
+find i: int(2..4)
+find __0: int(4..12)
+find __1: int(1..3)
+find __2: int(0..2)
+find a#matrix_to_atom_1_2: int(1..5)
+find a#matrix_to_atom_1_3: int(1..5)
+find a#matrix_to_atom_1_4: int(1..5)
+find a#matrix_to_atom_2_2: int(1..5)
+find a#matrix_to_atom_2_3: int(1..5)
+find a#matrix_to_atom_2_4: int(1..5)
+find a#matrix_to_atom_3_2: int(1..5)
+find a#matrix_to_atom_3_3: int(1..5)
+find a#matrix_to_atom_3_4: int(1..5)
+
+such that
+
+(a#matrix_to_atom_1_2 = 1),
+(a#matrix_to_atom_1_3 = 1),
+(a#matrix_to_atom_1_4 = 1),
+(a#matrix_to_atom_2_3 = 1),
+(a#matrix_to_atom_2_4 = 1),
+(a#matrix_to_atom_3_2 = 1),
+(a#matrix_to_atom_3_4 = 1),
+and([__minion_element_one([a#matrix_to_atom_1_2,a#matrix_to_atom_1_3,a#matrix_to_atom_1_4,a#matrix_to_atom_2_2,a#matrix_to_atom_2_3,a#matrix_to_atom_2_4,a#matrix_to_atom_3_2,a#matrix_to_atom_3_3,a#matrix_to_atom_3_4],__0,i),__minion_w_inintervalset(i,1,3),__minion_w_inintervalset(i,2,4);int(1..)]),
+and([FlatWeightedSumLeq([3, 1, 1],[__1, __2, 1],__0),FlatWeightedSumGeq([3, 1, 1],[__1, __2, 1],__0);int(1..)]),
+and([SumLeq([i, -1], __1),SumGeq([i, -1], __1);int(1..)]),
+and([SumLeq([i, -2], __2),SumGeq([i, -2], __2);int(1..)])
+

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.eprime
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.eprime
@@ -1,0 +1,16 @@
+language ESSENCE' 1.0
+
+$ the second domain starts at 2 now!
+find a: matrix indexed by [int(1..3),int(2..4)] of int(1..5) 
+find i: int(2..4)
+
+such that
+
+a[1,2] = 1,
+a[1,3] = 1,
+a[1,4] = 1,
+a[2,3] = 1,
+a[2,4] = 1,
+a[3,2] = 1,
+a[3,4] = 1,
+a[i,i] = i $ (2,2), (3,3)

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-minion.solutions.json
@@ -1,0 +1,1012 @@
+[
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 4
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 4
+    },
+    "__1": {
+      "Int": 1
+    },
+    "__2": {
+      "Int": 0
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 5
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 2
+    }
+  },
+  {
+    "__0": {
+      "Int": 8
+    },
+    "__1": {
+      "Int": 2
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 3
+    }
+  },
+  {
+    "__0": {
+      "Int": 8
+    },
+    "__1": {
+      "Int": 2
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 2
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 3
+    }
+  },
+  {
+    "__0": {
+      "Int": 8
+    },
+    "__1": {
+      "Int": 2
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 3
+    }
+  },
+  {
+    "__0": {
+      "Int": 8
+    },
+    "__1": {
+      "Int": 2
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 4
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 3
+    }
+  },
+  {
+    "__0": {
+      "Int": 8
+    },
+    "__1": {
+      "Int": 2
+    },
+    "__2": {
+      "Int": 1
+    },
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 3
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "AbstractLiteral": {
+                "Matrix": [
+                  [
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 1
+                    },
+                    {
+                      "Int": 5
+                    }
+                  ],
+                  {
+                    "IntDomain": [
+                      {
+                        "UnboundedR": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "i": {
+      "Int": 3
+    }
+  }
+]

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-parse.serialised.json
@@ -1,0 +1,656 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 4
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 4
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 3
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Literal": {
+                          "Int": 4
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "UnsafeIndex": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Atomic": [
+                    {
+                      "clean": false,
+                      "etype": null
+                    },
+                    {
+                      "Reference": {
+                        "UserName": "a"
+                      }
+                    }
+                  ]
+                },
+                [
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "i"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "Atomic": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "Reference": {
+                          "UserName": "i"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "UserName": "i"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 3733,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          5
+                        ]
+                      }
+                    ]
+                  },
+                  [
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            3
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            2,
+                            4
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "i"
+        },
+        {
+          "id": 3734,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      2,
+                      4
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "i"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input.expected-rewrite.serialised.json
@@ -1,0 +1,1235 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "1_2"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "1_3"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "1_4"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "2_3"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "2_4"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "3_2"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "Eq": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "RepresentedName": [
+                      {
+                        "UserName": "a"
+                      },
+                      "matrix_to_atom",
+                      "3_4"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Literal": {
+                    "Int": 1
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "MinionElementOne": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "1_2"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "1_3"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "1_4"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "2_2"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "2_3"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "2_4"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "3_2"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "3_3"
+                                ]
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "RepresentedName": [
+                                  {
+                                    "UserName": "a"
+                                  },
+                                  "matrix_to_atom",
+                                  "3_4"
+                                ]
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "MinionWInIntervalSet": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          },
+                          [
+                            1,
+                            3
+                          ]
+                        ]
+                      },
+                      {
+                        "MinionWInIntervalSet": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          },
+                          [
+                            2,
+                            4
+                          ]
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatWeightedSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 3
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatWeightedSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Int": 3
+                            },
+                            {
+                              "Int": 1
+                            },
+                            {
+                              "Int": 1
+                            }
+                          ],
+                          [
+                            {
+                              "Reference": {
+                                "MachineName": 1
+                              }
+                            },
+                            {
+                              "Reference": {
+                                "MachineName": 2
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": 1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 0
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -1
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 1
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "AbstractLiteral": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "Matrix": [
+                    [
+                      {
+                        "FlatSumLeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "FlatSumGeq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          [
+                            {
+                              "Reference": {
+                                "UserName": "i"
+                              }
+                            },
+                            {
+                              "Literal": {
+                                "Int": -2
+                              }
+                            }
+                          ],
+                          {
+                            "Reference": {
+                              "MachineName": 2
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 3,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 3735,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          5
+                        ]
+                      }
+                    ]
+                  },
+                  [
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            3
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            2,
+                            4
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "i"
+        },
+        {
+          "id": 3734,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      2,
+                      4
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "i"
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 0
+        },
+        {
+          "id": 3790,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      4,
+                      12
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 0
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 1
+        },
+        {
+          "id": 3791,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      3
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 1
+          }
+        }
+      ],
+      [
+        {
+          "MachineName": 2
+        },
+        {
+          "id": 3792,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      0,
+                      2
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "MachineName": 2
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1_2"
+          ]
+        },
+        {
+          "id": 3745,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1_2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1_3"
+          ]
+        },
+        {
+          "id": 3746,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1_3"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1_4"
+          ]
+        },
+        {
+          "id": 3747,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1_4"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2_2"
+          ]
+        },
+        {
+          "id": 3748,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2_2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2_3"
+          ]
+        },
+        {
+          "id": 3749,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2_3"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2_4"
+          ]
+        },
+        {
+          "id": 3750,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2_4"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3_2"
+          ]
+        },
+        {
+          "id": 3751,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3_2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3_3"
+          ]
+        },
+        {
+          "id": 3752,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3_3"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3_4"
+          ]
+        },
+        {
+          "id": 3753,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3_4"
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -366,6 +366,17 @@ pub enum Expression {
     #[compatible(Minion)]
     MinionWInIntervalSet(Metadata, Atom, Vec<i32>),
 
+    /// `element_one(vec, i, e)` specifies that `vec[i] = e`. This implies that i is
+    /// in the range `[1..len(vec)]`.
+    ///
+    /// Low-level Minion constraint.
+    ///
+    /// # See also
+    ///
+    ///  + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#element_one)
+    #[compatible(Minion)]
+    MinionElementOne(Metadata, Vec<Atom>, Atom, Atom),
+
     /// Declaration of an auxiliary variable.
     ///
     /// As with Savile Row, we semantically distinguish this from `Eq`.
@@ -569,6 +580,7 @@ impl Expression {
             Expression::MinionReify(_, _, _) => Some(Domain::BoolDomain),
             Expression::MinionReifyImply(_, _, _) => Some(Domain::BoolDomain),
             Expression::MinionWInIntervalSet(_, _, _) => Some(Domain::BoolDomain),
+            Expression::MinionElementOne(_, _, _, _) => Some(Domain::BoolDomain),
             Expression::Neg(_, x) => {
                 let Some(Domain::IntDomain(mut ranges)) = x.domain_of(syms) else {
                     return None;
@@ -689,6 +701,7 @@ impl Expression {
             Expression::MinionReify(_, _, _) => Some(ReturnType::Bool),
             Expression::MinionReifyImply(_, _, _) => Some(ReturnType::Bool),
             Expression::MinionWInIntervalSet(_, _, _) => Some(ReturnType::Bool),
+            Expression::MinionElementOne(_, _, _, _) => Some(ReturnType::Bool),
             Expression::AuxDeclaration(_, _, _) => Some(ReturnType::Bool),
             Expression::UnsafeMod(_, _, _) => Some(ReturnType::Int),
             Expression::SafeMod(_, _, _) => Some(ReturnType::Int),
@@ -865,7 +878,6 @@ impl Display for Expression {
 
                 write!(f, "{e1}[{args}]")
             }
-
             Expression::InDomain(_, e, domain) => {
                 write!(f, "__inDomain({e},{domain})")
             }
@@ -968,7 +980,6 @@ impl Display for Expression {
                     box3.clone()
                 )
             }
-
             Expression::FlatWatchedLiteral(_, x, l) => {
                 write!(f, "WatchedLiteral({},{})", x, l)
             }
@@ -1024,7 +1035,6 @@ impl Display for Expression {
                     total.clone()
                 )
             }
-
             Expression::FlatWeightedSumGeq(_, cs, vs, total) => {
                 write!(
                     f,
@@ -1036,6 +1046,10 @@ impl Display for Expression {
             }
             Expression::MinionPow(_, atom, atom1, atom2) => {
                 write!(f, "MinionPow({},{},{})", atom, atom1, atom2)
+            }
+            Expression::MinionElementOne(_, atoms, atom, atom1) => {
+                let atoms = atoms.iter().join(",");
+                write!(f, "__minion_element_one([{atoms}],{atom},{atom1})")
             }
         }
     }

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -353,6 +353,19 @@ pub enum Expression {
     #[compatible(Minion)]
     MinionReifyImply(Metadata, Box<Expression>, Atom),
 
+    /// `w-inintervalset(x, [a1,a2, b1,b2, … ])` ensures that the value of x belongs to one of the
+    /// intervals {a1,…,a2}, {b1,…,b2} etc.
+    ///
+    /// The list of intervals must be given in numerical order.
+    ///
+    /// Low-level Minion constraint.
+    ///
+    /// # See also
+    ///
+    ///  + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#w-inintervalset)
+    #[compatible(Minion)]
+    MinionWInIntervalSet(Metadata, Atom, Vec<i32>),
+
     /// Declaration of an auxiliary variable.
     ///
     /// As with Savile Row, we semantically distinguish this from `Eq`.
@@ -555,6 +568,7 @@ impl Expression {
             Expression::FlatWatchedLiteral(_, _, _) => Some(Domain::BoolDomain),
             Expression::MinionReify(_, _, _) => Some(Domain::BoolDomain),
             Expression::MinionReifyImply(_, _, _) => Some(Domain::BoolDomain),
+            Expression::MinionWInIntervalSet(_, _, _) => Some(Domain::BoolDomain),
             Expression::Neg(_, x) => {
                 let Some(Domain::IntDomain(mut ranges)) = x.domain_of(syms) else {
                     return None;
@@ -674,6 +688,7 @@ impl Expression {
             Expression::FlatWatchedLiteral(_, _, _) => Some(ReturnType::Bool),
             Expression::MinionReify(_, _, _) => Some(ReturnType::Bool),
             Expression::MinionReifyImply(_, _, _) => Some(ReturnType::Bool),
+            Expression::MinionWInIntervalSet(_, _, _) => Some(ReturnType::Bool),
             Expression::AuxDeclaration(_, _, _) => Some(ReturnType::Bool),
             Expression::UnsafeMod(_, _, _) => Some(ReturnType::Int),
             Expression::SafeMod(_, _, _) => Some(ReturnType::Int),
@@ -962,6 +977,10 @@ impl Display for Expression {
             }
             Expression::MinionReifyImply(_, box1, box2) => {
                 write!(f, "ReifyImply({}, {})", box1.clone(), box2.clone())
+            }
+            Expression::MinionWInIntervalSet(_, atom, intervals) => {
+                let intervals = intervals.iter().join(",");
+                write!(f, "__minion_w_inintervalset({atom},{intervals})")
             }
             Expression::AuxDeclaration(_, n, e) => {
                 write!(f, "{} =aux {}", n, e.clone())

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -46,6 +46,7 @@ fn remove_empty_expression(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
             | MinionDivEqUndefZero(_, _, _, _)
             | MinionModuloEqUndefZero(_, _, _, _)
             | MinionWInIntervalSet(_, _, _)
+            | MinionElementOne(_, _, _, _)
             | MinionPow(_, _, _, _)
             | MinionReify(_, _, _)
             | MinionReifyImply(_, _, _)

--- a/crates/conjure_core/src/rules/base.rs
+++ b/crates/conjure_core/src/rules/base.rs
@@ -45,6 +45,7 @@ fn remove_empty_expression(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
             | FlatWeightedSumLeq(_, _, _, _)
             | MinionDivEqUndefZero(_, _, _, _)
             | MinionModuloEqUndefZero(_, _, _, _)
+            | MinionWInIntervalSet(_, _, _)
             | MinionPow(_, _, _, _)
             | MinionReify(_, _, _)
             | MinionReifyImply(_, _, _)

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -274,6 +274,8 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             Some(Lit::Bool(a ^ b == c))
         }
 
+        Expr::MinionWInIntervalSet(_, _, _) => None,
+
         Expr::AllDiff(_, e) => {
             let es = e.clone().unwrap_list()?;
             let mut lits: HashSet<Lit> = HashSet::new();

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -31,9 +31,7 @@ fn apply_eval_constant(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 /// `Some(Const)` if the expression can be simplified to a constant
 pub fn eval_constant(expr: &Expr) -> Option<Lit> {
     match expr {
-        // `fromSolution()` pulls a literal value from last found solution
         Expr::FromSolution(_, _) => None,
-        // Same as Expr::Root, we should not replace the dominance relation with a constant
         Expr::DominanceRelation(_, _) => None,
         Expr::InDomain(_, e, domain) => {
             let Expr::Atomic(_, Atom::Literal(lit)) = e.as_ref() else {
@@ -118,14 +116,10 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
         Expr::Gt(_, a, b) => bin_op::<i32, bool>(|a, b| a > b, a, b).map(Lit::Bool),
         Expr::Leq(_, a, b) => bin_op::<i32, bool>(|a, b| a <= b, a, b).map(Lit::Bool),
         Expr::Geq(_, a, b) => bin_op::<i32, bool>(|a, b| a >= b, a, b).map(Lit::Bool),
-
         Expr::Not(_, expr) => un_op::<bool, bool>(|e| !e, expr).map(Lit::Bool),
-
         Expr::And(_, e) => {
             vec_lit_op::<bool, bool>(|e| e.iter().all(|&e| e), e.as_ref()).map(Lit::Bool)
         }
-        // this is done elsewhere instead - root should return a new root with a literal inside it,
-        // not a literal
         Expr::Root(_, _) => None,
         Expr::Or(_, e) => {
             vec_lit_op::<bool, bool>(|e| e.iter().any(|&e| e), e.as_ref()).map(Lit::Bool)
@@ -145,10 +139,8 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 Some(Lit::Bool(true))
             }
         }
-
         Expr::Sum(_, exprs) => vec_op::<i32, i32>(|e| e.iter().sum(), exprs).map(Lit::Int),
         Expr::Product(_, exprs) => vec_op::<i32, i32>(|e| e.iter().product(), exprs).map(Lit::Int),
-
         Expr::FlatIneq(_, a, b, c) => {
             let a: i32 = a.try_into().ok()?;
             let b: i32 = b.try_into().ok()?;
@@ -156,7 +148,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(a <= b + c))
         }
-
         Expr::FlatSumGeq(_, exprs, a) => {
             let sum = exprs.iter().try_fold(0, |acc, atom: &Atom| {
                 let n: i32 = atom.try_into().ok()?;
@@ -210,7 +201,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             Some(Lit::Bool(div == c))
         }
         Expr::Bubble(_, a, b) => bin_op::<bool, bool>(|a, b| a && b, a, b).map(Lit::Bool),
-
         Expr::MinionReify(_, a, b) => {
             let result = eval_constant(a)?;
 
@@ -219,7 +209,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(b == result))
         }
-
         Expr::MinionReifyImply(_, a, b) => {
             let result = eval_constant(a)?;
 
@@ -251,7 +240,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             let modulo = a - b * (a as f32 / b as f32).floor() as i32;
             Some(Lit::Bool(modulo == c))
         }
-
         Expr::MinionPow(_, a, b, c) => {
             // only available for positive a b c
 
@@ -273,9 +261,7 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(a ^ b == c))
         }
-
         Expr::MinionWInIntervalSet(_, _, _) => None,
-
         Expr::AllDiff(_, e) => {
             let es = e.clone().unwrap_list()?;
             let mut lits: HashSet<Lit> = HashSet::new();
@@ -358,7 +344,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(sum <= total))
         }
-
         Expr::FlatWeightedSumGeq(_, cs, vs, total) => {
             let cs: Vec<i32> = cs
                 .iter()
@@ -380,7 +365,6 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
 
             Some(Lit::Bool(x == y.abs()))
         }
-
         Expr::UnsafePow(_, a, b) | Expr::SafePow(_, a, b) => {
             let a: &Atom = a.try_into().ok()?;
             let a: i32 = a.try_into().ok()?;
@@ -395,6 +379,7 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             }
         }
         Expr::Scope(_, _) => None,
+        Expr::MinionElementOne(_, _, _, _) => None,
     }
 }
 

--- a/crates/conjure_core/src/rules/matrix/repr_matrix.rs
+++ b/crates/conjure_core/src/rules/matrix/repr_matrix.rs
@@ -3,22 +3,26 @@ use conjure_core::ast::{matrix, SymbolTable};
 use conjure_core::rule_engine::{
     register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
 };
-use itertools::Itertools;
+use itertools::{chain, izip, Itertools};
 use uniplate::Uniplate;
 
-use crate::ast::Atom;
 use crate::ast::Domain;
 use crate::ast::Literal;
 use crate::ast::Name;
+use crate::ast::{Atom, Range};
 use crate::into_matrix_expr;
+use crate::metadata::Metadata;
 
 /// Using the `matrix_to_atom`  representation rule, rewrite matrix indexing.
 #[register_rule(("Base", 2000))]
 fn index_matrix_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
+    // is this an indexing operation?
     let Expr::SafeIndex(_, subject, indices) = expr else {
         return Err(RuleNotApplicable);
     };
 
+    // ensure that we are indexing a decision variable with the representation "matrix_to_atom"
+    // selected for it.
     let Expr::Atomic(_, Atom::Reference(Name::WithRepresentation(name, reprs))) = &**subject else {
         return Err(RuleNotApplicable);
     };
@@ -27,32 +31,185 @@ fn index_matrix_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult
         return Err(RuleNotApplicable);
     }
 
-    let decl = symbols.lookup(name).unwrap();
     let repr = symbols
         .get_representation(name, &["matrix_to_atom"])
         .unwrap()[0]
         .clone();
 
-    let Some(Domain::DomainMatrix(_, _)) = decl.domain() else {
+    // ensure that the subject has a matrix domain.
+    let decl = symbols.lookup(name).unwrap();
+
+    let Some(Domain::DomainMatrix(_, index_domains)) = decl.domain() else {
         return Err(RuleNotApplicable);
     };
 
+    // checks are all ok: do the actual rewrite!
+
+    // 1. indices are constant -> find the element being indexed and only return that variable.
+    // 2. indices are not constant -> flatten matrix and return [flattened_matrix][flattened_index_expr]
+
+    // are the indices constant?
+    let mut indices_are_const = true;
     let mut indices_as_lits: Vec<Literal> = vec![];
 
     for index in indices {
-        let index = index.clone().to_literal().ok_or(RuleNotApplicable)?;
+        let Some(index) = index.clone().to_literal() else {
+            indices_are_const = false;
+            break;
+        };
         indices_as_lits.push(index);
     }
 
-    let indices_as_name = Name::RepresentedName(
-        name.clone(),
-        "matrix_to_atom".into(),
-        indices_as_lits.iter().join("_"),
-    );
+    if indices_are_const {
+        // indices are constant -> find the element being indexed and only return that variable.
+        //
+        let indices_as_name = Name::RepresentedName(
+            name.clone(),
+            "matrix_to_atom".into(),
+            indices_as_lits.iter().join("_"),
+        );
 
-    let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
+        let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
 
-    Ok(Reduction::pure(subject))
+        Ok(Reduction::pure(subject))
+    } else {
+        // indices are not constant -> flatten matrix and return [flattened_matrix][flattened_index_expr]
+
+        // For now, only supports matrices with index domains in the form int(n..m).
+        //
+        // Assuming this, to turn some x[a,b] and x[a,b,c] into x'[z]:
+        //
+        // z =                               + size(b) * (a-lb(a)) + 1 * (b-lb(b))  + 1 [2d matrix]
+        // z = (size(b)*size(c))*(a−lb(a))   + size(c) * (b−lb(b)) + 1 * (c−lb(c))  + 1 [3d matrix]
+        //
+        // where lb(a) is the lower bound for a.
+        //
+        //
+        // TODO: For other cases, we should generate table constraints that map the flat indices to
+        // the real ones.
+
+        // only need to do this for >1d matrices.
+        let n_dims = index_domains.len();
+        if n_dims <= 1 {
+            return Err(RuleNotApplicable);
+        };
+
+        // some intermediate values we need to do the above..
+
+        // [(lb(a),ub(a)),(lb(b),ub(b)),(lb(c),ub(c),...]
+        let bounds = index_domains
+            .iter()
+            .map(|dom| {
+                let Domain::IntDomain(ranges) = dom else {
+                    return Err(RuleNotApplicable);
+                };
+
+                let &[Range::Bounded(from, to)] = &ranges[..] else {
+                    return Err(RuleNotApplicable);
+                };
+
+                Ok((from, to))
+            })
+            .process_results(|it| it.collect_vec())?;
+
+        // [size(a),size(b),size(c),..]
+        let sizes = bounds
+            .iter()
+            .map(|(from, to)| (to - from) + 1)
+            .collect_vec();
+
+        // [lb(a),lb(b),lb(c),..]
+        let lower_bounds = bounds.iter().map(|(from, _)| from).collect_vec();
+
+        // from the examples above:
+        //
+        // index = (coefficients . terms) + 1
+        //
+        // where coefficients = [size(b)*size(c), size(c), 1      ]
+        //       terms =        [a-lb(a)        , b-lb(b), c-lb(c)]
+
+        // building coefficients.
+        //
+        // starting with sizes==[size(a),size(b),size(c)]
+        //
+        // ~~ skip(1) ~~>
+        //
+        // [size(b),size(c)]
+        //
+        // ~~ rev ~~>
+        //
+        // [size(c),size(b)]
+        //
+        // ~~ chain!(std::iter::once(&1),...) ~~>
+        //
+        // [1,size(c),size(b)]
+        //
+        // ~~ scan * ~~>
+        //
+        // [1,1*size(c),1*size(c)*size(b)]
+        //
+        // ~~ reverse ~~>
+        //
+        // [size(b)*size(c),size(c),1]
+        let mut coeffs: Vec<Expr> = chain!(std::iter::once(&1), sizes.iter().skip(1).rev())
+            .scan(1, |state, &x| {
+                *state *= x;
+                Some(*state)
+            })
+            .map(|x| Expr::Atomic(Metadata::new(), Atom::Literal(Literal::Int(x))))
+            .collect_vec();
+
+        coeffs.reverse();
+
+        // [(a-lb(a)),b-lb(b),c-lb(c)]
+        let terms: Vec<Expr> = izip!(indices, lower_bounds)
+            .map(|(i, lbi)| {
+                Expr::Minus(
+                    Metadata::new(),
+                    Box::new(i.clone()),
+                    Box::new(Expr::Atomic(
+                        Metadata::new(),
+                        Atom::Literal(Literal::Int(*lbi)),
+                    )),
+                )
+            })
+            .collect_vec();
+
+        // coeffs . terms
+        let mut sum_terms: Vec<Expr> = izip!(coeffs, terms)
+            .map(|(coeff, term)| Expr::Product(Metadata::new(), vec![coeff, term]))
+            .collect_vec();
+
+        // (coeffs . terms) + 1
+        sum_terms.push(Expr::Atomic(
+            Metadata::new(),
+            Atom::Literal(Literal::Int(1)),
+        ));
+
+        let flat_index = Expr::Sum(Metadata::new(), sum_terms);
+
+        // now lets get the flat matrix.
+
+        let repr_exprs = repr.expression_down(symbols)?;
+        let flat_elems = matrix::enumerate_indices(index_domains.clone())
+            .map(|xs| {
+                Name::RepresentedName(
+                    name.clone(),
+                    "matrix_to_atom".into(),
+                    xs.into_iter().join("_"),
+                )
+            })
+            .map(|x| repr_exprs[&x].clone())
+            .collect_vec();
+
+        let flat_matrix = into_matrix_expr![flat_elems];
+
+        Ok(Reduction::pure(Expr::SafeIndex(
+            Metadata::new(),
+            Box::new(flat_matrix),
+            vec![flat_index],
+        )))
+    }
 }
 
 /// Using the `matrix_to_atom` representation rule, rewrite matrix slicing.

--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -360,6 +360,7 @@ fn partial_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         MinionPow(_, _, _, _) => Err(RuleNotApplicable),
         MinionReify(_, _, _) => Err(RuleNotApplicable),
         MinionReifyImply(_, _, _) => Err(RuleNotApplicable),
+        MinionWInIntervalSet(_, _, _) => Err(RuleNotApplicable),
     }
 }
 

--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -361,6 +361,7 @@ fn partial_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         MinionReify(_, _, _) => Err(RuleNotApplicable),
         MinionReifyImply(_, _, _) => Err(RuleNotApplicable),
         MinionWInIntervalSet(_, _, _) => Err(RuleNotApplicable),
+        MinionElementOne(_, _, _, _) => Err(RuleNotApplicable),
     }
 }
 

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -225,6 +225,11 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
                     .collect_vec(),
             ))
         }
+
+        conjure_ast::Expression::MinionElementOne(_, vec, i, e) => Ok(
+            minion_ast::Constraint::ElementOne(parse_atoms(vec)?, parse_atom(i)?, parse_atom(e)?),
+        ),
+
         conjure_ast::Expression::Or(_metadata, e) => Ok(minion_ast::Constraint::WatchedOr(
             e.unwrap_matrix_unchecked()
                 .ok_or_else(|| {

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -2,6 +2,7 @@
 
 use std::cell::Ref;
 
+use itertools::Itertools as _;
 use minion_ast::Model as MinionModel;
 use minion_rs::ast as minion_ast;
 use minion_rs::error::MinionError;
@@ -214,6 +215,14 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
             Ok(minion_ast::Constraint::ModuloUndefZero(
                 (parse_atom(a)?, parse_atom(b)?),
                 parse_atom(c)?,
+            ))
+        }
+        conjure_ast::Expression::MinionWInIntervalSet(_metadata, a, xs) => {
+            Ok(minion_ast::Constraint::WInIntervalSet(
+                parse_atom(a)?,
+                xs.into_iter()
+                    .map(minion_ast::Constant::Integer)
+                    .collect_vec(),
             ))
         }
         conjure_ast::Expression::Or(_metadata, e) => Ok(minion_ast::Constraint::WatchedOr(

--- a/solvers/minion/src/run.rs
+++ b/solvers/minion/src/run.rs
@@ -561,10 +561,15 @@ unsafe fn constraint_add_args(
         //Constraint::NvalueGeq(_, _) => todo!(),
         //Constraint::NvalueLeq(_, _) => todo!(),
         //Constraint::Element(_, _, _) => todo!(),
-        //Constraint::ElementOne(_, _, _) => todo!(),
         //Constraint::ElementUndefZero(_, _, _) => todo!(),
         //Constraint::WatchElement(_, _, _) => todo!(),
         //Constraint::WatchElementOne(_, _, _) => todo!(),
+        Constraint::ElementOne(vec, j, e) => {
+            read_list(i, r_constr, vec)?;
+            read_var(i, r_constr, j)?;
+            read_var(i, r_constr, e)?;
+            Ok(())
+        }
         //Constraint::WatchElementOneUndefZero(_, _, _) => todo!(),
         //Constraint::WatchElementUndefZero(_, _, _) => todo!(),
         Constraint::WLiteral(a, b) => {
@@ -573,7 +578,11 @@ unsafe fn constraint_add_args(
             Ok(())
         }
         //Constraint::WNotLiteral(_, _) => todo!(),
-        //Constraint::WInIntervalSet(_, _) => todo!(),
+        Constraint::WInIntervalSet(var, consts) => {
+            read_var(i, r_constr, var)?;
+            read_constant_list(r_constr, consts)?;
+            Ok(())
+        }
         //Constraint::WInRange(_, _) => todo!(),
         Constraint::WInset(a, b) => {
             read_var(i, r_constr, a)?;


### PR DESCRIPTION
- **feat(minion): rewrite __inDomain(variable,...) to `w-inintervalset`**
  Rewrite the internal `__inDomain(variable,...)` constraint to the
  `w-inintervalset` constraint, allowing it to be solved with Minion.
  
  We currently only have the constant evaluation of this, which occurs
  when `variable` is a literal. This commit adds solver support for when
  variables (and thus any arbitrary expression via flattening) are
  
  As __inDomain is generated while making matrix indexing and slicing
  safe, the main use of this will be when matrices are sliced/indexed by
  decision variables. As this is not supported at all yet, it was
  difficult to construct a test case for this at time of writing. This
  work will be tested once matrices can be indexed by variables and
  arbitrary non-constant expressions.
  
  Closes: #736
  

- **feat(minion): solve matrices indexed by non-constant expressions**
  Extend `index_matrix_to_atom` rule to also support matrices indexed by
  non-constant expressions. Add support for the minion `element`
  constraint to solve these.
  
  Before this commit, this rule only supported matrices indexed by
  constants. For example, for the following model:
  
  ```
  find m: matrix indexed by [int(1..2),int(2..3)] of int(1..4)
  such that
    m[2,3]=2
  ```
  
  `index_matrix_to_atom` converts `m[2,3]` into the represented variable
  `m#matrix_to_atom_2_3`.
  
  ```
  find m#matrix_to_atom_2_1: int(1..4)
  find m#matrix_to_atom_2_2: int(1..4)
  find m#matrix_to_atom_2_3: int(1..4)
  find m#matrix_to_atom_3_1: int(1..4)
  find m#matrix_to_atom_3_2: int(1..4)
  find m#matrix_to_atom_3_3: int(1..4)
  
  such that
    m#matrix_to_atom_2_3=2
  ```
  
  When we are indexing by expressions or search variables, however, we
  cannot do this. In these scenarios, we flatten the matrix and the
  indices, turning it into a 1 dimensional indexing operation:
  
  For sake of example, consider the following model:
  
  ```
  find m: matrix indexed by [int(1..2),int(2..3)] of int(1..4)
  find i: int(1..5)
  such that
  m[i,i]
  ```
  
  This becomes:
  
  ```
  find m#matrix_to_atom_2_1: int(1..4)
  find m#matrix_to_atom_2_2: int(1..4)
  find m#matrix_to_atom_2_3: int(1..4)
  find m#matrix_to_atom_3_1: int(1..4)
  find m#matrix_to_atom_3_2: int(1..4)
  find m#matrix_to_atom_3_3: int(1..4)
  find i: int(1..5)
  
  such that
  [m#matrix_to_atom_2_1, m#matrix_to_atom_2_2,
   m#matrix_to_atom_2_3, m#matrix_to_atom_3_1,
   m#matrix_to_atom_3_2, m#matrix_to_atom_3_3][i + 3*(i-1)]
  ```
  
As the result of this rule is a 1 dimensional matrix slice, it can be solved by Minion using the `element_one` constraint.
  
  The index is calculated as follows:
  
    For each dimension...
  
      1. Convert the given index into one that goes from 1..s, where s is
         the size of the dimension in question.
  
      2. If it is not the first dimension, add (index-1) * size of dimension
  
      3. If it is the dimension, add it to the previous indices.
  
  The conversion done in step 1 is possible but annoying to do for any
  finite domain, but for now only domains in the form int(n..m) are
  supported, as the conversion for these is trivial.
  