### PR TITLE
refactor: rename `apply_eval_const` rule to `constant_evaluator`

### DIFF
--- a/conjure_oxide/tests/integration/basic/abs/03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/abs/03-nested/input-expected-rule-trace-human.txt
@@ -29,7 +29,7 @@ UnsafeDiv(x, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -41,7 +41,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -53,7 +53,7 @@ Sum({[SafeDiv(x, 2),y,-(z);int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -65,7 +65,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -77,7 +77,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -89,7 +89,7 @@ Sum({[|Sum([SafeDiv(x, 2),y,-(z);int(1..)])|,UnsafeDiv(|y|, 2);int(1..2)] @ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -101,7 +101,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -133,7 +133,7 @@ UnsafeDiv(|y|, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -145,7 +145,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -157,7 +157,7 @@ Sum({[|Sum([SafeDiv(x, 2),y,-(z);int(1..)])|,SafeDiv(|y|, 2);int(1..2)] @ true})
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -169,7 +169,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/comprehension/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/01/input-expected-rule-trace-human.txt
@@ -66,7 +66,7 @@ m#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -78,7 +78,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -126,7 +126,7 @@ m#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -138,7 +138,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -186,7 +186,7 @@ m#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -198,7 +198,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -246,7 +246,7 @@ m#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -258,7 +258,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -306,7 +306,7 @@ m#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -318,7 +318,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
@@ -17,31 +17,31 @@ and([((n[i] < 5)) -> ((m[i] = i)) | i: int(1..5),(i < 4)])
 --
 
 (6 - 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
 
 (6 - 2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
 
 (6 - 3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 3 
 
 --
 
 (6 - 4), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --
 
 (6 - 5), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
@@ -100,7 +100,7 @@ n#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -112,7 +112,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -164,7 +164,7 @@ n#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -176,7 +176,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -228,7 +228,7 @@ n#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -240,7 +240,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -292,7 +292,7 @@ n#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -304,7 +304,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -356,7 +356,7 @@ n#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -368,7 +368,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -450,7 +450,7 @@ n#matrix_to_atom_5
 --
 
 Sum([4,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 3 
 
 --
@@ -492,7 +492,7 @@ and([((n[1] < 5)) -> ((m[1] = 1)),((n[2] < 5)) -> ((m[2] = 2)),((n[3] < 5)) -> (
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -504,7 +504,7 @@ Sum([5,-1;int(1..)]),
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -516,7 +516,7 @@ Sum([5,-1;int(1..)]),
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -569,7 +569,7 @@ n#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -581,7 +581,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -611,7 +611,7 @@ m#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -623,7 +623,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -653,7 +653,7 @@ n#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -665,7 +665,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -695,7 +695,7 @@ m#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -707,7 +707,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -737,7 +737,7 @@ n#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -749,7 +749,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -779,7 +779,7 @@ m#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -791,7 +791,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
@@ -18,7 +18,7 @@ and([((y < 5)) -> ((m[x] = x)) | x: int(1..5),(x < 4)])
 --
 
 Sum([4,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 3 
 
 --
@@ -52,7 +52,7 @@ and([((y < 5)) -> ((m[1] = 1)),((y < 5)) -> ((m[2] = 2)),((y < 5)) -> ((m[3] = 3
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -64,7 +64,7 @@ Sum([5,-1;int(1..)]),
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -76,7 +76,7 @@ Sum([5,-1;int(1..)]),
 --
 
 Sum([5,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -111,7 +111,7 @@ m#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -123,7 +123,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -153,7 +153,7 @@ m#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -165,7 +165,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -195,7 +195,7 @@ m#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -207,7 +207,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/comprehension/04-sum/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/04-sum/input-expected-rule-trace-human.txt
@@ -35,7 +35,7 @@ a#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -47,7 +47,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -59,7 +59,7 @@ Sum({[a#matrix_to_atom[1],a#matrix_to_atom[2];int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -71,7 +71,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -103,7 +103,7 @@ a#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -115,7 +115,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -127,7 +127,7 @@ Sum({[a#matrix_to_atom[1],a#matrix_to_atom[2];int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -139,7 +139,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/div/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/02/input-expected-rule-trace-human.txt
@@ -9,7 +9,7 @@ such that
 --
 
 UnsafeDiv(4, 2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/implies/02-flattening/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/02-flattening/input-expected-rule-trace-human.txt
@@ -18,7 +18,7 @@ such that
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/implies/05-no-parentheses/input-expected-rule-trace-human.txt
@@ -18,7 +18,7 @@ such that
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/01-value-bool/input-expected-rule-trace-human.txt
@@ -16,7 +16,7 @@ such that
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/lettings/02-value-int/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/02-value-int/input-expected-rule-trace-human.txt
@@ -22,7 +22,7 @@ A,
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input-expected-rule-trace-human.txt
@@ -17,7 +17,7 @@ such that
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --
@@ -41,7 +41,7 @@ false
 --
 
 Not(false), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/lettings/04-domain/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/04-domain/input-expected-rule-trace-human.txt
@@ -18,7 +18,7 @@ such that
 --
 
 Sum([3,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --

--- a/conjure_oxide/tests/integration/basic/lettings/05-letting-in-domain/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/05-letting-in-domain/input-expected-rule-trace-human.txt
@@ -22,7 +22,7 @@ n,
 --
 
 Sum([2,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
@@ -60,7 +60,7 @@ a#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -72,7 +72,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -120,7 +120,7 @@ a#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -132,7 +132,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -180,7 +180,7 @@ a#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -192,7 +192,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -240,7 +240,7 @@ a#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -252,7 +252,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -300,7 +300,7 @@ a#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -312,7 +312,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -360,7 +360,7 @@ a#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(1..5));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -372,7 +372,7 @@ Not({a#matrix_to_atom[4] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
@@ -69,7 +69,7 @@ a#matrix_to_atom[..,1],
 --
 
 and([__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -81,7 +81,7 @@ allDiff({a#matrix_to_atom[..,1] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -137,7 +137,7 @@ a#matrix_to_atom[..,2],
 --
 
 and([__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -149,7 +149,7 @@ allDiff({a#matrix_to_atom[..,2] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -205,7 +205,7 @@ a#matrix_to_atom[1,..],
 --
 
 and([__inDomain(1,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -217,7 +217,7 @@ allDiff({a#matrix_to_atom[1,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -273,7 +273,7 @@ a#matrix_to_atom[2,..],
 --
 
 and([__inDomain(2,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -285,7 +285,7 @@ allDiff({a#matrix_to_atom[2,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -341,7 +341,7 @@ a#matrix_to_atom[3,..],
 --
 
 and([__inDomain(3,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -353,7 +353,7 @@ allDiff({a#matrix_to_atom[3,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -409,7 +409,7 @@ a#matrix_to_atom[1, 1],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -421,7 +421,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -477,7 +477,7 @@ a#matrix_to_atom[2, 2],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -489,7 +489,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
@@ -70,7 +70,7 @@ a#matrix_to_atom[..,1],
 --
 
 and([__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -82,7 +82,7 @@ allDiff({a#matrix_to_atom[..,1] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -138,7 +138,7 @@ a#matrix_to_atom[..,2],
 --
 
 and([__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -150,7 +150,7 @@ allDiff({a#matrix_to_atom[..,2] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -206,7 +206,7 @@ a#matrix_to_atom[1,..],
 --
 
 and([__inDomain(1,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -218,7 +218,7 @@ allDiff({a#matrix_to_atom[1,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -274,7 +274,7 @@ a#matrix_to_atom[2,..],
 --
 
 and([__inDomain(2,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -286,7 +286,7 @@ allDiff({a#matrix_to_atom[2,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -342,7 +342,7 @@ a#matrix_to_atom[3,..],
 --
 
 and([__inDomain(3,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -354,7 +354,7 @@ allDiff({a#matrix_to_atom[3,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -410,7 +410,7 @@ a#matrix_to_atom[1, 1],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -422,7 +422,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -478,7 +478,7 @@ a#matrix_to_atom[2, 2],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -490,7 +490,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/04-value-letting/input-expected-rule-trace-human.txt
@@ -22,7 +22,7 @@ a,
 --
 
 [[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][3, 3], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 9 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/05-value-letting-index/input-expected-rule-trace-human.txt
@@ -11,13 +11,13 @@ allDiff(a[-(2),..])
 --
 
 -(2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -2 
 
 --
 
 -(2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -2 
 
 --
@@ -35,7 +35,7 @@ a,
 --
 
 Sum([[[1,2,3;int(1,2,4)],[1,3,2;int(1,2,4)],[3,2,1;int(1,2,4)];int(-2..0)][-2, 2],-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
@@ -47,13 +47,13 @@ a,
 --
 
 [[1,2,3;int(1,2,4)],[1,3,2;int(1,2,4)],[3,2,1;int(1,2,4)];int(-2..0)][-2,..], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 Matrix([Int(1), Int(2), Int(3)], IntDomain([UnboundedR(1)])) 
 
 --
 
 allDiff(Matrix([Int(1), Int(2), Int(3)], IntDomain([UnboundedR(1)]))), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
@@ -70,7 +70,7 @@ a#matrix_to_atom[..,1],
 --
 
 and([__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -82,7 +82,7 @@ allDiff({a#matrix_to_atom[..,1] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -138,7 +138,7 @@ a#matrix_to_atom[..,2],
 --
 
 and([__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -150,7 +150,7 @@ allDiff({a#matrix_to_atom[..,2] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -206,7 +206,7 @@ a#matrix_to_atom[1,..],
 --
 
 and([__inDomain(1,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -218,7 +218,7 @@ allDiff({a#matrix_to_atom[1,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -274,7 +274,7 @@ a#matrix_to_atom[2,..],
 --
 
 and([__inDomain(2,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -286,7 +286,7 @@ allDiff({a#matrix_to_atom[2,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -342,7 +342,7 @@ a#matrix_to_atom[3,..],
 --
 
 and([__inDomain(3,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -354,7 +354,7 @@ allDiff({a#matrix_to_atom[3,..] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -410,7 +410,7 @@ a#matrix_to_atom[1, 1],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -422,7 +422,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -478,7 +478,7 @@ a#matrix_to_atom[2, 3],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(3,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
 --
@@ -490,7 +490,7 @@ false
 --
 
 and([false;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
@@ -70,7 +70,7 @@ a#matrix_to_atom[..,1],
 --
 
 and([__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -82,7 +82,7 @@ allDiff({a#matrix_to_atom[..,1] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -138,7 +138,7 @@ a#matrix_to_atom[..,3],
 --
 
 and([__inDomain(3,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
 --
@@ -150,7 +150,7 @@ allDiff({a#matrix_to_atom[..,3] @ false}),
 --
 
 and([false;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
@@ -122,7 +122,7 @@ a#matrix_to_atom[1, 2],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -134,7 +134,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -190,7 +190,7 @@ a#matrix_to_atom[2, 1],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -202,7 +202,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -258,7 +258,7 @@ a#matrix_to_atom[3, 1],
 --
 
 and([__inDomain(3,int(1..3)),__inDomain(1,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -270,7 +270,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -326,7 +326,7 @@ a#matrix_to_atom[3, 2],
 --
 
 and([__inDomain(3,int(1..3)),__inDomain(2,int(1..2));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -338,7 +338,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -412,7 +412,7 @@ Sum([i,-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
@@ -424,7 +424,7 @@ Sum([i,-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
@@ -80,7 +80,7 @@ a#matrix_to_atom[1, 2],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(2,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -92,7 +92,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -152,7 +152,7 @@ a#matrix_to_atom[1, 3],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(3,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -164,7 +164,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -224,7 +224,7 @@ a#matrix_to_atom[1, 4],
 --
 
 and([__inDomain(1,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -236,7 +236,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -296,7 +296,7 @@ a#matrix_to_atom[2, 3],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(3,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -308,7 +308,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -368,7 +368,7 @@ a#matrix_to_atom[2, 4],
 --
 
 and([__inDomain(2,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -380,7 +380,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -440,7 +440,7 @@ a#matrix_to_atom[3, 2],
 --
 
 and([__inDomain(3,int(1..3)),__inDomain(2,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -452,7 +452,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -512,7 +512,7 @@ a#matrix_to_atom[3, 4],
 --
 
 and([__inDomain(3,int(1..3)),__inDomain(4,int(2..4));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -524,7 +524,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -728,7 +728,7 @@ Sum([i,-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
@@ -740,7 +740,7 @@ Sum([i,-(2);int(1..)])
 --
 
 -(2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -2 
 
 --

--- a/conjure_oxide/tests/integration/basic/mod/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/02/input-expected-rule-trace-human.txt
@@ -9,7 +9,7 @@ such that
 --
 
 4 % 2, 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 0 
 
 --

--- a/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/06-sum-nested/input-expected-rule-trace-human.txt
@@ -37,7 +37,7 @@ Sum([-(z),-(1),-(-(a));int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
@@ -16,7 +16,7 @@ UnsafeDiv(y, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -28,7 +28,7 @@ UnsafePow(Sum([x,2;int(1..2)]), {SafeDiv(y, 2) @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -40,7 +40,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/basic/product/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/product/01-simple/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ Product([x, y, z])
 --
 
 Sum([15,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 14 
 
 --

--- a/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/01-simple-lt/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ Sum([Product([2, x]),Product([3, y]),z;int(1..2)])
 --
 
 Sum([14,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 13 
 
 --

--- a/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/04-needs-normalising/input-expected-rule-trace-human.txt
@@ -11,13 +11,13 @@ such that
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
 
 -(5), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -5 
 
 --
@@ -59,7 +59,7 @@ Product([-5, y])
 --
 
 Sum([11,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 10 
 
 --

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
@@ -69,7 +69,7 @@ a#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -81,7 +81,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -121,7 +121,7 @@ a#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -133,7 +133,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -173,7 +173,7 @@ a#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -185,7 +185,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/issue-336-empty-or-should-be-false/input-expected-rule-trace-human.txt
@@ -15,7 +15,7 @@ or([;int(1..)])
 --
 
 or([;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
 --

--- a/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/input-expected-rule-trace-human.txt
@@ -21,7 +21,7 @@ min([5,7;int(1..)])
 --
 
 min([5,7;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --

--- a/conjure_oxide/tests/integration/eprime-minion/nqueens-4/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/eprime-minion/nqueens-4/input-expected-rule-trace-human.txt
@@ -231,7 +231,7 @@ majorDiagonal#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -243,7 +243,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -273,7 +273,7 @@ row#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -285,7 +285,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -297,7 +297,7 @@ Sum({[0,row#matrix_to_atom[0];int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -309,7 +309,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -339,7 +339,7 @@ minorDiagonal#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -351,7 +351,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -381,7 +381,7 @@ row#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -393,7 +393,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -405,7 +405,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -417,7 +417,7 @@ Sum({[0,-(row#matrix_to_atom[0]);int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -429,7 +429,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -459,7 +459,7 @@ majorDiagonal#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -471,7 +471,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -501,7 +501,7 @@ row#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -513,7 +513,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -525,7 +525,7 @@ Sum({[1,row#matrix_to_atom[1];int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -537,7 +537,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -567,7 +567,7 @@ minorDiagonal#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -579,7 +579,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -609,7 +609,7 @@ row#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -621,7 +621,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -633,7 +633,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -645,7 +645,7 @@ Sum({[1,-(row#matrix_to_atom[1]);int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -657,7 +657,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -687,7 +687,7 @@ majorDiagonal#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -699,7 +699,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -729,7 +729,7 @@ row#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -741,7 +741,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -753,7 +753,7 @@ Sum({[2,row#matrix_to_atom[2];int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -765,7 +765,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -795,7 +795,7 @@ minorDiagonal#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -807,7 +807,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -837,7 +837,7 @@ row#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -849,7 +849,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -861,7 +861,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -873,7 +873,7 @@ Sum({[2,-(row#matrix_to_atom[2]);int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -885,7 +885,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -915,7 +915,7 @@ majorDiagonal#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -927,7 +927,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -957,7 +957,7 @@ row#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -969,7 +969,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -981,7 +981,7 @@ Sum({[3,row#matrix_to_atom[3];int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -993,7 +993,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1023,7 +1023,7 @@ minorDiagonal#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..3));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1035,7 +1035,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1065,7 +1065,7 @@ row#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1077,7 +1077,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1089,7 +1089,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1101,7 +1101,7 @@ Sum({[3,-(row#matrix_to_atom[3]);int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1113,7 +1113,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/hakank_eprime/xkcd/xkcd-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/hakank_eprime/xkcd/xkcd-expected-rule-trace-human.txt
@@ -72,7 +72,7 @@ x#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -84,7 +84,7 @@ Product([price[1], {x#matrix_to_atom[1] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -96,7 +96,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -108,7 +108,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -120,7 +120,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -152,7 +152,7 @@ x#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -164,7 +164,7 @@ Product([price[2], {x#matrix_to_atom[2] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -176,7 +176,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -188,7 +188,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -200,7 +200,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -232,7 +232,7 @@ x#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -244,7 +244,7 @@ Product([price[3], {x#matrix_to_atom[3] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -256,7 +256,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -268,7 +268,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -280,7 +280,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -312,7 +312,7 @@ x#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -324,7 +324,7 @@ Product([price[4], {x#matrix_to_atom[4] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -336,7 +336,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -348,7 +348,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -360,7 +360,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -392,7 +392,7 @@ x#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -404,7 +404,7 @@ Product([price[5], {x#matrix_to_atom[5] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -416,7 +416,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -428,7 +428,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -440,7 +440,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -472,7 +472,7 @@ x#matrix_to_atom[6],
 --
 
 and([__inDomain(6,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -484,7 +484,7 @@ Product([price[6], {x#matrix_to_atom[6] @ true}]),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -496,7 +496,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -508,7 +508,7 @@ Sum({[Product([price[1], x#matrix_to_atom[1]]),Product([price[2], x#matrix_to_at
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -520,7 +520,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -552,7 +552,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][1], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 215 
 
 --
@@ -564,7 +564,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][2], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 275 
 
 --
@@ -576,7 +576,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][3], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 335 
 
 --
@@ -588,7 +588,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][4], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 355 
 
 --
@@ -600,7 +600,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][5], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 420 
 
 --
@@ -612,7 +612,7 @@ price,
 --
 
 [215,275,335,355,420,580;int(1..6)][6], 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 580 
 
 --

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/input-expected-rule-trace-human.txt
@@ -11,7 +11,7 @@ such that
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
@@ -23,7 +23,7 @@ Sum([y,-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --

--- a/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/input-expected-rule-trace-human.txt
@@ -11,7 +11,7 @@ such that
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
@@ -23,7 +23,7 @@ Sum([y,-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --

--- a/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/optimisations/implies-tautologies-cse/input-expected-rule-trace-human.txt
@@ -94,7 +94,7 @@ or([((UnsafeDiv(q, 2) = r)) -> ((n < 6)),a,b,((UnsafeDiv(q, 2) = r)) -> (Not((n 
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -106,7 +106,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -118,7 +118,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -130,7 +130,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -142,7 +142,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -154,7 +154,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -166,7 +166,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -178,7 +178,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -190,7 +190,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -202,7 +202,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -214,7 +214,7 @@ Sum([6,-1;int(1..)]),
 --
 
 Sum([6,-1;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -226,7 +226,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -238,7 +238,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -268,7 +268,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -280,7 +280,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -310,7 +310,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -322,7 +322,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -352,7 +352,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -364,7 +364,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -394,7 +394,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -406,7 +406,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -482,7 +482,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -494,7 +494,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -524,7 +524,7 @@ m % 2,
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -536,7 +536,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -566,7 +566,7 @@ UnsafeDiv(q, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -578,7 +578,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -608,7 +608,7 @@ UnsafeDiv(q, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -620,7 +620,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -650,7 +650,7 @@ UnsafeDiv(q, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -662,7 +662,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -692,7 +692,7 @@ UnsafeDiv(q, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -704,7 +704,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
@@ -180,7 +180,7 @@ position#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -192,7 +192,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -204,7 +204,7 @@ Sum({[position#matrix_to_atom[1],1,1;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -216,7 +216,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -329,7 +329,7 @@ position#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -341,7 +341,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -353,7 +353,7 @@ Sum({[position#matrix_to_atom[2],2,1;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -365,7 +365,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -488,7 +488,7 @@ position#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(1..6));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -500,7 +500,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -512,7 +512,7 @@ Sum({[position#matrix_to_atom[3],3,1;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -524,7 +524,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -616,7 +616,7 @@ Sum([1,3;int(1..)])
 --
 
 Sum([1,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
@@ -676,13 +676,13 @@ Sum([1,3;int(1..)])
 --
 
 Sum([1,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
 
 __inDomain(4,int(1..6)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -715,7 +715,7 @@ Sum([2,3;int(1..)])
 --
 
 Sum([2,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
@@ -777,13 +777,13 @@ Sum([2,3;int(1..)])
 --
 
 Sum([2,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 5 
 
 --
 
 __inDomain(5,int(1..6)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -818,7 +818,7 @@ Sum([3,3;int(1..)])
 --
 
 Sum([3,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 6 
 
 --
@@ -882,13 +882,13 @@ Sum([3,3;int(1..)])
 --
 
 Sum([3,3;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 6 
 
 --
 
 __inDomain(6,int(1..6)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
@@ -148,7 +148,7 @@ Sum([q1[0],-(0);int(1..)])
 --
 
 -(0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 0 
 
 --
@@ -160,7 +160,7 @@ Sum([q1[1],-(1);int(1..)])
 --
 
 -(1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -1 
 
 --
@@ -172,7 +172,7 @@ Sum([q1[2],-(2);int(1..)])
 --
 
 -(2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -2 
 
 --
@@ -184,7 +184,7 @@ Sum([q1[3],-(3);int(1..)])
 --
 
 -(3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -3 
 
 --
@@ -196,7 +196,7 @@ Sum([q1[4],-(4);int(1..)])
 --
 
 -(4), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -4 
 
 --
@@ -208,7 +208,7 @@ Sum([q1[5],-(5);int(1..)])
 --
 
 -(5), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -5 
 
 --
@@ -220,7 +220,7 @@ Sum([q1[6],-(6);int(1..)])
 --
 
 -(6), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -6 
 
 --
@@ -232,7 +232,7 @@ Sum([q1[7],-(7);int(1..)])
 --
 
 -(7), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -7 
 
 --
@@ -436,7 +436,7 @@ q2#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -448,7 +448,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -478,7 +478,7 @@ q1#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -490,7 +490,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -502,7 +502,7 @@ Sum({[q1#matrix_to_atom[0],0;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -514,7 +514,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -544,7 +544,7 @@ q3#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -556,7 +556,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -586,7 +586,7 @@ q1#matrix_to_atom[0],
 --
 
 and([__inDomain(0,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -598,7 +598,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -610,7 +610,7 @@ Sum({[q1#matrix_to_atom[0],0;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -622,7 +622,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -652,7 +652,7 @@ q2#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -664,7 +664,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -694,7 +694,7 @@ q1#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -706,7 +706,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -718,7 +718,7 @@ Sum({[q1#matrix_to_atom[1],-1;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -730,7 +730,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -760,7 +760,7 @@ q3#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -772,7 +772,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -802,7 +802,7 @@ q1#matrix_to_atom[1],
 --
 
 and([__inDomain(1,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -814,7 +814,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -826,7 +826,7 @@ Sum({[q1#matrix_to_atom[1],1;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -838,7 +838,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -868,7 +868,7 @@ q2#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -880,7 +880,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -910,7 +910,7 @@ q1#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -922,7 +922,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -934,7 +934,7 @@ Sum({[q1#matrix_to_atom[2],-2;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -946,7 +946,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -976,7 +976,7 @@ q3#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -988,7 +988,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1018,7 +1018,7 @@ q1#matrix_to_atom[2],
 --
 
 and([__inDomain(2,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1030,7 +1030,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1042,7 +1042,7 @@ Sum({[q1#matrix_to_atom[2],2;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1054,7 +1054,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1084,7 +1084,7 @@ q2#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1096,7 +1096,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1126,7 +1126,7 @@ q1#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1138,7 +1138,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1150,7 +1150,7 @@ Sum({[q1#matrix_to_atom[3],-3;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1162,7 +1162,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1192,7 +1192,7 @@ q3#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1204,7 +1204,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1234,7 +1234,7 @@ q1#matrix_to_atom[3],
 --
 
 and([__inDomain(3,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1246,7 +1246,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1258,7 +1258,7 @@ Sum({[q1#matrix_to_atom[3],3;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1270,7 +1270,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1300,7 +1300,7 @@ q2#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1312,7 +1312,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1342,7 +1342,7 @@ q1#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1354,7 +1354,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1366,7 +1366,7 @@ Sum({[q1#matrix_to_atom[4],-4;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1378,7 +1378,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1408,7 +1408,7 @@ q3#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1420,7 +1420,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1450,7 +1450,7 @@ q1#matrix_to_atom[4],
 --
 
 and([__inDomain(4,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1462,7 +1462,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1474,7 +1474,7 @@ Sum({[q1#matrix_to_atom[4],4;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1486,7 +1486,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1516,7 +1516,7 @@ q2#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1528,7 +1528,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1558,7 +1558,7 @@ q1#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1570,7 +1570,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1582,7 +1582,7 @@ Sum({[q1#matrix_to_atom[5],-5;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1594,7 +1594,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1624,7 +1624,7 @@ q3#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1636,7 +1636,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1666,7 +1666,7 @@ q1#matrix_to_atom[5],
 --
 
 and([__inDomain(5,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1678,7 +1678,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1690,7 +1690,7 @@ Sum({[q1#matrix_to_atom[5],5;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1702,7 +1702,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1732,7 +1732,7 @@ q2#matrix_to_atom[6],
 --
 
 and([__inDomain(6,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1744,7 +1744,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1774,7 +1774,7 @@ q1#matrix_to_atom[6],
 --
 
 and([__inDomain(6,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1786,7 +1786,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1798,7 +1798,7 @@ Sum({[q1#matrix_to_atom[6],-6;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1810,7 +1810,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1840,7 +1840,7 @@ q3#matrix_to_atom[6],
 --
 
 and([__inDomain(6,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1852,7 +1852,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1882,7 +1882,7 @@ q1#matrix_to_atom[6],
 --
 
 and([__inDomain(6,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1894,7 +1894,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1906,7 +1906,7 @@ Sum({[q1#matrix_to_atom[6],6;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1918,7 +1918,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1948,7 +1948,7 @@ q2#matrix_to_atom[7],
 --
 
 and([__inDomain(7,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1960,7 +1960,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -1990,7 +1990,7 @@ q1#matrix_to_atom[7],
 --
 
 and([__inDomain(7,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2002,7 +2002,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2014,7 +2014,7 @@ Sum({[q1#matrix_to_atom[7],-7;int(1..)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2026,7 +2026,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2056,7 +2056,7 @@ q3#matrix_to_atom[7],
 --
 
 and([__inDomain(7,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2068,7 +2068,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2098,7 +2098,7 @@ q1#matrix_to_atom[7],
 --
 
 and([__inDomain(7,int(0..7));int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2110,7 +2110,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2122,7 +2122,7 @@ Sum({[q1#matrix_to_atom[7],7;int(1..2)] @ true}),
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -2134,7 +2134,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/conjure_oxide/tests/integration/savilerow/test-power/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/test-power/input-expected-rule-trace-human.txt
@@ -24,151 +24,151 @@ true
 --
 
 UnsafePow(1, 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
 
 (-(1) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(1, 2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
 
 (-(1) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(1, 3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
 
 (-(1) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(1, 4), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 1 
 
 --
 
 (-(1) = -(1)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(2, 1), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 2 
 
 --
 
 (-(2) = -(2)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(2, 2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 4 
 
 --
 
 (-(4) = -(4)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(2, 3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 8 
 
 --
 
 (-(8) = -(8)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(2, 4), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 16 
 
 --
 
 (-(16) = -(16)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 -(2), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -2 
 
 --
 
 -(4), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -4 
 
 --
 
 -(8), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -8 
 
 --
 
 -(16), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 -16 
 
 --
 
 UnsafePow(2, 3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 8 
 
 --
 
 UnsafePow(2, 8), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 256 
 
 --
 
 (-(256) = -(256)), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 UnsafePow(2, 3), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 8 
 
 --
 
 (UnsafePow(2, 8) = 256), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -205,13 +205,13 @@ UnsafePow(x, 1),
 --
 
 (1 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 (1 >= 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -229,7 +229,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -241,7 +241,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -253,7 +253,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -301,13 +301,13 @@ UnsafePow(x, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 (2 >= 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -325,7 +325,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -337,7 +337,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -349,7 +349,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -397,13 +397,13 @@ UnsafePow(x, 3),
 --
 
 (3 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 (3 >= 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -421,7 +421,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -433,7 +433,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -445,7 +445,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -493,13 +493,13 @@ UnsafePow(x, 4),
 --
 
 (4 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 (4 >= 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -517,7 +517,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -529,7 +529,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -541,7 +541,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -589,13 +589,13 @@ UnsafePow(x, 2),
 --
 
 (2 != 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
 
 (2 >= 0), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -613,7 +613,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --
@@ -625,7 +625,7 @@ true
 --
 
 and([true;int(1..)]), 
-   ~~> apply_eval_constant ([("Constant", 9001)]) 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
 --

--- a/crates/conjure_core/src/rules/constant_eval.rs
+++ b/crates/conjure_core/src/rules/constant_eval.rs
@@ -16,7 +16,7 @@ use crate::into_matrix;
 register_rule_set!("Constant", ());
 
 #[register_rule(("Constant", 9001))]
-fn apply_eval_constant(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
+fn constant_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     if let Expr::Atomic(_, Atom::Literal(_)) = expr {
         return Err(ApplicationError::RuleNotApplicable);
     }


### PR DESCRIPTION
This makes the naming of the rule consistent with the partial evaluator,
ran by rule `partial_evaluator`.
