### PR TITLE
fix: `substitute_domain_lettings` bug in nested scopes

### DIFF
--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
@@ -1,0 +1,2 @@
+use_naive_parser=false
+solve_with_minion=false

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
@@ -1,2 +1,2 @@
 use_naive_parser=false
-solve_with_minion=false
+solve_with_minion=true

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
@@ -9,6 +9,12 @@ and([(a[i] = i) | i: DOM,])
 
 --
 
+and([(a[i] = i) | i: DOM,]), 
+   ~~> substitute_domain_lettings ([("Base", 5000)]) 
+and([(a[i] = i) | i: DOM,]) 
+
+--
+
 , 
    ~~> eval_root ([("Constant", 9001)]) 
 true 
@@ -18,16 +24,189 @@ true
 true, 
    ~~> substitute_domain_lettings ([("Base", 5000)]) 
 true 
+
+--
+
+[(a[i] = i) | i: int(1..3),true], 
+   ~~> expand_comprehension ([("Base", 1000)]) 
+[(a[1] = 1),(a[2] = 2),(a[3] = 3);int(1..)] 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
 new variables:
-  find a: matrix indexed by [[DOM]] of DOM
+  find a#matrix_to_atom_1: int(1..3)
+  find a#matrix_to_atom_2: int(1..3)
+  find a#matrix_to_atom_3: int(1..3)
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a, 
+   ~~> select_representation ([("Base", 8000)]) 
+a#matrix_to_atom 
+
+--
+
+a#matrix_to_atom[1], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[1] @ and([__inDomain(1,int(1..3));int(1..)])} 
+
+--
+
+and([__inDomain(1,int(1..3));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[1] @ true} = 1), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[1] = 1) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[1] = 1) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[1] = 1),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1] = 1),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[1] = 1);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[1] = 1);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[1] = 1) 
+
+--
+
+a#matrix_to_atom[2], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[2] @ and([__inDomain(2,int(1..3));int(1..)])} 
+
+--
+
+and([__inDomain(2,int(1..3));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[2] @ true} = 2), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[2] = 2) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[2] = 2) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[2] = 2),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2] = 2),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[2] = 2);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[2] = 2);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[2] = 2) 
+
+--
+
+a#matrix_to_atom[3], 
+   ~~> index_to_bubble ([("Bubble", 6000)]) 
+{a#matrix_to_atom[3] @ and([__inDomain(3,int(1..3));int(1..)])} 
+
+--
+
+and([__inDomain(3,int(1..3));int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+({a#matrix_to_atom[3] @ true} = 3), 
+   ~~> bubble_up ([("Bubble", 8900)]) 
+{(a#matrix_to_atom[3] = 3) @ and([true;int(1..)])} 
+
+--
+
+and([true;int(1..)]), 
+   ~~> apply_eval_constant ([("Constant", 9001)]) 
+true 
+
+--
+
+{(a#matrix_to_atom[3] = 3) @ true}, 
+   ~~> expand_bubble ([("Bubble", 8900)]) 
+and([(a#matrix_to_atom[3] = 3),true;int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3] = 3),true;int(1..)]), 
+   ~~> partial_evaluator ([("Base", 9000)]) 
+and([(a#matrix_to_atom[3] = 3);int(1..)]) 
+
+--
+
+and([(a#matrix_to_atom[3] = 3);int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+(a#matrix_to_atom[3] = 3) 
+
+--
+
+a#matrix_to_atom[1], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_1 
+
+--
+
+a#matrix_to_atom[2], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_2 
+
+--
+
+a#matrix_to_atom[3], 
+   ~~> index_matrix_to_atom ([("Base", 2000)]) 
+a#matrix_to_atom_3 
+
 --
 
 Final model:
 
 letting DOM be domain int(1..3)
-find a: matrix indexed by [[DOM]] of DOM
+find a: matrix indexed by [[int(1..3)]] of int(1..3)
+find a#matrix_to_atom_1: int(1..3)
+find a#matrix_to_atom_2: int(1..3)
+find a#matrix_to_atom_3: int(1..3)
 
 such that
 
-and([(a[i] = i) | a: matrix indexed by [[DOM]] of DOM,i: int(1..3),true])
+and([(a#matrix_to_atom_1 = 1),(a#matrix_to_atom_2 = 2),(a#matrix_to_atom_3 = 3);int(1..)])
 

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
@@ -1,0 +1,33 @@
+Model before rewriting:
+
+letting DOM be domain int(1..3)
+find a: matrix indexed by [[DOM]] of DOM
+
+such that
+
+and([(a[i] = i) | i: DOM,])
+
+--
+
+, 
+   ~~> eval_root ([("Constant", 9001)]) 
+true 
+
+--
+
+true, 
+   ~~> substitute_domain_lettings ([("Base", 5000)]) 
+true 
+new variables:
+  find a: matrix indexed by [[DOM]] of DOM
+--
+
+Final model:
+
+letting DOM be domain int(1..3)
+find a: matrix indexed by [[DOM]] of DOM
+
+such that
+
+and([(a[i] = i) | a: matrix indexed by [[DOM]] of DOM,i: int(1..3),true])
+

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.eprime
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.eprime
@@ -1,0 +1,16 @@
+language ESSENCE' 1.0
+
+letting DOM be domain int(1..3)
+find a: matrix [DOM] of DOM 
+
+
+$ currently, when substituting DOM in the below comprehension, a and all its
+$ representations are added to the comprehensions' symbol table!
+
+$ (this is probably because substitute_domain_lettings iterates over and
+$ updates the symbol table deeply. However, update_insert only looks over the
+$ local symbol table, and inserts variables if they don't exist locally).
+
+such that
+
+and([a[i] = i |i:DOM])

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-minion.solutions.json
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-minion.solutions.json
@@ -1,0 +1,28 @@
+[
+  {
+    "a": {
+      "AbstractLiteral": {
+        "Matrix": [
+          [
+            {
+              "Int": 1
+            },
+            {
+              "Int": 2
+            },
+            {
+              "Int": 3
+            }
+          ],
+          {
+            "IntDomain": [
+              {
+                "UnboundedR": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+]

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-parse.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-parse.serialised.json
@@ -1,0 +1,193 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Comprehension": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "expression": {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeIndex": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "i"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "induction_vars": [
+                    {
+                      "UserName": "i"
+                    }
+                  ],
+                  "submodel": {
+                    "constraints": {
+                      "Root": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        []
+                      ]
+                    },
+                    "symbols": {
+                      "id": 1,
+                      "next_machine_name": 0,
+                      "parent": 0,
+                      "table": [
+                        [
+                          {
+                            "UserName": "i"
+                          },
+                          {
+                            "id": 15092,
+                            "kind": {
+                              "DecisionVariable": {
+                                "domain": {
+                                  "DomainReference": {
+                                    "UserName": "DOM"
+                                  }
+                                }
+                              }
+                            },
+                            "name": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": 0,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "DOM"
+        },
+        {
+          "id": 15090,
+          "kind": {
+            "DomainLetting": {
+              "IntDomain": [
+                {
+                  "Bounded": [
+                    1,
+                    3
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "DOM"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 15091,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "DomainReference": {
+                      "UserName": "DOM"
+                    }
+                  },
+                  [
+                    {
+                      "DomainReference": {
+                        "UserName": "DOM"
+                      }
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-rewrite.serialised.json
@@ -1,0 +1,243 @@
+{
+  "constraints": {
+    "Root": [
+      {
+        "clean": false,
+        "etype": null
+      },
+      [
+        {
+          "And": [
+            {
+              "clean": false,
+              "etype": null
+            },
+            {
+              "Comprehension": [
+                {
+                  "clean": false,
+                  "etype": null
+                },
+                {
+                  "expression": {
+                    "Eq": [
+                      {
+                        "clean": false,
+                        "etype": null
+                      },
+                      {
+                        "UnsafeIndex": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "UserName": "a"
+                                }
+                              }
+                            ]
+                          },
+                          [
+                            {
+                              "Atomic": [
+                                {
+                                  "clean": false,
+                                  "etype": null
+                                },
+                                {
+                                  "Reference": {
+                                    "UserName": "i"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Reference": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "induction_vars": [
+                    {
+                      "UserName": "i"
+                    }
+                  ],
+                  "submodel": {
+                    "constraints": {
+                      "Root": [
+                        {
+                          "clean": false,
+                          "etype": null
+                        },
+                        [
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Bool": true
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    "symbols": {
+                      "id": 65,
+                      "next_machine_name": 0,
+                      "parent": 69,
+                      "table": [
+                        [
+                          {
+                            "UserName": "a"
+                          },
+                          {
+                            "id": 15091,
+                            "kind": {
+                              "DecisionVariable": {
+                                "domain": {
+                                  "DomainMatrix": [
+                                    {
+                                      "DomainReference": {
+                                        "UserName": "DOM"
+                                      }
+                                    },
+                                    [
+                                      {
+                                        "DomainReference": {
+                                          "UserName": "DOM"
+                                        }
+                                      }
+                                    ]
+                                  ]
+                                }
+                              }
+                            },
+                            "name": {
+                              "UserName": "a"
+                            }
+                          }
+                        ],
+                        [
+                          {
+                            "UserName": "i"
+                          },
+                          {
+                            "id": 15093,
+                            "kind": {
+                              "DecisionVariable": {
+                                "domain": {
+                                  "IntDomain": [
+                                    {
+                                      "Bounded": [
+                                        1,
+                                        3
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "name": {
+                              "UserName": "i"
+                            }
+                          }
+                        ]
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": 69,
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "UserName": "DOM"
+        },
+        {
+          "id": 15090,
+          "kind": {
+            "DomainLetting": {
+              "IntDomain": [
+                {
+                  "Bounded": [
+                    1,
+                    3
+                  ]
+                }
+              ]
+            }
+          },
+          "name": {
+            "UserName": "DOM"
+          }
+        }
+      ],
+      [
+        {
+          "UserName": "a"
+        },
+        {
+          "id": 15091,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "DomainMatrix": [
+                  {
+                    "DomainReference": {
+                      "UserName": "DOM"
+                    }
+                  },
+                  [
+                    {
+                      "DomainReference": {
+                        "UserName": "DOM"
+                      }
+                    }
+                  ]
+                ]
+              }
+            }
+          },
+          "name": {
+            "UserName": "a"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input.expected-rewrite.serialised.json
@@ -13,20 +13,16 @@
               "etype": null
             },
             {
-              "Comprehension": [
+              "AbstractLiteral": [
                 {
                   "clean": false,
                   "etype": null
                 },
                 {
-                  "expression": {
-                    "Eq": [
+                  "Matrix": [
+                    [
                       {
-                        "clean": false,
-                        "etype": null
-                      },
-                      {
-                        "UnsafeIndex": [
+                        "Eq": [
                           {
                             "clean": false,
                             "etype": null
@@ -39,56 +35,17 @@
                               },
                               {
                                 "Reference": {
-                                  "UserName": "a"
+                                  "RepresentedName": [
+                                    {
+                                      "UserName": "a"
+                                    },
+                                    "matrix_to_atom",
+                                    "1"
+                                  ]
                                 }
                               }
                             ]
                           },
-                          [
-                            {
-                              "Atomic": [
-                                {
-                                  "clean": false,
-                                  "etype": null
-                                },
-                                {
-                                  "Reference": {
-                                    "UserName": "i"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        ]
-                      },
-                      {
-                        "Atomic": [
-                          {
-                            "clean": false,
-                            "etype": null
-                          },
-                          {
-                            "Reference": {
-                              "UserName": "i"
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "induction_vars": [
-                    {
-                      "UserName": "i"
-                    }
-                  ],
-                  "submodel": {
-                    "constraints": {
-                      "Root": [
-                        {
-                          "clean": false,
-                          "etype": null
-                        },
-                        [
                           {
                             "Atomic": [
                               {
@@ -97,78 +54,102 @@
                               },
                               {
                                 "Literal": {
-                                  "Bool": true
+                                  "Int": 1
                                 }
                               }
                             ]
                           }
                         ]
-                      ]
-                    },
-                    "symbols": {
-                      "id": 65,
-                      "next_machine_name": 0,
-                      "parent": 69,
-                      "table": [
-                        [
+                      },
+                      {
+                        "Eq": [
                           {
-                            "UserName": "a"
+                            "clean": false,
+                            "etype": null
                           },
                           {
-                            "id": 15091,
-                            "kind": {
-                              "DecisionVariable": {
-                                "domain": {
-                                  "DomainMatrix": [
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "RepresentedName": [
                                     {
-                                      "DomainReference": {
-                                        "UserName": "DOM"
-                                      }
+                                      "UserName": "a"
                                     },
-                                    [
-                                      {
-                                        "DomainReference": {
-                                          "UserName": "DOM"
-                                        }
-                                      }
-                                    ]
+                                    "matrix_to_atom",
+                                    "2"
                                   ]
                                 }
                               }
-                            },
-                            "name": {
-                              "UserName": "a"
-                            }
-                          }
-                        ],
-                        [
-                          {
-                            "UserName": "i"
+                            ]
                           },
                           {
-                            "id": 15093,
-                            "kind": {
-                              "DecisionVariable": {
-                                "domain": {
-                                  "IntDomain": [
-                                    {
-                                      "Bounded": [
-                                        1,
-                                        3
-                                      ]
-                                    }
-                                  ]
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 2
                                 }
                               }
-                            },
-                            "name": {
-                              "UserName": "i"
-                            }
+                            ]
                           }
                         ]
+                      },
+                      {
+                        "Eq": [
+                          {
+                            "clean": false,
+                            "etype": null
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Reference": {
+                                  "RepresentedName": [
+                                    {
+                                      "UserName": "a"
+                                    },
+                                    "matrix_to_atom",
+                                    "3"
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "Atomic": [
+                              {
+                                "clean": false,
+                                "etype": null
+                              },
+                              {
+                                "Literal": {
+                                  "Int": 3
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    {
+                      "IntDomain": [
+                        {
+                          "UnboundedR": 1
+                        }
                       ]
                     }
-                  }
+                  ]
                 }
               ]
             }
@@ -180,7 +161,7 @@
   "dominance": null,
   "search_order": null,
   "symbols": {
-    "id": 69,
+    "id": 62,
     "next_machine_name": 0,
     "parent": null,
     "table": [
@@ -212,21 +193,31 @@
           "UserName": "a"
         },
         {
-          "id": 15091,
+          "id": 15095,
           "kind": {
             "DecisionVariable": {
               "domain": {
                 "DomainMatrix": [
                   {
-                    "DomainReference": {
-                      "UserName": "DOM"
-                    }
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          3
+                        ]
+                      }
+                    ]
                   },
                   [
                     {
-                      "DomainReference": {
-                        "UserName": "DOM"
-                      }
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            3
+                          ]
+                        }
+                      ]
                     }
                   ]
                 ]
@@ -235,6 +226,117 @@
           },
           "name": {
             "UserName": "a"
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "1"
+          ]
+        },
+        {
+          "id": 15099,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      3
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "1"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "2"
+          ]
+        },
+        {
+          "id": 15100,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      3
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "2"
+            ]
+          }
+        }
+      ],
+      [
+        {
+          "RepresentedName": [
+            {
+              "UserName": "a"
+            },
+            "matrix_to_atom",
+            "3"
+          ]
+        },
+        {
+          "id": 15101,
+          "kind": {
+            "DecisionVariable": {
+              "domain": {
+                "IntDomain": [
+                  {
+                    "Bounded": [
+                      1,
+                      3
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "RepresentedName": [
+              {
+                "UserName": "a"
+              },
+              "matrix_to_atom",
+              "3"
+            ]
           }
         }
       ]

--- a/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
@@ -24,6 +24,14 @@ new variables:
   find position#matrix_to_atom_6: int(1..6)
 --
 
+and([(position[Sum([i, k])] = Sum([Sum([position[i], i]), 1])) | i: int(1..3),]),
+allDiff(position#matrix_to_atom), 
+   ~~> substitute_domain_lettings ([("Base", 5000)]) 
+and([(position[Sum([i, k])] = Sum([Sum([position[i], i]), 1])) | i: int(1..3),]),
+allDiff(position#matrix_to_atom) 
+
+--
+
 allDiff(position#matrix_to_atom), 
    ~~> matrix_ref_to_atom ([("Base", 2000)]) 
 allDiff([position#matrix_to_atom_1,position#matrix_to_atom_2,position#matrix_to_atom_3,position#matrix_to_atom_4,position#matrix_to_atom_5,position#matrix_to_atom_6;int(1..)]) 
@@ -555,7 +563,7 @@ position#matrix_to_atom_3
 Final model:
 
 letting k be 3
-find position: matrix indexed by [[positionDomain]] of positionDomain
+find position: matrix indexed by [[int(1..6)]] of int(1..6)
 letting positionDomain be domain int(1..6)
 letting two_k be 6
 find __0: int(1..6)

--- a/conjure_oxide/tests/integration/savilerow/langford/langford.expected-rewrite.serialised.json
+++ b/conjure_oxide/tests/integration/savilerow/langford/langford.expected-rewrite.serialised.json
@@ -645,7 +645,7 @@
           "UserName": "k"
         },
         {
-          "id": 18797,
+          "id": 18816,
           "kind": {
             "ValueLetting": {
               "Atomic": [
@@ -671,21 +671,31 @@
           "UserName": "position"
         },
         {
-          "id": 18802,
+          "id": 18834,
           "kind": {
             "DecisionVariable": {
               "domain": {
                 "DomainMatrix": [
                   {
-                    "DomainReference": {
-                      "UserName": "positionDomain"
-                    }
+                    "IntDomain": [
+                      {
+                        "Bounded": [
+                          1,
+                          6
+                        ]
+                      }
+                    ]
                   },
                   [
                     {
-                      "DomainReference": {
-                        "UserName": "positionDomain"
-                      }
+                      "IntDomain": [
+                        {
+                          "Bounded": [
+                            1,
+                            6
+                          ]
+                        }
+                      ]
                     }
                   ]
                 ]
@@ -702,7 +712,7 @@
           "UserName": "positionDomain"
         },
         {
-          "id": 18799,
+          "id": 18818,
           "kind": {
             "DomainLetting": {
               "IntDomain": [
@@ -725,7 +735,7 @@
           "UserName": "two_k"
         },
         {
-          "id": 18798,
+          "id": 18817,
           "kind": {
             "ValueLetting": {
               "Atomic": [
@@ -751,7 +761,7 @@
           "MachineName": 0
         },
         {
-          "id": 18815,
+          "id": 18835,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -776,7 +786,7 @@
           "MachineName": 1
         },
         {
-          "id": 18816,
+          "id": 18836,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -801,7 +811,7 @@
           "MachineName": 2
         },
         {
-          "id": 18817,
+          "id": 18837,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -826,7 +836,7 @@
           "MachineName": 3
         },
         {
-          "id": 18818,
+          "id": 18838,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -851,7 +861,7 @@
           "MachineName": 4
         },
         {
-          "id": 18819,
+          "id": 18839,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -876,7 +886,7 @@
           "MachineName": 5
         },
         {
-          "id": 18820,
+          "id": 18840,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -901,7 +911,7 @@
           "MachineName": 6
         },
         {
-          "id": 18821,
+          "id": 18841,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -926,7 +936,7 @@
           "MachineName": 7
         },
         {
-          "id": 18822,
+          "id": 18842,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -951,7 +961,7 @@
           "MachineName": 8
         },
         {
-          "id": 18823,
+          "id": 18843,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -982,7 +992,7 @@
           ]
         },
         {
-          "id": 18809,
+          "id": 18828,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1019,7 +1029,7 @@
           ]
         },
         {
-          "id": 18810,
+          "id": 18829,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1056,7 +1066,7 @@
           ]
         },
         {
-          "id": 18811,
+          "id": 18830,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1093,7 +1103,7 @@
           ]
         },
         {
-          "id": 18812,
+          "id": 18831,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1130,7 +1140,7 @@
           ]
         },
         {
-          "id": 18813,
+          "id": 18832,
           "kind": {
             "DecisionVariable": {
               "domain": {
@@ -1167,7 +1177,7 @@
           ]
         },
         {
-          "id": 18814,
+          "id": 18833,
           "kind": {
             "DecisionVariable": {
               "domain": {

--- a/crates/conjure_core/src/rules/subsitute_lettings.rs
+++ b/crates/conjure_core/src/rules/subsitute_lettings.rs
@@ -30,6 +30,10 @@ fn substitute_value_lettings(expr: &Expr, symbols: &SymbolTable) -> ApplicationR
 /// Substitutes domain lettings for their values in the symbol table.
 #[register_rule(("Base", 5000))]
 fn substitute_domain_lettings(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
+    let Expr::Root(_, _) = expr else {
+        return Err(RuleNotApplicable);
+    };
+
     let mut new_symbols = symbols.clone();
     let mut has_changed = false;
 


### PR DESCRIPTION
This PR contains a bug fix for substituting domain lettings inside comprehensions, and other miscellaneous fixes to this rule.

See the changelog below for details:


---

- **test: bug/domain-lettings-in-comprehensions-leak-vars-into-scope**
  Add test-case for the following bug:
  
  ```
  letting DOM be domain int(1..3)
  find a: matrix [DOM] of DOM
  
  $ currently, when substituting DOM in the below comprehension, a and all its
  $ representations are added to the comprehensions' symbol table!
  such that
  
  and([a[i] = i |i:DOM])
  ```
 

- **fix: only apply subsitute_domain_lettings to the local scope**
  * Make substitute_domain lettings only substitute domains in variables in
    the local scope, instead of all parent scopes.
  
    This fixes the bug described in 730d5ab86 (test: bug/domain-lettings-in-comprehensions-leak-vars-into-scope, 2025-03-26).
  
    For more details on what this changed, see the integration test diff.
  
  * Make the rule use `domain.resolve` instead, which should allow this to
    substitute domain references deep inside recursive domains.
  

- **perf: only apply substitute_domain_lettings on root expressions**
  Only make `substitute_domain_lettings` apply on the root expressions.
  
  As the rule only relies on the symbol-table and not the expression, this
  does not effect correctness.
  
  Before this commit, this rule is considered not applicable after
  checking that no changes are made to any domains. This is relatively
  expensive, especially when the model has recursive domains (e.g.
  matrices).
  
  After this change, this rule will only be checked exactly once per
  tree-traversal, instead of on every expression.
  
  The rewriter always returns to the root after a change is made.
  Therefore, if this rule is not applicable on the root, it will also not
  be on its sub-expressions during that traversal, so checking this rule
  on them is redundant.
  