### PR TITLE
fixing bug where accept=true testing would fail

### DIFF
--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -303,6 +303,7 @@ pub fn normalize_solutions_for_comparison(
                             }));
                         updates.push((k, Literal::AbstractLiteral(tuple)));
                     }
+                    Literal::Int(_) => {}
                     e => bug!("unexpected literal type: {e:?}"),
                 }
             }


### PR DESCRIPTION
Normalising solutions didn't have a case for integer Literals, leading to errors on any test which included ints when using ACCEPT=true