### PR TITLE
fix: don't apply any transformation if reduction is empty

### DIFF
--- a/crates/conjure_core/src/rule_engine/rule.rs
+++ b/crates/conjure_core/src/rule_engine/rule.rs
@@ -213,7 +213,9 @@ impl MorphRule<Expression, SymbolTable> for Rule<'_> {
     ) -> Option<Expression> {
         let reduction = self.apply(subtree, meta).ok()?;
         commands.mut_meta(Box::new(|m: &mut SymbolTable| m.extend(reduction.symbols)));
-        commands.transform(Box::new(|m| m.extend_root(reduction.new_top)));
+        if !reduction.new_top.is_empty() {
+            commands.transform(Box::new(|m| m.extend_root(reduction.new_top)));
+        }
         Some(reduction.new_expression)
     }
 }


### PR DESCRIPTION
in #756 I missed the other definition of MorphRule. This PR adds the same change I've made there but for that other definitoin