### PR TITLE
fix: update new_top only if reduction contains new_top

### DIFF
--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -227,7 +227,9 @@ impl MorphRule<Expression, SymbolTable> for &Rule<'_> {
     ) -> Option<Expression> {
         let reduction = Rule::apply(self, subtree, meta).ok()?;
         commands.mut_meta(Box::new(|m: &mut SymbolTable| m.extend(reduction.symbols)));
-        commands.transform(Box::new(|m| m.extend_root(reduction.new_top)));
+        if !reduction.new_top.is_empty() {
+            commands.transform(Box::new(|m| m.extend_root(reduction.new_top)));
+        }
         Some(reduction.new_expression)
     }
 }


### PR DESCRIPTION
This PR is created to fix #734