### PR TITLE
fix(build): unnecessary rebuilding of conjure_oxide, tree-sitter-essence

### DIFF
--- a/conjure_oxide/build.rs
+++ b/conjure_oxide/build.rs
@@ -8,7 +8,7 @@ use walkdir::WalkDir;
 fn main() -> io::Result<()> {
     println!("cargo:rerun-if-changed=tests/integration");
     println!("cargo:rerun-if-changed=tests/custom");
-    println!("cargo:rerun-if-changed=tests/gen_test_template");
+    println!("cargo:rerun-if-changed=tests/integration_test_template");
     println!("cargo:rerun-if-changed=tests/custom_test_template");
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/crates/tree-sitter-essence/bindings/rust/build.rs
+++ b/crates/tree-sitter-essence/bindings/rust/build.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 use tree_sitter_generate::generate_parser_in_directory;
 
 fn main() {
+    println!("cargo:rerun-if-changed=grammar.js");
+
     let src_dir = Path::new("src");
 
     generate_parser_in_directory(Path::new(""), Some("grammar.js"), 13, None, None)
@@ -15,7 +17,6 @@ fn main() {
 
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
     c_config.compile("tree-sitter-essence");
 }


### PR DESCRIPTION
Fix unnecessary rebuilding of the `conjure_oxide` and
`tree-sitter-essence` crates.

* Fix typo in `conjure_oxide/build.rs`. This was checking for a
  change to a file that no longer exists (gen_test_template); as this
  check always failed, a rebuild was always triggered.

* Rebuild `tree-sitter-essence` on change to the `grammar.js` file, not
  `parser.c`. The `build.rs` file for `tree-sitter-essence` always
  regenerated `parser.c`. As Rust's rebuild-on-changed mechanism is
  timestamp based, this regeneration would always cause rebuilds of the
  `tree-sitter-essence` crate.
