### PR TITLE
feat(essence macro): constructing essence AST from strings at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "conjure_essence_macros"
+version = "0.1.0"
+dependencies = [
+ "conjure_core",
+ "conjure_essence_parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "tree-sitter",
+ "uniplate",
+]
+
+[[package]]
 name = "conjure_essence_parser"
 version = "0.1.0"
 dependencies = [
@@ -442,6 +455,7 @@ dependencies = [
  "anyhow",
  "clap",
  "conjure_core",
+ "conjure_essence_macros",
  "conjure_essence_parser",
  "env_logger",
  "git-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ default-members = [
 members = [
     "conjure_oxide",
     "crates/conjure_core",
+    "crates/conjure_essence_parser",
+    "crates/conjure_essence_macros",
     "crates/enum_compatability_macro",
     "crates/conjure_macros",
     "solvers/minion",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -12,6 +12,7 @@ walkdir = "2.5.0"
 conjure_core = { path = "../crates/conjure_core" }
 minion_rs = { path = "../solvers/minion" }
 conjure_essence_parser = { path = "../crates/conjure_essence_parser" }
+conjure_essence_macros = { path = "../crates/conjure_essence_macros" }
 
 
 uniplate = "0.2.2"

--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -14,10 +14,10 @@ pub use conjure_core::rules;
 pub use conjure_core::solver;
 pub use conjure_core::solver::SolverFamily;
 pub use conjure_core::Model;
+pub use conjure_essence_macros::essence_expr;
 pub use conjure_essence_parser::{
     parse_essence_file, parse_essence_file_native, EssenceParseError,
 };
-
 pub mod find_conjure;
 pub mod utils;
 

--- a/conjure_oxide/tests/essence_macro_tests/mod.rs
+++ b/conjure_oxide/tests/essence_macro_tests/mod.rs
@@ -1,5 +1,6 @@
 use conjure_core::ast::{Atom, Expression};
 use conjure_core::matrix_expr;
+use conjure_essence_macros::essence_vec;
 use conjure_oxide::{essence_expr, Metadata};
 
 #[test]
@@ -54,7 +55,10 @@ fn test_such_that() {
 
 #[test]
 fn test_alldiff() {
-    let expr = essence_expr!(allDiff([a, b, c]));
+    let expr = essence_expr!(
+        // Comments work!
+        allDiff([a, b, c])
+    );
     assert_eq!(
         expr,
         Expression::AllDiff(
@@ -64,6 +68,83 @@ fn test_alldiff() {
                 Expression::Atomic(Metadata::new(), Atom::new_uref("b")),
                 Expression::Atomic(Metadata::new(), Atom::new_uref("c")),
             ])
+        )
+    )
+}
+
+#[test]
+fn test_and() {
+    let expr = essence_expr!("a /\\ b");
+    assert_eq!(
+        expr,
+        Expression::And(
+            Metadata::new(),
+            Box::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
+                Expression::Atomic(Metadata::new(), Atom::new_uref("b")),
+            ])
+        )
+    )
+}
+
+#[test]
+fn test_essence_vec_basic() {
+    let exprs = essence_vec!(a + 2, b = true);
+    assert_eq!(exprs.len(), 2);
+    assert_eq!(
+        exprs[0],
+        Expression::Sum(
+            Metadata::new(),
+            Box::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
+                Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+            ])
+        )
+    );
+    assert_eq!(
+        exprs[1],
+        Expression::Eq(
+            Metadata::new(),
+            Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b"))),
+            Box::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
+        )
+    );
+}
+
+#[test]
+fn test_essence_vec() {
+    let exprs = essence_vec!(r"(x /\ y) -> true, |a / |b|| = 42");
+    assert_eq!(exprs.len(), 2);
+    assert_eq!(
+        exprs[0],
+        Expression::Imply(
+            Metadata::new(),
+            Box::new(Expression::And(
+                Metadata::new(),
+                Box::new(matrix_expr![
+                    Expression::Atomic(Metadata::new(), Atom::new_uref("x")),
+                    Expression::Atomic(Metadata::new(), Atom::new_uref("y")),
+                ])
+            )),
+            Box::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
+        )
+    );
+    assert_eq!(
+        exprs[1],
+        Expression::Eq(
+            Metadata::new(),
+            Box::new(Expression::Abs(
+                Metadata::new(),
+                Box::new(Expression::UnsafeDiv(
+                    Metadata::new(),
+                    Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("a"))),
+                    Box::new(Expression::Abs(
+                        Metadata::new(),
+                        Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b")))
+                    ))
+                ))
+            )),
+            Box::new(Expression::Atomic(Metadata::new(), Atom::new_ilit(42)))
         )
     )
 }

--- a/conjure_oxide/tests/essence_macro_tests/mod.rs
+++ b/conjure_oxide/tests/essence_macro_tests/mod.rs
@@ -1,0 +1,69 @@
+use conjure_core::ast::{Atom, Expression};
+use conjure_core::matrix_expr;
+use conjure_oxide::{essence_expr, Metadata};
+
+#[test]
+fn test_2plus2() {
+    let expr = essence_expr!(2 + 2);
+    assert_eq!(
+        expr,
+        Expression::Sum(
+            Metadata::new(),
+            Box::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), Atom::new_ilit(2)),
+                Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+            ])
+        )
+    );
+}
+
+#[test]
+fn test_metavar_const() {
+    let x = 4;
+    let expr = essence_expr!(&x + 2);
+    assert_eq!(
+        expr,
+        Expression::Sum(
+            Metadata::new(),
+            Box::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), Atom::new_ilit(4)),
+                Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+            ])
+        )
+    );
+}
+
+#[test]
+fn test_such_that() {
+    let expr = essence_expr!(such that x + 2 > y);
+    assert_eq!(
+        expr,
+        Expression::Gt(
+            Metadata::new(),
+            Box::new(Expression::Sum(
+                Metadata::new(),
+                Box::new(matrix_expr![
+                    Expression::Atomic(Metadata::new(), Atom::new_uref("x")),
+                    Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+                ])
+            )),
+            Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("y")))
+        )
+    );
+}
+
+#[test]
+fn test_alldiff() {
+    let expr = essence_expr!(allDiff([a, b, c]));
+    assert_eq!(
+        expr,
+        Expression::AllDiff(
+            Metadata::new(),
+            Box::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
+                Expression::Atomic(Metadata::new(), Atom::new_uref("b")),
+                Expression::Atomic(Metadata::new(), Atom::new_uref("c")),
+            ])
+        )
+    )
+}

--- a/conjure_oxide/tests/mod.rs
+++ b/conjure_oxide/tests/mod.rs
@@ -1,3 +1,4 @@
+mod essence_macro_tests;
 mod model_tests;
 mod parser_tests;
 mod rewrite_tests;

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -26,6 +26,11 @@ impl Atom {
     pub fn new_ilit(value: i32) -> Atom {
         Atom::Literal(Literal::Int(value))
     }
+
+    /// Shorthand to create a boolean literal.
+    pub fn new_blit(value: bool) -> Atom {
+        Atom::Literal(Literal::Bool(value))
+    }
 }
 
 impl std::fmt::Display for Atom {

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -21,6 +21,11 @@ impl Atom {
     pub fn new_uref(name: &str) -> Atom {
         Atom::Reference(Name::UserName(name.to_string()))
     }
+
+    /// Shorthand to create an integer literal.
+    pub fn new_ilit(value: i32) -> Atom {
+        Atom::Literal(Literal::Int(value))
+    }
 }
 
 impl std::fmt::Display for Atom {

--- a/crates/conjure_essence_macros/Cargo.toml
+++ b/crates/conjure_essence_macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "conjure_essence_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+conjure_core = { path = "../conjure_core" }
+conjure_essence_parser = { path = "../conjure_essence_parser" }
+
+tree-sitter = "0.24.7"
+uniplate = "0.2.2"
+quote = "1.0.40"
+syn = { version = "2.0.100", features = ["full"] }
+proc-macro2 = "1.0.94"
+
+[lints]
+workspace = true

--- a/crates/conjure_essence_macros/src/expand.rs
+++ b/crates/conjure_essence_macros/src/expand.rs
@@ -1,0 +1,54 @@
+use super::expression::parse_expr_to_ts;
+use conjure_essence_parser::util::{get_tree, query_toplevel};
+use proc_macro2::{TokenStream, TokenTree};
+use quote::quote;
+use syn::{Error, Result};
+
+pub fn expand_expr(essence: &TokenTree) -> Result<TokenStream> {
+    let src = essence.to_string();
+    let (tree, source_code) =
+        get_tree(&src).ok_or(Error::new(essence.span(), "Could not parse Essence AST"))?;
+    let root = tree.root_node();
+
+    let mut query = query_toplevel(&root, &|n| n.kind() == "expression");
+    let expr_node = query
+        .next()
+        .ok_or(Error::new(essence.span(), "Expected an Essence expression"))?;
+    if let Some(expr) = query.next() {
+        let tokens = &source_code[expr.start_byte()..expr.end_byte()];
+        return Err(Error::new(essence.span(), format!("Unexpected tokens: `{}`. Expected a single Essence expression. Perhaps you meant `essence_exprs!`?", tokens)));
+    }
+
+    let expr = match parse_expr_to_ts(expr_node, &source_code, &root) {
+        Ok(expr) => Ok(expr),
+        Err(err) => {
+            let msg = format!("Error parsing Essence expression: {}", err);
+            Err(Error::new(essence.span(), msg))
+        }
+    }?;
+
+    Ok(expr)
+}
+
+pub fn expand_expr_vec(exprs: TokenStream) -> Result<TokenStream> {
+    let mut ans: Vec<TokenStream> = Vec::new();
+    for tt in exprs.into_iter() {
+        let src = tt.to_string();
+        let (tree, source_code) =
+            get_tree(&src).ok_or(Error::new(tt.span(), "Could not parse Essence AST"))?;
+        let root = tree.root_node();
+
+        let query = query_toplevel(&root, &|n| n.kind() == "expression");
+        for expr_node in query {
+            let expr = match parse_expr_to_ts(expr_node, &source_code, &root) {
+                Ok(expr) => Ok(expr),
+                Err(err) => {
+                    let msg = format!("Error parsing Essence expression: {}", err);
+                    Err(Error::new(tt.span(), msg))
+                }
+            }?;
+            ans.push(expr);
+        }
+    }
+    Ok(quote! { vec![#(#ans),*] })
+}

--- a/crates/conjure_essence_macros/src/expand.rs
+++ b/crates/conjure_essence_macros/src/expand.rs
@@ -20,7 +20,7 @@ pub fn expand_expr(essence: &TokenTree) -> Result<TokenStream> {
     // We only expect one expression, error if that's not the case
     if let Some(expr) = query.next() {
         let tokens = &source_code[expr.start_byte()..expr.end_byte()];
-        return Err(Error::new(essence.span(), format!("Unexpected tokens: `{}`. Expected a single Essence expression. Perhaps you meant `essence_exprs!`?", tokens)));
+        return Err(Error::new(essence.span(), format!("Unexpected tokens: `{}`. Expected a single Essence expression. Perhaps you meant `essence_vec!`?", tokens)));
     }
 
     // Parse expression and build the token stream

--- a/crates/conjure_essence_macros/src/expand.rs
+++ b/crates/conjure_essence_macros/src/expand.rs
@@ -1,54 +1,63 @@
 use super::expression::parse_expr_to_ts;
 use conjure_essence_parser::util::{get_tree, query_toplevel};
 use proc_macro2::{TokenStream, TokenTree};
-use quote::quote;
-use syn::{Error, Result};
+use quote::{quote, ToTokens};
+use syn::{Error, LitStr, Result};
+use tree_sitter::Node;
 
 pub fn expand_expr(essence: &TokenTree) -> Result<TokenStream> {
-    let src = essence.to_string();
+    let src = to_src(essence);
     let (tree, source_code) =
         get_tree(&src).ok_or(Error::new(essence.span(), "Could not parse Essence AST"))?;
     let root = tree.root_node();
 
+    // Get top level expressions
     let mut query = query_toplevel(&root, &|n| n.kind() == "expression");
     let expr_node = query
         .next()
         .ok_or(Error::new(essence.span(), "Expected an Essence expression"))?;
+
+    // We only expect one expression, error if that's not the case
     if let Some(expr) = query.next() {
         let tokens = &source_code[expr.start_byte()..expr.end_byte()];
         return Err(Error::new(essence.span(), format!("Unexpected tokens: `{}`. Expected a single Essence expression. Perhaps you meant `essence_exprs!`?", tokens)));
     }
 
-    let expr = match parse_expr_to_ts(expr_node, &source_code, &root) {
-        Ok(expr) => Ok(expr),
-        Err(err) => {
-            let msg = format!("Error parsing Essence expression: {}", err);
-            Err(Error::new(essence.span(), msg))
-        }
-    }?;
-
+    // Parse expression and build the token stream
+    let expr = mk_expr(expr_node, &source_code, &root, essence)?;
     Ok(expr)
 }
 
-pub fn expand_expr_vec(exprs: TokenStream) -> Result<TokenStream> {
+pub fn expand_expr_vec(tt: &TokenTree) -> Result<TokenStream> {
     let mut ans: Vec<TokenStream> = Vec::new();
-    for tt in exprs.into_iter() {
-        let src = tt.to_string();
-        let (tree, source_code) =
-            get_tree(&src).ok_or(Error::new(tt.span(), "Could not parse Essence AST"))?;
-        let root = tree.root_node();
+    let src = to_src(tt);
+    let (tree, source_code) =
+        get_tree(&src).ok_or(Error::new(tt.span(), "Could not parse Essence AST"))?;
+    let root = tree.root_node();
 
-        let query = query_toplevel(&root, &|n| n.kind() == "expression");
-        for expr_node in query {
-            let expr = match parse_expr_to_ts(expr_node, &source_code, &root) {
-                Ok(expr) => Ok(expr),
-                Err(err) => {
-                    let msg = format!("Error parsing Essence expression: {}", err);
-                    Err(Error::new(tt.span(), msg))
-                }
-            }?;
-            ans.push(expr);
-        }
+    let query = query_toplevel(&root, &|n| n.kind() == "expression");
+    for expr_node in query {
+        let expr = mk_expr(expr_node, &source_code, &root, tt)?;
+        ans.push(expr);
     }
     Ok(quote! { vec![#(#ans),*] })
+}
+
+/// Parse a single expression or make a compile time error
+fn mk_expr(node: Node, src: &str, root: &Node, tt: &TokenTree) -> Result<TokenStream> {
+    match parse_expr_to_ts(node, src, root) {
+        Ok(expr) => Ok(expr),
+        Err(err) => {
+            let msg = format!("Error parsing Essence expression: {}", err);
+            Err(Error::new(tt.span(), msg))
+        }
+    }
+}
+
+/// Parse string literals (gets rid of ""), otherwise use tokens as is
+fn to_src(tt: &TokenTree) -> String {
+    match syn::parse::<LitStr>(tt.to_token_stream().into()) {
+        Ok(src) => src.value(),
+        Err(_) => tt.to_string(),
+    }
 }

--- a/crates/conjure_essence_macros/src/expression.rs
+++ b/crates/conjure_essence_macros/src/expression.rs
@@ -63,7 +63,7 @@ pub fn parse_expr_to_ts(
                 )}),
                 "+" => Ok(quote! {::conjure_core::ast::Expression::Sum(
                     ::conjure_core::metadata::Metadata::new(),
-                    Box::new(matrix_expr![#expr1, #expr2]),
+                    Box::new(::conjure_core::matrix_expr![#expr1, #expr2]),
                 )}),
                 "-" => Ok(quote! {::conjure_core::ast::Expression::Minus(
                     ::conjure_core::metadata::Metadata::new(),
@@ -121,11 +121,11 @@ pub fn parse_expr_to_ts(
                 )}),
                 "/\\" => Ok(quote! {::conjure_core::ast::Expression::And(
                     ::conjure_core::metadata::Metadata::new(),
-                    Box::new(matrix_expr![#expr1, #expr2]),
+                    Box::new(::conjure_core::matrix_expr![#expr1, #expr2]),
                 )}),
                 "\\/" => Ok(quote! {::conjure_core::ast::Expression::Or(
                     ::conjure_core::metadata::Metadata::new(),
-                    Box::new(matrix_expr![#expr1, #expr2]),
+                    Box::new(::conjure_core::matrix_expr![#expr1, #expr2]),
                 )}),
                 "->" => Ok(quote! {::conjure_core::ast::Expression::Imply(
                     ::conjure_core::metadata::Metadata::new(),
@@ -217,21 +217,23 @@ pub fn parse_expr_to_ts(
                     ::conjure_core::ast::Expression::Atomic(_, _) => Ok(quote! {
                         ::conjure_core::ast::Expression::FromSolution(::conjure_core::metadata::Metadata::new(), Box::new(#inner_ts))
                     }),
-                    _ => Err(format!(
+                    _ => Err(
                         "Expression inside a `fromSolution()` must be a variable name"
-                    )
-                    .into()),
+                            .to_string()
+                            .into(),
+                    ),
                 }
             }
-            _ => Err(format!(
+            _ => Err(
                 "`fromSolution()` is only allowed inside dominance relation definitions"
-            )
-            .into()),
+                    .to_string()
+                    .into(),
+            ),
         },
         "metavar" => {
             let inner = constraint
                 .named_child(0)
-                .ok_or(format!("Expected name for meta-variable"))?;
+                .ok_or("Expected name for meta-variable".to_string())?;
             let name = &source_code[inner.start_byte()..inner.end_byte()];
             let ident = Ident::new(name, Span::call_site());
             Ok(quote! {#ident.into()})

--- a/crates/conjure_essence_macros/src/expression.rs
+++ b/crates/conjure_essence_macros/src/expression.rs
@@ -1,234 +1,252 @@
-use conjure_core::ast::Expression;
-use conjure_core::metadata::Metadata;
-use conjure_essence_parser::errors::{ConjureParseError, EssenceParseError};
+use conjure_essence_parser::errors::EssenceParseError;
 use conjure_essence_parser::expression::child_expr;
 use conjure_essence_parser::util::named_children;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
+use syn::Ident;
 use tree_sitter::Node;
 
-/// Parse an Essence expression into its Conjure AST representation.
-pub fn expand_expression(
+// TODO (gskorokhod) - This is a lot of code duplication, but I don't see an easy way to avoid it short of a ~visitor pattern~ of some sort.
+
+/// "Sister function" to conjure_essence_parser::::conjure_core::ast::Expression::parse_::conjure_core::ast::Expression.
+/// Instead of actually constructing the AST, this returns its constructor as a TokenStream.
+/// Intended for compile-time parsing inside macros.
+pub fn parse_expr_to_ts(
     constraint: Node,
     source_code: &str,
     root: &Node,
-) -> Result<Expression, EssenceParseError> {
+) -> Result<TokenStream, EssenceParseError> {
     match constraint.kind() {
         "constraint" | "expression" | "boolean_expr" | "comparison_expr" | "arithmetic_expr"
-        | "primary_expr" | "sub_expr" => child_expr(constraint, source_code, root),
-        "not_expr" => Ok(Expression::Not(
-            Metadata::new(),
-            Box::new(child_expr(constraint, source_code, root)?),
-        )),
-        "abs_value" => Ok(Expression::Abs(
-            Metadata::new(),
-            Box::new(child_expr(constraint, source_code, root)?),
-        )),
-        "negative_expr" => Ok(Expression::Neg(
-            Metadata::new(),
-            Box::new(child_expr(constraint, source_code, root)?),
-        )),
+        | "primary_expr" | "sub_expr" => child_expr_to_ts(constraint, source_code, root),
+        "not_expr" => {
+            let child = child_expr_to_ts(constraint, source_code, root)?;
+            Ok(quote! {::conjure_core::ast::Expression::Not(
+                ::conjure_core::metadata::Metadata::new(),
+                Box::new(#child),
+            )})
+        }
+        "abs_value" => {
+            let child = child_expr_to_ts(constraint, source_code, root)?;
+            Ok(quote! {
+                ::conjure_core::ast::Expression::Abs(
+                ::conjure_core::metadata::Metadata::new(),
+                Box::new(#child),
+            )})
+        }
+        "negative_expr" => {
+            let child = child_expr_to_ts(constraint, source_code, root)?;
+            Ok(quote! {::conjure_core::ast::Expression::Neg(
+                ::conjure_core::metadata::Metadata::new(),
+                Box::new(#child),
+            )})
+        }
         "exponent" | "product_expr" | "sum_expr" | "comparison" | "and_expr" | "or_expr"
         | "implication" => {
-            let expr1 = child_expr(constraint, source_code, root)?;
-            let op = constraint.child(1).ok_or(ConjureParseError::Parse(format!(
+            let expr1 = child_expr_to_ts(constraint, source_code, root)?;
+            let op = constraint.child(1).ok_or(format!(
                 "Missing operator in expression {}",
                 constraint.kind()
-            )))?;
+            ))?;
             let op_type = &source_code[op.start_byte()..op.end_byte()];
-            let expr2_node = constraint.child(2).ok_or(ConjureParseError::Parse(format!(
+            let expr2_node = constraint.child(2).ok_or(format!(
                 "Missing second operand in expression {}",
                 constraint.kind()
-            )))?;
-            let expr2 = parse_expression(expr2_node, source_code, root)?;
+            ))?;
+            let expr2 = parse_expr_to_ts(expr2_node, source_code, root)?;
 
             match op_type {
-                "**" => Ok(Expression::UnsafePow(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "+" => Ok(Expression::Sum(
-                    Metadata::new(),
-                    Box::new(matrix_expr![expr1, expr2]),
-                )),
-                "-" => Ok(Expression::Minus(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "*" => Ok(Expression::Product(Metadata::new(), vec![expr1, expr2])),
+                "**" => Ok(quote! {::conjure_core::ast::Expression::UnsafePow(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "+" => Ok(quote! {::conjure_core::ast::Expression::Sum(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(matrix_expr![#expr1, #expr2]),
+                )}),
+                "-" => Ok(quote! {::conjure_core::ast::Expression::Minus(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "*" => Ok(
+                    quote! {::conjure_core::ast::Expression::Product(::conjure_core::metadata::Metadata::new(), vec![#expr1, #expr2])},
+                ),
                 "/" => {
                     //TODO: add checks for if division is safe or not
-                    Ok(Expression::UnsafeDiv(
-                        Metadata::new(),
-                        Box::new(expr1),
-                        Box::new(expr2),
-                    ))
+                    Ok(quote! {::conjure_core::ast::Expression::UnsafeDiv(
+                        ::conjure_core::metadata::Metadata::new(),
+                        Box::new(#expr1),
+                        Box::new(#expr2),
+                    )})
                 }
                 "%" => {
                     //TODO: add checks for if mod is safe or not
-                    Ok(Expression::UnsafeMod(
-                        Metadata::new(),
-                        Box::new(expr1),
-                        Box::new(expr2),
-                    ))
+                    Ok(quote! {::conjure_core::ast::Expression::UnsafeMod(
+                        ::conjure_core::metadata::Metadata::new(),
+                        Box::new(#expr1),
+                        Box::new(#expr2),
+                    )})
                 }
-                "=" => Ok(Expression::Eq(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "!=" => Ok(Expression::Neq(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "<=" => Ok(Expression::Leq(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                ">=" => Ok(Expression::Geq(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "<" => Ok(Expression::Lt(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                ">" => Ok(Expression::Gt(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                "/\\" => Ok(Expression::And(
-                    Metadata::new(),
-                    Box::new(matrix_expr![expr1, expr2]),
-                )),
-                "\\/" => Ok(Expression::Or(
-                    Metadata::new(),
-                    Box::new(matrix_expr![expr1, expr2]),
-                )),
-                "->" => Ok(Expression::Imply(
-                    Metadata::new(),
-                    Box::new(expr1),
-                    Box::new(expr2),
-                )),
-                _ => panic!("Error: unsupported operator"),
+                "=" => Ok(quote! {::conjure_core::ast::Expression::Eq(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "!=" => Ok(quote! {::conjure_core::ast::Expression::Neq(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "<=" => Ok(quote! {::conjure_core::ast::Expression::Leq(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                ">=" => Ok(quote! {::conjure_core::ast::Expression::Geq(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "<" => Ok(quote! {::conjure_core::ast::Expression::Lt(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                ">" => Ok(quote! {::conjure_core::ast::Expression::Gt(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                "/\\" => Ok(quote! {::conjure_core::ast::Expression::And(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(matrix_expr![#expr1, #expr2]),
+                )}),
+                "\\/" => Ok(quote! {::conjure_core::ast::Expression::Or(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(matrix_expr![#expr1, #expr2]),
+                )}),
+                "->" => Ok(quote! {::conjure_core::ast::Expression::Imply(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(#expr1),
+                    Box::new(#expr2),
+                )}),
+                _ => Err(format!("Unsupported operator '{}'", op_type).into()),
             }
         }
         "quantifier_expr" => {
             let mut expr_list = Vec::new();
             for expr in named_children(&constraint) {
-                expr_list.push(parse_expression(expr, source_code, root)?);
+                expr_list.push(parse_expr_to_ts(expr, source_code, root)?);
             }
 
-            let quantifier = constraint.child(0).unwrap_or_else(|| {
-                panic!(
-                    "Error: missing node in expression of kind {}",
-                    constraint.kind()
-                )
-            });
+            let quantifier = constraint.child(0).ok_or(format!(
+                "Missing quantifier in expression {}",
+                constraint.kind()
+            ))?;
             let quantifier_type = &source_code[quantifier.start_byte()..quantifier.end_byte()];
 
             match quantifier_type {
-                "and" => Ok(Expression::And(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                "or" => Ok(Expression::Or(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                "min" => Ok(Expression::Min(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                "max" => Ok(Expression::Max(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                "sum" => Ok(Expression::Sum(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                "allDiff" => Ok(Expression::AllDiff(
-                    Metadata::new(),
-                    Box::new(into_matrix_expr![expr_list]),
-                )),
-                _ => panic!("Error: unsupported quantifier"),
+                "and" => Ok(quote! {::conjure_core::ast::Expression::And(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                "or" => Ok(quote! {::conjure_core::ast::Expression::Or(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                "min" => Ok(quote! {::conjure_core::ast::Expression::Min(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                "max" => Ok(quote! {::conjure_core::ast::Expression::Max(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                "sum" => Ok(quote! {::conjure_core::ast::Expression::Sum(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                "allDiff" => Ok(quote! {::conjure_core::ast::Expression::AllDiff(
+                    ::conjure_core::metadata::Metadata::new(),
+                    Box::new(::conjure_core::matrix_expr![#(#expr_list),*]),
+                )}),
+                _ => Err(format!("Unsupported quantifier {}", constraint.kind()).into()),
             }
         }
         "constant" => {
-            let child = constraint.child(0).unwrap_or_else(|| {
-                panic!(
-                    "Error: missing node in expression of kind {}",
-                    constraint.kind()
-                )
-            });
+            let child = constraint.child(0).ok_or(format!(
+                "Missing value for constant expression {}",
+                constraint.kind()
+            ))?;
             match child.kind() {
                 "integer" => {
                     let constant_value = &source_code[child.start_byte()..child.end_byte()]
                         .parse::<i32>()
                         .unwrap();
-                    Ok(Expression::Atomic(
-                        Metadata::new(),
-                        Atom::Literal(Literal::Int(*constant_value)),
-                    ))
+                    Ok(quote! {::conjure_core::ast::Expression::Atomic(
+                        ::conjure_core::metadata::Metadata::new(),
+                        ::conjure_core::ast::Atom::Literal(::conjure_core::ast::Literal::Int(#constant_value)),
+                    )})
                 }
-                "TRUE" => Ok(Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Bool(true)),
-                )),
-                "FALSE" => Ok(Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Bool(false)),
-                )),
-                _ => Err(ConjureParseError::Parse(format!(
-                    "Unsupported constant kind: {}",
-                    child.kind()
-                ))
-                .into()),
+                "TRUE" => Ok(quote! {::conjure_core::ast::Expression::Atomic(
+                    ::conjure_core::metadata::Metadata::new(),
+                    ::conjure_core::ast::Atom::Literal(::conjure_core::ast::Literal::Bool(true)),
+                )}),
+                "FALSE" => Ok(quote! {::conjure_core::ast::Expression::Atomic(
+                    ::conjure_core::metadata::Metadata::new(),
+                    ::conjure_core::ast::Atom::Literal(::conjure_core::ast::Literal::Bool(false)),
+                )}),
+                _ => Err(format!("Unsupported constant kind: {}", child.kind()).into()),
             }
         }
         "variable" => {
             let variable_name =
                 String::from(&source_code[constraint.start_byte()..constraint.end_byte()]);
-            Ok(Expression::Atomic(
-                Metadata::new(),
-                Atom::Reference(Name::UserName(variable_name)),
-            ))
+            Ok(quote! {::conjure_core::ast::Expression::Atomic(
+                ::conjure_core::metadata::Metadata::new(),
+                ::conjure_core::ast::Atom::Reference(::conjure_core::ast::Name::UserName(#variable_name.into())),
+            )})
         }
         "from_solution" => match root.kind() {
             "dominance_relation" => {
+                let inner_ts = child_expr_to_ts(constraint, source_code, root)?;
                 let inner = child_expr(constraint, source_code, root)?;
                 match inner {
-                    Expression::Atomic(_, _) => {
-                        Ok(Expression::FromSolution(Metadata::new(), Box::new(inner)))
-                    }
-                    _ => panic!("Expression inside a `fromSolution()` must be a variable name"),
+                    ::conjure_core::ast::Expression::Atomic(_, _) => Ok(quote! {
+                        ::conjure_core::ast::Expression::FromSolution(::conjure_core::metadata::Metadata::new(), Box::new(#inner_ts))
+                    }),
+                    _ => Err(format!(
+                        "Expression inside a `fromSolution()` must be a variable name"
+                    )
+                    .into()),
                 }
             }
-            _ => panic!("`fromSolution()` is only allowed inside dominance relation definitions"),
+            _ => Err(format!(
+                "`fromSolution()` is only allowed inside dominance relation definitions"
+            )
+            .into()),
         },
-        _ => panic!("{} is not a recognized node kind", constraint.kind()),
+        "metavar" => {
+            let inner = constraint
+                .named_child(0)
+                .ok_or(format!("Expected name for meta-variable"))?;
+            let name = &source_code[inner.start_byte()..inner.end_byte()];
+            let ident = Ident::new(name, Span::call_site());
+            Ok(quote! {#ident.into()})
+        }
+        _ => Err(format!("{} is not a recognized node kind", constraint.kind()).into()),
     }
 }
 
-pub fn expand_child_expr(
+fn child_expr_to_ts(
     node: Node,
     source_code: &str,
     root: &Node,
-) -> Result<Expression, EssenceParseError> {
+) -> Result<TokenStream, EssenceParseError> {
     match node.named_child(0) {
-        Some(child) => parse_expression(child, source_code, root),
-        None => Err(ConjureParseError::Parse(format!(
-            "Missing node in expression of kind {}",
-            node.kind()
-        ))
-        .into()),
+        Some(child) => parse_expr_to_ts(child, source_code, root),
+        None => Err(format!("Missing node in expression of kind {}", node.kind()).into()),
     }
 }

--- a/crates/conjure_essence_macros/src/expression.rs
+++ b/crates/conjure_essence_macros/src/expression.rs
@@ -1,21 +1,18 @@
-#![allow(clippy::legacy_numeric_constants)]
+use conjure_core::ast::Expression;
+use conjure_core::metadata::Metadata;
+use conjure_essence_parser::errors::{ConjureParseError, EssenceParseError};
+use conjure_essence_parser::expression::child_expr;
+use conjure_essence_parser::util::named_children;
+use proc_macro2::TokenStream;
+use quote::quote;
 use tree_sitter::Node;
 
-use conjure_core::ast::{Atom, Expression, Literal, Name};
-use conjure_core::metadata::Metadata;
-use conjure_core::{into_matrix_expr, matrix_expr};
-
-use crate::errors::{ConjureParseError, EssenceParseError};
-
-use super::util::named_children;
-
 /// Parse an Essence expression into its Conjure AST representation.
-pub fn parse_expression(
+pub fn expand_expression(
     constraint: Node,
     source_code: &str,
     root: &Node,
 ) -> Result<Expression, EssenceParseError> {
-    // TODO (gskorokhod) - Factor this further (make match arms into separate functions, extract common logic)
     match constraint.kind() {
         "constraint" | "expression" | "boolean_expr" | "comparison_expr" | "arithmetic_expr"
         | "primary_expr" | "sub_expr" => child_expr(constraint, source_code, root),
@@ -221,7 +218,7 @@ pub fn parse_expression(
     }
 }
 
-pub fn child_expr(
+pub fn expand_child_expr(
     node: Node,
     source_code: &str,
     root: &Node,

--- a/crates/conjure_essence_macros/src/lib.rs
+++ b/crates/conjure_essence_macros/src/lib.rs
@@ -1,24 +1,26 @@
-use conjure_essence_parser::expression::parse_expression;
-use conjure_essence_parser::util::{get_metavars, get_tree, query_toplevel};
 use proc_macro::TokenStream;
-#[allow(unused)]
-use uniplate::Uniplate;
+use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
 
-use quote::quote;
-use syn::{parse::Parse, parse::ParseStream, parse_macro_input, LitStr, Result};
-
+mod expand;
 mod expression;
 
-struct EssenceExprArgs {
-    essence: LitStr,
-}
+use expand::*;
 
-impl Parse for EssenceExprArgs {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let essence = input.parse::<LitStr>()?;
-        Ok(Self { essence })
+#[proc_macro]
+pub fn essence_expr(args: TokenStream) -> TokenStream {
+    let ts = TokenStream2::from(args);
+    let tt = TokenTree::Group(Group::new(Delimiter::None, ts));
+    match expand_expr(&tt) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
     }
 }
 
 #[proc_macro]
-pub fn essence_expr(args: TokenStream) -> TokenStream {}
+pub fn essence_vec(args: TokenStream) -> TokenStream {
+    let ts = TokenStream2::from(args);
+    match expand_expr_vec(ts) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/conjure_essence_macros/src/lib.rs
+++ b/crates/conjure_essence_macros/src/lib.rs
@@ -1,0 +1,24 @@
+use conjure_essence_parser::expression::parse_expression;
+use conjure_essence_parser::util::{get_metavars, get_tree, query_toplevel};
+use proc_macro::TokenStream;
+#[allow(unused)]
+use uniplate::Uniplate;
+
+use quote::quote;
+use syn::{parse::Parse, parse::ParseStream, parse_macro_input, LitStr, Result};
+
+mod expression;
+
+struct EssenceExprArgs {
+    essence: LitStr,
+}
+
+impl Parse for EssenceExprArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let essence = input.parse::<LitStr>()?;
+        Ok(Self { essence })
+    }
+}
+
+#[proc_macro]
+pub fn essence_expr(args: TokenStream) -> TokenStream {}

--- a/crates/conjure_essence_macros/src/lib.rs
+++ b/crates/conjure_essence_macros/src/lib.rs
@@ -4,8 +4,33 @@ use proc_macro2::{Delimiter, Group, TokenStream as TokenStream2, TokenTree};
 mod expand;
 mod expression;
 
-use expand::*;
+use expand::{expand_expr, expand_expr_vec};
 
+/// Parses an Essence expression into its corresponding Conjure AST at compile time.
+///
+/// ## Input
+/// The input can be one of the following:
+/// - The raw Essence tokens (`essence_expr!(2 + 2)`)
+/// - A string literal (`essence_expr!("2 + 2")`)
+///
+/// The macro may reference variables in the current scope (called "metavars")
+/// using the syntax `&<name>`. For example:
+/// ```
+/// use conjure_essence_macros::essence_expr;
+/// let x = 42;
+/// essence_expr!(2 + &x);
+/// ```
+///
+/// ## Expansion
+/// If the input is valid Essence, expands to a valid AST constructor
+///
+/// ## Note
+/// Some characters (e.g. `\`) are valid Essence tokens, but not Rust tokens.
+/// If you encounter an error similar to:
+///
+/// > rustc: unknown start of token: \
+///
+/// The workaround is to wrap the Essence code in a string literal (e.g. `r"a /\ b"`).
 #[proc_macro]
 pub fn essence_expr(args: TokenStream) -> TokenStream {
     let ts = TokenStream2::from(args);
@@ -16,10 +41,38 @@ pub fn essence_expr(args: TokenStream) -> TokenStream {
     }
 }
 
+/// Parses a sequence of Essence expressions into a vector of Conjure AST instances
+///
+/// ## Example
+/// ```rust
+/// use conjure_core::ast::{Atom, Expression};
+/// use conjure_core::matrix_expr;
+/// use conjure_core::metadata::Metadata;
+/// use conjure_essence_macros::essence_vec;
+///
+/// let exprs = essence_vec!(a + 2, b = true);
+/// println!("{:?}", exprs);
+/// assert_eq!(exprs.len(), 2);
+/// assert_eq!(
+///     exprs[0],
+///     Expression::Sum(Metadata::new(), Box::new(matrix_expr![
+///         Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
+///         Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+///     ]))
+/// );
+/// assert_eq!(
+///    exprs[1],
+///     Expression::Eq(Metadata::new(),
+///         Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b"))),
+///         Box::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
+///     )
+/// );
+/// ```
 #[proc_macro]
 pub fn essence_vec(args: TokenStream) -> TokenStream {
     let ts = TokenStream2::from(args);
-    match expand_expr_vec(ts) {
+    let tt = TokenTree::Group(Group::new(Delimiter::None, ts));
+    match expand_expr_vec(&tt) {
         Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }

--- a/crates/conjure_essence_parser/src/errors.rs
+++ b/crates/conjure_essence_parser/src/errors.rs
@@ -22,3 +22,15 @@ impl From<ConjureParseError> for EssenceParseError {
         EssenceParseError::ParseError(e)
     }
 }
+
+impl From<&str> for EssenceParseError {
+    fn from(e: &str) -> Self {
+        EssenceParseError::ParseError(ConjureParseError::Parse(e.to_string()))
+    }
+}
+
+impl From<String> for EssenceParseError {
+    fn from(e: String) -> Self {
+        EssenceParseError::ParseError(ConjureParseError::Parse(e))
+    }
+}

--- a/crates/conjure_essence_parser/src/errors.rs
+++ b/crates/conjure_essence_parser/src/errors.rs
@@ -1,4 +1,4 @@
-use conjure_core::error::Error as ConjureParseError;
+pub use conjure_core::error::Error as ConjureParseError;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]

--- a/crates/conjure_essence_parser/src/lib.rs
+++ b/crates/conjure_essence_parser/src/lib.rs
@@ -1,6 +1,6 @@
-mod errors;
+pub mod errors;
 mod parser;
-mod parser_legacy;
+pub mod parser_legacy;
 
 pub use errors::EssenceParseError;
 pub use parser::*;

--- a/crates/conjure_essence_parser/src/parser/expression.rs
+++ b/crates/conjure_essence_parser/src/parser/expression.rs
@@ -203,16 +203,18 @@ pub fn parse_expression(
                     Expression::Atomic(_, _) => {
                         Ok(Expression::FromSolution(Metadata::new(), Box::new(inner)))
                     }
-                    _ => Err(format!(
+                    _ => Err(
                         "Expression inside a `fromSolution()` must be a variable name"
-                    )
-                    .into()),
+                            .to_string()
+                            .into(),
+                    ),
                 }
             }
-            _ => Err(format!(
+            _ => Err(
                 "`fromSolution()` is only allowed inside dominance relation definitions"
-            )
-            .into()),
+                    .to_string()
+                    .into(),
+            ),
         },
         _ => Err(format!("{} is not a recognized node kind", constraint.kind()).into()),
     }

--- a/crates/conjure_essence_parser/src/parser/letting.rs
+++ b/crates/conjure_essence_parser/src/parser/letting.rs
@@ -4,15 +4,18 @@ use std::rc::Rc;
 
 use tree_sitter::Node;
 
-use conjure_core::ast::Declaration;
-use conjure_core::ast::{Name, SymbolTable};
-
 use super::domain::parse_domain;
 use super::expression::parse_expression;
 use super::util::named_children;
+use crate::errors::EssenceParseError;
+use conjure_core::ast::Declaration;
+use conjure_core::ast::{Name, SymbolTable};
 
 /// Parse a letting statement into a SymbolTable containing the declared symbols
-pub fn parse_letting_statement(letting_statement_list: Node, source_code: &str) -> SymbolTable {
+pub fn parse_letting_statement(
+    letting_statement_list: Node,
+    source_code: &str,
+) -> Result<SymbolTable, EssenceParseError> {
     let mut symbol_table = SymbolTable::new();
 
     for letting_statement in named_children(&letting_statement_list) {
@@ -32,7 +35,7 @@ pub fn parse_letting_statement(letting_statement_list: Node, source_code: &str) 
                 for name in temp_symbols {
                     symbol_table.insert(Rc::new(Declaration::new_value_letting(
                         Name::UserName(String::from(name)),
-                        parse_expression(expr_or_domain, source_code, &letting_statement_list),
+                        parse_expression(expr_or_domain, source_code, &letting_statement_list)?,
                     )));
                 }
             }
@@ -47,5 +50,5 @@ pub fn parse_letting_statement(letting_statement_list: Node, source_code: &str) 
             _ => panic!("Unrecognized node in letting statement"),
         }
     }
-    symbol_table
+    Ok(symbol_table)
 }

--- a/crates/conjure_essence_parser/src/parser/parse_exprs.rs
+++ b/crates/conjure_essence_parser/src/parser/parse_exprs.rs
@@ -19,19 +19,14 @@ pub fn parse_expr(src: &str) -> Result<Expression, EssenceParseError> {
 }
 
 pub fn parse_exprs(src: &str) -> Result<Vec<Expression>, EssenceParseError> {
-    let (tree, source_code) = match get_tree(src) {
-        Some(t) => t,
-        None => {
-            return Err(EssenceParseError::TreeSitterError(
-                "Failed to parse source code".to_string(),
-            ))
-        }
-    };
+    let (tree, source_code) = get_tree(src).ok_or(EssenceParseError::TreeSitterError(
+        "Failed to parse Essence source code".to_string(),
+    ))?;
 
     let root = tree.root_node();
     let mut ans = Vec::new();
     for expr in query_toplevel(&root, &|n| n.kind() == "expression") {
-        ans.push(parse_expression(expr, &source_code, &root));
+        ans.push(parse_expression(expr, &source_code, &root)?);
     }
     Ok(ans)
 }

--- a/crates/conjure_essence_parser/src/parser/parse_model.rs
+++ b/crates/conjure_essence_parser/src/parser/parse_model.rs
@@ -59,21 +59,25 @@ pub fn parse_essence_with_context(
                 let mut constraint_vec: Vec<Expression> = Vec::new();
                 for constraint in named_children(&statement) {
                     if constraint.kind() != "single_line_comment" {
-                        constraint_vec.push(parse_expression(constraint, &source_code, &statement));
+                        constraint_vec.push(parse_expression(
+                            constraint,
+                            &source_code,
+                            &statement,
+                        )?);
                     }
                 }
                 model.as_submodel_mut().add_constraints(constraint_vec);
             }
             "language_label" => {}
             "letting_statement_list" => {
-                let letting_vars = parse_letting_statement(statement, &source_code);
+                let letting_vars = parse_letting_statement(statement, &source_code)?;
                 model.as_submodel_mut().symbols_mut().extend(letting_vars);
             }
             "dominance_relation" => {
                 let inner = statement
                     .child(1)
                     .expect("Expected a sub-expression inside `dominanceRelation`");
-                let expr = parse_expression(inner, &source_code, &statement);
+                let expr = parse_expression(inner, &source_code, &statement)?;
                 let dominance = Expression::DominanceRelation(Metadata::new(), Box::new(expr));
                 if model.dominance.is_some() {
                     return Err(EssenceParseError::ParseError(Error::Parse(

--- a/crates/tree-sitter-essence/grammar.js
+++ b/crates/tree-sitter-essence/grammar.js
@@ -35,6 +35,9 @@ module.exports = grammar ({
 
     variable: $ => /[a-zA-Z_][a-zA-Z0-9_]*/,
 
+    //meta-variable (aka template argument)
+    metavar: $ => seq("&", $.variable),
+
     //find statements
     find_statement_list: $ => seq("find", repeat($.find_statement)),
 
@@ -101,6 +104,7 @@ module.exports = grammar ({
 
     expression: $ => choice(
       seq("(", $.expression, ")"),
+      $.metavar,
       $.not_expr,
       $.abs_value,
       $.exponent,


### PR DESCRIPTION
> If {thing} is so good, why didn't they make {thing} 2?
> (c) unknown

This PR implements the alternative approach to parsing Essence at compile time, as discussed in the comments for #710.
It achieves the same results (complete with metavar support!) with significantly less complexity.

It also attempts to produce some semi-useful compile time errors for bad input. 

## Example

```rust
#[test]
fn test_metavar_const() {
    let x = 4;
    let expr = essence_expr!(&x + 2);
    assert_eq!(
        expr,
        Expression::Sum(
            Metadata::new(),
            Box::new(matrix_expr![
                Expression::Atomic(Metadata::new(), Atom::new_ilit(4)),
                Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
            ])
        )
    );
}
```