### PR TITLE
Performance improvements

### DIFF
--- a/crates/conjure_core/src/rules/partial_eval.rs
+++ b/crates/conjure_core/src/rules/partial_eval.rs
@@ -268,7 +268,6 @@ fn partial_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
             let mut new_vec: Vec<Expr> = Vec::new();
             let mut has_changed: bool = false;
             for expr in es {
-                eprintln!("{expr}");
                 match expr {
                     Expr::Atomic(_, Atom::Literal(Bool(x))) => {
                         has_changed = true;


### PR DESCRIPTION
- **fix: remove debug print from partial evaluator**
  

- **perf: only compile regexes in Minion solver adaptor once**
  Only compile the regexes in the Minion solver adaptor once.
  
  Before this commit, each time a name in the solution needed to be
  parsed, the regexes were recompiled.
  
  Profiling revealed that this recompilation took a significant amount of
  time. In my test model^1, the majority of time running Minion was
  actually spent inside the callback compiling these regexes. This change
  reduced the time spent inside Minion from 38% of the total time of
  Conjure Oxide to 6%.
  
  1: letting n be 10 in
     https://github.com/niklasdewally/conjure-bits/blob/d135f57f3cfc20249e3bdde98af33739a3c86853/2025-tau-pythagorean-triples/models/guard_inside_comprehension.eprime
  