### PR TITLE
feat(cli): add test-solve subcommand

### DIFF
--- a/conjure_oxide/src/cli.rs
+++ b/conjure_oxide/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{arg, command, Args, Parser, Subcommand};
 
 use conjure_oxide::SolverFamily;
 
-use crate::solve;
+use crate::{solve, test_solve};
 static AFTER_HELP_TEXT: &str = include_str!("help_text.txt");
 
 /// All subcommands of conjure-oxide
@@ -12,6 +12,11 @@ pub enum Command {
     Solve(solve::Args),
     /// Print the JSON info file schema
     PrintJsonSchema,
+    /// Tests whether the Essence model is solvable with Conjure Oxide, and whether it gets the
+    /// same solutions as Conjure.
+    ///
+    /// Return-code will be 0 if the solutions match, 1 if they don't, and >1 on crash.
+    TestSolve(test_solve::Args),
 }
 
 /// Global command line arguments.
@@ -38,10 +43,6 @@ pub struct GlobalArgs {
     /// Solver family to use
     #[arg(long, value_enum, value_name = "SOLVER", short = 's', global = true)]
     pub solver: Option<SolverFamily>,
-
-    /// Use the in development dirty-clean optimising rewriter
-    #[arg(long, default_value_t = false, global = true)]
-    pub use_optimising_rewriter: bool,
 
     /// Log verbosely
     #[arg(long, short = 'v', help = "Log verbosely to sterr", global = true)]

--- a/conjure_oxide/src/test_solve.rs
+++ b/conjure_oxide/src/test_solve.rs
@@ -1,0 +1,54 @@
+use std::path::PathBuf;
+use std::process::exit;
+use std::sync::Arc;
+
+use conjure_oxide::utils::conjure::{
+    get_minion_solutions, get_solutions_from_conjure, minion_solutions_to_json,
+};
+use conjure_oxide::utils::testing::normalize_solutions_for_comparison;
+
+use crate::cli::GlobalArgs;
+use crate::solve;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Args {
+    /// The input Essence file
+    #[arg(value_name = "INPUT_ESSENCE")]
+    pub input_file: PathBuf,
+}
+
+pub fn run_test_solve_command(global_args: GlobalArgs, local_args: Args) -> anyhow::Result<()> {
+    // stealing most of the steps of the solve command, except the solver stuff.
+    let input_file = local_args.input_file.clone();
+
+    let context = solve::init_context(&global_args, input_file.clone())?;
+    let model = solve::parse(&global_args, Arc::clone(&context))?;
+    let rewritten_model = solve::rewrite(model, &global_args, Arc::clone(&context))?;
+
+    // now we are stealing from the integration tester
+
+    let our_solutions = get_minion_solutions(rewritten_model, 0)?;
+    let conjure_solutions =
+        get_solutions_from_conjure(input_file.to_str().unwrap(), Arc::clone(&context))?;
+
+    let our_solutions = normalize_solutions_for_comparison(&our_solutions);
+    let conjure_solutions = normalize_solutions_for_comparison(&conjure_solutions);
+
+    let mut our_solutions_json = minion_solutions_to_json(&our_solutions);
+    let mut conjure_solutions_json = minion_solutions_to_json(&conjure_solutions);
+
+    our_solutions_json.sort_all_objects();
+    conjure_solutions_json.sort_all_objects();
+
+    if our_solutions_json == conjure_solutions_json {
+        eprintln!("Success: solutions match!");
+        exit(0);
+    } else {
+        eprintln!("=== our solutions:");
+        eprintln!("{}", our_solutions_json);
+        eprintln!("=== conjure's solutions:");
+        eprintln!("{}", conjure_solutions_json);
+        eprintln!("Failure: solutions do not match!");
+        exit(1);
+    }
+}

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -1,13 +1,15 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 
+use itertools::Itertools as _;
 use std::fs::File;
 use std::fs::{read_to_string, OpenOptions};
 use std::hash::Hash;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
+use uniplate::Uniplate;
 
-use conjure_core::ast::SerdeModel;
+use conjure_core::ast::{AbstractLiteral, Domain, SerdeModel};
 use conjure_core::context::Context;
 use serde_json::{json, Error as JsonError, Value as JsonValue};
 
@@ -214,4 +216,67 @@ pub fn read_human_rule_trace(
         .collect();
 
     Ok(rules_trace)
+}
+
+#[doc(hidden)]
+pub fn normalize_solutions_for_comparison(
+    input_solutions: &[BTreeMap<Name, Literal>],
+) -> Vec<BTreeMap<Name, Literal>> {
+    let mut normalized = input_solutions.to_vec();
+
+    for solset in &mut normalized {
+        // remove machine names
+        let keys_to_remove: Vec<Name> = solset
+            .keys()
+            .filter(|k| matches!(k, Name::MachineName(_)))
+            .cloned()
+            .collect();
+        for k in keys_to_remove {
+            solset.remove(&k);
+        }
+
+        let mut updates = vec![];
+        for (k, v) in solset.clone() {
+            if let Name::UserName(_) = k {
+                match v {
+                    Literal::Bool(true) => updates.push((k, Literal::Int(1))),
+                    Literal::Bool(false) => updates.push((k, Literal::Int(0))),
+                    Literal::AbstractLiteral(AbstractLiteral::Matrix(elems, _)) => {
+                        // make all domains the same (this is just in the tester so the types dont
+                        // actually matter)
+
+                        let mut matrix = AbstractLiteral::Matrix(elems, Domain::IntDomain(vec![]));
+                        matrix =
+                            matrix.transform(Arc::new(
+                                move |x: AbstractLiteral<Literal>| match x {
+                                    AbstractLiteral::Matrix(items, _) => {
+                                        let items = items
+                                            .into_iter()
+                                            .map(|x| match x {
+                                                Literal::Bool(false) => Literal::Int(0),
+                                                Literal::Bool(true) => Literal::Int(1),
+                                                x => x,
+                                            })
+                                            .collect_vec();
+
+                                        AbstractLiteral::Matrix(items, Domain::IntDomain(vec![]))
+                                    }
+                                    x => x,
+                                },
+                            ));
+                        updates.push((k, Literal::AbstractLiteral(matrix)));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        for (k, v) in updates {
+            solset.insert(k, v);
+        }
+    }
+
+    // Remove duplicates
+    normalized = normalized.into_iter().unique().collect();
+    normalized
 }


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #742

## Chain of upstream PRs as of 2025-03-23

* PR #742:
  `main` ← `nik/validate-conjure-flag`

  * **PR #743 (THIS ONE)**:
    `nik/validate-conjure-flag` ← `nik/validate-conjure-flag-2`

<!-- end git-machete generated -->
---

Add test-solve subcommand. This subcommand runs a model through Conjure
Oxide and Conjure, and ensures that the solutions returned are the same.

This is similar to the ACCEPT=true mode of the integration tester, but
can be called ad-hoc on any input file, so is more useful for scripting.

This command mostly uses functionality already found in the solve
subcommand and the integration tester. This commit moves some stuff
found in these into functions, to ensure that this subcommand stays in
sync with changes in both.