### PR TITLE
cli!: tidy things into sub-commands

### DIFF
--- a/conjure_oxide/src/cli.rs
+++ b/conjure_oxide/src/cli.rs
@@ -1,0 +1,71 @@
+use clap::{arg, command, Args, Parser, Subcommand};
+
+use conjure_oxide::SolverFamily;
+
+use crate::solve;
+static AFTER_HELP_TEXT: &str = include_str!("help_text.txt");
+
+/// All subcommands of conjure-oxide
+#[derive(Clone, Debug, Subcommand)]
+pub enum Command {
+    /// Solve a model
+    Solve(solve::Args),
+    /// Print the JSON info file schema
+    PrintJsonSchema,
+}
+
+/// Global command line arguments.
+#[derive(Clone, Debug, Parser)]
+#[command(author, about, long_about = None, after_long_help=AFTER_HELP_TEXT)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub subcommand: Command,
+
+    #[command(flatten)]
+    pub global_args: GlobalArgs,
+
+    /// Print version
+    #[arg(long = "version", short = 'V')]
+    pub version: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct GlobalArgs {
+    /// Extra rule sets to enable
+    #[arg(long, value_name = "EXTRA_RULE_SETS", global = true)]
+    pub extra_rule_sets: Vec<String>,
+
+    /// Solver family to use
+    #[arg(long, value_enum, value_name = "SOLVER", short = 's', global = true)]
+    pub solver: Option<SolverFamily>,
+
+    /// Use the in development dirty-clean optimising rewriter
+    #[arg(long, default_value_t = false, global = true)]
+    pub use_optimising_rewriter: bool,
+
+    /// Log verbosely
+    #[arg(long, short = 'v', help = "Log verbosely to sterr", global = true)]
+    pub verbose: bool,
+
+    // --no-x flag disables --x flag : https://jwodder.github.io/kbits/posts/clap-bool-negate/
+    /// Check for multiple equally applicable rules, exiting if any are found.
+    ///
+    /// Only compatible with the default rewriter.
+    #[arg(
+        long,
+        overrides_with = "_no_check_equally_applicable_rules",
+        default_value_t = false,
+        global = true
+    )]
+    pub check_equally_applicable_rules: bool,
+
+    /// Do not check for multiple equally applicable rules [default].
+    ///
+    /// Only compatible with the default rewriter.
+    #[arg(long, global = true)]
+    pub _no_check_equally_applicable_rules: bool,
+
+    /// Use the native parser instead of Conjure's.
+    #[arg(long, default_value_t = false, global = true)]
+    pub enable_native_parser: bool,
+}

--- a/conjure_oxide/src/cli.rs
+++ b/conjure_oxide/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{arg, command, Args, Parser, Subcommand};
 
 use conjure_oxide::SolverFamily;
 
-use crate::solve;
+use crate::{solve, test_solve};
 static AFTER_HELP_TEXT: &str = include_str!("help_text.txt");
 
 /// All subcommands of conjure-oxide
@@ -12,6 +12,11 @@ pub enum Command {
     Solve(solve::Args),
     /// Print the JSON info file schema
     PrintJsonSchema,
+    /// Tests whether the Essence model is solvable with Conjure Oxide, and whether it gets the
+    /// same solutions as Conjure.
+    ///
+    /// Return-code will be 0 if the solutions match, 1 if they don't, and >1 on crash.
+    TestSolve(test_solve::Args),
 }
 
 /// Global command line arguments.
@@ -38,10 +43,6 @@ pub struct GlobalArgs {
     /// Solver family to use
     #[arg(long, value_enum, value_name = "SOLVER", short = 's', global = true)]
     pub solver: Option<SolverFamily>,
-
-    /// Use the in development dirty-clean optimising rewriter
-    #[arg(long, default_value_t = false, global = true)]
-    pub use_optimising_rewriter: bool,
 
     /// Log verbosely
     #[arg(long, short = 'v', help = "Log verbosely to sterr", global = true)]

--- a/conjure_oxide/src/help_text.txt
+++ b/conjure_oxide/src/help_text.txt
@@ -24,9 +24,9 @@ LOGGING RULE TRACES
 For example, to see TRACE logs in a pretty format (mainly useful for
 debugging):
 
-    $ RUST_LOG=trace conjure-oxide --verbose <model>
+    $ RUST_LOG=trace conjure-oxide solve --verbose <model>
 
     # or through cargo:
-    $ RUST_LOG=trace cargo run -- --verbose <model>
+    $ RUST_LOG=trace cargo run -- solve --verbose <model>
 
 

--- a/conjure_oxide/src/print_info_schema.rs
+++ b/conjure_oxide/src/print_info_schema.rs
@@ -1,0 +1,11 @@
+//! conjure-oxide print-info-schema subcommand
+
+use conjure_core::context::Context;
+use schemars::schema_for;
+
+/// Prints the schema for the JSON info file.
+pub fn run_print_info_schema_command() -> anyhow::Result<()> {
+    let schema = schema_for!(Context);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+    Ok(())
+}

--- a/conjure_oxide/src/solve.rs
+++ b/conjure_oxide/src/solve.rs
@@ -1,0 +1,199 @@
+//! conjure_oxide solve sub-command
+#![allow(clippy::unwrap_used)]
+use std::{fs::File, io::Write as _, path::PathBuf, process::exit};
+
+use anyhow::{anyhow, ensure};
+use conjure_core::{
+    context::Context,
+    rule_engine::{resolve_rule_sets, rewrite_naive},
+    Model,
+};
+use conjure_oxide::{
+    defaults::DEFAULT_RULE_SETS,
+    find_conjure::conjure_executable,
+    get_rules, model_from_json,
+    utils::{
+        conjure::{get_minion_solutions, minion_solutions_to_json},
+        essence_parser::parse_essence_file_native,
+    },
+    SolverFamily,
+};
+use serde_json::to_string_pretty;
+
+use crate::cli::GlobalArgs;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Args {
+    /// The input Essence file
+    #[arg(value_name = "INPUT_ESSENCE")]
+    pub input_file: PathBuf,
+
+    /// Save execution info as JSON to the given filepath.
+    #[arg(long)]
+    pub info_json_path: Option<PathBuf>,
+
+    /// Do not run the solver.
+    ///
+    /// The rewritten model is printed to stdout in an Essence-style syntax (but is not necessarily
+    /// valid Essence).
+    #[arg(long, default_value_t = false)]
+    pub no_run_solver: bool,
+
+    /// Number of solutions to return. 0 returns all solutions
+    #[arg(long, default_value_t = 0, short = 'n')]
+    pub number_of_solutions: i32,
+
+    /// Save solutions to the given JSON file
+    #[arg(long, short = 'o')]
+    pub output: Option<PathBuf>,
+}
+
+pub fn run_solve_command(global_args: GlobalArgs, solve_args: Args) -> anyhow::Result<()> {
+    let target_family = global_args.solver.unwrap_or(SolverFamily::Minion);
+    let mut extra_rule_sets: Vec<&str> = DEFAULT_RULE_SETS.to_vec();
+    for rs in &global_args.extra_rule_sets {
+        extra_rule_sets.push(rs.as_str());
+    }
+
+    ensure!(
+        target_family == SolverFamily::Minion,
+        "Only the Minion solver is currently supported!"
+    );
+
+    let rule_sets = match resolve_rule_sets(target_family, &extra_rule_sets) {
+        Ok(rs) => rs,
+        Err(e) => {
+            tracing::error!("Error resolving rule sets: {}", e);
+            exit(1);
+        }
+    };
+
+    let pretty_rule_sets = rule_sets
+        .iter()
+        .map(|rule_set| rule_set.name)
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    tracing::info!("Enabled rule sets: [{}]", pretty_rule_sets);
+    tracing::info!(
+        target: "file",
+        "Rule sets: {}",
+        pretty_rule_sets
+    );
+
+    let rules = get_rules(&rule_sets)?.into_iter().collect::<Vec<_>>();
+    tracing::info!(
+        target: "file",
+        "Rules: {}",
+        rules.iter().map(|rd| format!("{}", rd)).collect::<Vec<_>>().join("\n")
+    );
+    let input = solve_args.input_file.clone();
+    tracing::info!(target: "file", "Input file: {}", input.display());
+    let input_file: &str = input.to_str().ok_or(anyhow!(
+        "Given input_file could not be converted to a string"
+    ))?;
+
+    /******************************************************/
+    /*        Parse essence to json using Conjure         */
+    /******************************************************/
+
+    let context = Context::new_ptr(
+        target_family,
+        extra_rule_sets.iter().map(|rs| rs.to_string()).collect(),
+        rules,
+        rule_sets.clone(),
+    );
+    context.write().unwrap().file_name = Some(input.to_str().expect("").into());
+
+    let mut model;
+    if global_args.enable_native_parser {
+        model = parse_essence_file_native(input_file, context.clone())?;
+    } else {
+        conjure_executable()
+            .map_err(|e| anyhow!("Could not find correct conjure executable: {}", e))?;
+
+        let mut cmd = std::process::Command::new("conjure");
+        let output = cmd
+            .arg("pretty")
+            .arg("--output-format=astjson")
+            .arg(input_file)
+            .output()?;
+
+        let conjure_stderr = String::from_utf8(output.stderr)?;
+
+        ensure!(conjure_stderr.is_empty(), conjure_stderr);
+
+        let astjson = String::from_utf8(output.stdout)?;
+
+        if cfg!(feature = "extra-rule-checks") {
+            tracing::info!("extra-rule-checks: enabled");
+        } else {
+            tracing::info!("extra-rule-checks: disabled");
+        }
+
+        model = model_from_json(&astjson, context.clone())?;
+    }
+
+    tracing::info!("Initial model: \n{}\n", model);
+
+    tracing::info!("Rewriting model...");
+
+    if !global_args.use_optimising_rewriter {
+        tracing::info!("Rewriting model...");
+        model = rewrite_naive(
+            &model,
+            &rule_sets,
+            global_args.check_equally_applicable_rules,
+        )?;
+    }
+
+    tracing::info!("Rewritten model: \n{}\n", model);
+
+    if solve_args.no_run_solver {
+        println!("{}", model);
+    } else {
+        run_solver(&solve_args, model)?;
+    }
+
+    // still do postamble even if we didn't run the solver
+    if let Some(ref path) = solve_args.info_json_path {
+        let context_obj = context.read().unwrap().clone();
+        let generated_json = &serde_json::to_value(context_obj)?;
+        let pretty_json = serde_json::to_string_pretty(&generated_json)?;
+        File::create(path)?.write_all(pretty_json.as_bytes())?;
+    }
+    Ok(())
+}
+
+fn run_solver(cmd_args: &Args, model: Model) -> anyhow::Result<()> {
+    let out_file: Option<File> = match &cmd_args.output {
+        None => None,
+        Some(pth) => Some(
+            File::options()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(pth)?,
+        ),
+    };
+
+    let solutions = get_minion_solutions(model, cmd_args.number_of_solutions)?; // ToDo we need to properly set the solver adaptor here, not hard code minion
+    tracing::info!(target: "file", "Solutions: {}", minion_solutions_to_json(&solutions));
+
+    let solutions_json = minion_solutions_to_json(&solutions);
+    let solutions_str = to_string_pretty(&solutions_json)?;
+    match out_file {
+        None => {
+            println!("Solutions:");
+            println!("{}", solutions_str);
+        }
+        Some(mut outf) => {
+            outf.write_all(solutions_str.as_bytes())?;
+            println!(
+                "Solutions saved to {:?}",
+                &cmd_args.output.clone().unwrap().canonicalize()?
+            )
+        }
+    }
+    Ok(())
+}

--- a/conjure_oxide/src/test_solve.rs
+++ b/conjure_oxide/src/test_solve.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+use std::process::exit;
+use std::sync::Arc;
+
+use conjure_oxide::utils::conjure::{
+    get_minion_solutions, get_solutions_from_conjure, minion_solutions_to_json,
+};
+use conjure_oxide::utils::testing::normalize_solutions_for_comparison;
+
+use crate::cli::GlobalArgs;
+use crate::solve;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Args {
+    /// The input Essence file
+    #[arg(value_name = "INPUT_ESSENCE")]
+    pub input_file: PathBuf,
+}
+
+pub fn run_test_solve_command(global_args: GlobalArgs, local_args: Args) -> anyhow::Result<()> {
+    // stealing most of the steps of the solve command, except the solver stuff.
+    let input_file = local_args.input_file.clone();
+
+    let context = solve::init_context(&global_args, input_file.clone())?;
+    let model = solve::parse(&global_args, Arc::clone(&context))?;
+    let rewritten_model = solve::rewrite(model, &global_args, Arc::clone(&context))?;
+
+    // now we are stealing from the integration tester
+
+    let our_solutions = get_minion_solutions(rewritten_model, 0)?;
+    let conjure_solutions =
+        get_solutions_from_conjure(input_file.to_str().unwrap(), Arc::clone(&context))?;
+
+    let our_solutions = normalize_solutions_for_comparison(&our_solutions);
+    let conjure_solutions = normalize_solutions_for_comparison(&conjure_solutions);
+
+    let mut our_solutions_json = minion_solutions_to_json(&our_solutions);
+    let mut conjure_solutions_json = minion_solutions_to_json(&conjure_solutions);
+
+    our_solutions_json.sort_all_objects();
+    conjure_solutions_json.sort_all_objects();
+
+    if our_solutions_json == conjure_solutions_json {
+        eprintln!("Success: solutions match!");
+        exit(0);
+    } else {
+        eprintln!("=== our solutions:");
+        eprintln!("{}", our_solutions_json);
+        eprintln!("=== conjure's solutions:");
+        eprintln!("{}", conjure_solutions_json);
+        eprintln!("Failure: solutions do not match!");
+        exit(1);
+    }
+}

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -1,13 +1,15 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 
+use itertools::Itertools as _;
 use std::fs::File;
 use std::fs::{read_to_string, OpenOptions};
 use std::hash::Hash;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
+use uniplate::Uniplate;
 
-use conjure_core::ast::SerdeModel;
+use conjure_core::ast::{AbstractLiteral, Domain, SerdeModel};
 use conjure_core::context::Context;
 use serde_json::{json, Error as JsonError, Value as JsonValue};
 
@@ -214,4 +216,67 @@ pub fn read_human_rule_trace(
         .collect();
 
     Ok(rules_trace)
+}
+
+#[doc(hidden)]
+pub fn normalize_solutions_for_comparison(
+    input_solutions: &[BTreeMap<Name, Literal>],
+) -> Vec<BTreeMap<Name, Literal>> {
+    let mut normalized = input_solutions.to_vec();
+
+    for solset in &mut normalized {
+        // remove machine names
+        let keys_to_remove: Vec<Name> = solset
+            .keys()
+            .filter(|k| matches!(k, Name::MachineName(_)))
+            .cloned()
+            .collect();
+        for k in keys_to_remove {
+            solset.remove(&k);
+        }
+
+        let mut updates = vec![];
+        for (k, v) in solset.clone() {
+            if let Name::UserName(_) = k {
+                match v {
+                    Literal::Bool(true) => updates.push((k, Literal::Int(1))),
+                    Literal::Bool(false) => updates.push((k, Literal::Int(0))),
+                    Literal::AbstractLiteral(AbstractLiteral::Matrix(elems, _)) => {
+                        // make all domains the same (this is just in the tester so the types dont
+                        // actually matter)
+
+                        let mut matrix = AbstractLiteral::Matrix(elems, Domain::IntDomain(vec![]));
+                        matrix =
+                            matrix.transform(Arc::new(
+                                move |x: AbstractLiteral<Literal>| match x {
+                                    AbstractLiteral::Matrix(items, _) => {
+                                        let items = items
+                                            .into_iter()
+                                            .map(|x| match x {
+                                                Literal::Bool(false) => Literal::Int(0),
+                                                Literal::Bool(true) => Literal::Int(1),
+                                                x => x,
+                                            })
+                                            .collect_vec();
+
+                                        AbstractLiteral::Matrix(items, Domain::IntDomain(vec![]))
+                                    }
+                                    x => x,
+                                },
+                            ));
+                        updates.push((k, Literal::AbstractLiteral(matrix)));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        for (k, v) in updates {
+            solset.insert(k, v);
+        }
+    }
+
+    // Remove duplicates
+    normalized = normalized.into_iter().unique().collect();
+    normalized
 }


### PR DESCRIPTION
Tidy the CLI code, and add sub-commands.

As a consequence of this latter change, to run conjure oxide, one must
now do `cargo run -- solve <input>` or `conjure_oxide solve <input>`.
This is because I could not find a good way to do default arguments with
clap.

Other tidying includes:

* Move CLI flags into a separate file
* Move logging setup into its own function
* Move things for each subcommand into their own files.

The motivation of this work is to allow more subcommands to be added in
the future.

Before this change, we had the `--print-info-schema` flag that ignored
all other flags, just printed the schema, and exited. Using proper
subcommands is a more scalable way to add features like this, with the
added advantage that subcommands can have their own arguments.
