### PR TITLE
feat(ci)!: add Docker images, use them to build Conjure Oxide

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,6 @@
-name: Nightly CI 
+name: Nightly CI
 
-# Nightly CI. 
+# Nightly CI.
 #
 # If the repo has changed over the last 24 hours, check that Conjure Oxide
 # clean builds on all platforms, create an updated nightly release, and run
@@ -9,43 +9,22 @@ name: Nightly CI
 # Nightly Releases
 # ===============
 #
-# `build_nightly` builds Conjure Oxide on all platforms, prepares release
-# archives, and uploads these as Github artifacts for later jobs to use.
+# `build_nightly` builds Conjure Oxide on all platforms and prepares release
+# archives.
 #
-# The archives made are described in the Build Artifacts section below.
 #
 # If builds pass on all platform, the nightly release and tag is updated to the
-# current HEAD by the `create_release` job; otherwise, it is left unchanged.
-# This ensures that there is always a build of Conjure Oxide for each platform
-# in the releases tab.
+# current HEAD by the `create_release` job, and the release archives uploaded;
+# otherwise, it is left unchanged. This ensures that there is always a build of
+# Conjure Oxide for each platform in the releases tab.
 #
-# Nightly Tests
-# =============
-#
-# In the future, this workflow will run long running CI jobs (e.g. performance
-# testing, more extensive language coverage checks).
-#
-# To add such a job, make a new job which depends on `build_nightly` (`need:
-# build_nightly`). Then, install Conjure Oxide and all its dependences using
-# the build artifacts (described below).
-#
-# Using the build artifacts saves each test from having to download/compile
-# Conjure Oxide and dependencies from scratch.
+# The contents of each release are described in the Build Artifacts section
+# below.
 #
 # Build Artifacts
-# ===============
+# ---------------
 #
-# `build_nightly` uploads the produced releases for each platform to a Github
-# artifact of name `conjure-oxide-nightly-PLATFORM`.
-#
-# Valid values of PLATFORM are: 
-#
-#     - aarch64-linux-gnu
-#     - aarch64-darwin
-#     - x86_64-linux-gnu
-#     - x86_64-darwin
-#
-# Each artifact contains 3 zip files:
+# For each platform, this CI creates the following archives:
 #
 #   - conjure-oxide-nightly-PLATFORM-standalone.zip - just conjure oxide
 #   - conjure-oxide-nightly-PLATFORM-with-conjure.zip - just conjure oxide and conjure
@@ -53,22 +32,29 @@ name: Nightly CI
 #   conjure, savilerow, and all solvers (as provided by conjure's with-solvers
 #   release)
 #
-# An exception to the rule is `aarch64-linux-gnu`, which only provides a
-# standalone release. This is because `conjure` does not provide a release for
-# `aarch64-linux-gnu`.
-# 
-# To download artifacts in a job, use actions/download-artifact.
+# Valid values of PLATFORM are:
+#
+#     - aarch64-darwin
+#     - x86_64-linux-gnu
+#     - x86_64-darwin
+#
+# Linux builds are performed in a manylinux (github.com/pypa/manylinux)
+# container to ensure compatibility with the older glibc versions, such as
+# those found in RHEL/Alma and Debian. For more details, see the Dockerfile.
+#
+# We don't support aarch64-linux-gnu yet as Conjure does not provide a release
+# for it.
 
-on: 
+on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
-  contents: write  
+  contents: write
+
 
 jobs:
-
   # check if anything has happened in the repo today
   #
   # https://stackoverflow.com/a/67527144
@@ -79,6 +65,7 @@ jobs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
       - uses: actions/checkout@v4
+
       - name: print latest_commit
         run: echo ${{ github.sha }}
 
@@ -89,32 +76,159 @@ jobs:
         run: test -z $(git rev-list  --after="24 hours" ${{ github.sha }}) && echo "::set-output name=should_run::false" &&  gh run list -b main -w Test -L 1 --json conclusion | jq '.[].conclusion == "success"'
 
 
+  # From https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+  publish_container:
+    name: Publish Container (conjure-oxide:nightly)
+    runs-on: ubuntu-latest
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
 
-  build_nightly:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Container
+      # registry registry using the account and password that will publish the
+      # packages. Once published, the packages are scoped to the account
+      # defined here.
+      #
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+        # This step uses
+        # [docker/metadata-action](https://github.com/docker/metadata-action#about)
+        # to extract tags and labels that will be applied to the specified image. The
+        # `id` "meta" allows the output of this step to be referenced in a subsequent
+        # step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            nightly
+            type=sha
+
+      # This step uses the `docker/build-push-action` action to build the
+      # image, based on your repository's `Dockerfile`. If the build
+      # succeeds, it pushes the image to GitHub Packages. It uses the `context`
+      # parameter to define the build's context as the set of files located in the
+      # specified path. For more information, see
+      # [Usage](https://github.com/docker/build-push-action#usage) in the README of
+      # the `docker/build-push-action` repository. It uses the `tags` and `labels`
+      # parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+
+
+  # From https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+  publish_build_container:
+    name: Publish Container (conjure-oxide:build-environment-nightly)
+    runs-on: ubuntu-latest
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Container
+      # registry registry using the account and password that will publish the
+      # packages. Once published, the packages are scoped to the account
+      # defined here.
+      #
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+        # This step uses
+        # [docker/metadata-action](https://github.com/docker/metadata-action#about)
+        # to extract tags and labels that will be applied to the specified image. The
+        # `id` "meta" allows the output of this step to be referenced in a subsequent
+        # step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            # no latest tag
+            latest=false
+            prefix=build-environment-
+
+          tags: |
+            nightly
+
+      # This step uses the `docker/build-push-action` action to build the
+      # image, based on your repository's `Dockerfile`. If the build
+      # succeeds, it pushes the image to GitHub Packages. It uses the `context`
+      # parameter to define the build's context as the set of files located in the
+      # specified path. For more information, see
+      # [Usage](https://github.com/docker/build-push-action#usage) in the README of
+      # the `docker/build-push-action` repository. It uses the `tags` and `labels`
+      # parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: .
+          push: true
+          target: build-environment
+          provenance: false
+
+
+  build_nightly_mac:
     name: "Build Nightly (${{ matrix.arch_name }}-${{ matrix.os_name }})"
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
-    strategy: 
+    strategy:
       fail-fast: false
       matrix:
-        os: 
-          - ubuntu-24.04     # x86_64 linux
-          - ubuntu-24.04-arm # aarch64 linux 
+        os:
           - macos-13         # x86_64 mac
           - macos-latest     # aarch64 mac
 
         # platform and arch info for naming the binary
         include:
-          - os: ubuntu-24.04
-            os_name: linux-gnu
-            arch_name: x86_64
-            conjure_prefix: linux
-
-          - os: ubuntu-24.04-arm
-            os_name: linux-gnu
-            arch_name: aarch64
-            conjure_prefix: linux
-
           - os: macos-13
             os_name: darwin
             arch_name: x86_64
@@ -127,7 +241,7 @@ jobs:
 
 
     runs-on: ${{ matrix.os }}
-    env: 
+    env:
       release_prefix: "${{ matrix.arch_name }}-${{ matrix.os_name }}-conjure-oxide-nightly"
       conjure_version: 2.5.1
 
@@ -137,7 +251,11 @@ jobs:
       - name: Install rust
         run: rustup update stable && rustup default stable
 
-      - name: Build release 
+      - name: Test
+        run: |
+          cargo test --release
+
+      - name: Build release
         run: |
           cargo build --release -p conjure_oxide
           mkdir -p bin # place to store all the different stuff we want to add to the release
@@ -155,9 +273,8 @@ jobs:
           rm -rf bin/${CONJURE_FOLDER}
 
       - name: Prepare releases
-        if: ${{ !(matrix.arch_name == 'aarch64' && matrix.os_name == 'linux-gnu') }}
         run: |
-          mkdir dist 
+          mkdir dist
 
           cd bin
           zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure_oxide
@@ -165,29 +282,73 @@ jobs:
           zip "../dist/${{ env.release_prefix }}-with-solvers.zip" *
           cd ..
 
-      - name: Prepare releases (linux-aarch64)
-        if: ${{ matrix.arch_name == 'aarch64' && matrix.os_name == 'linux-gnu' }}
-        run: |
-          mkdir dist 
+      - name: Save builds
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.release_prefix }}
+          path: dist/*.zip
 
-          # no conjure version for linux-aarch64 yet
-          
+  build_nightly_linux:
+    name: "Build Nightly (x86_64-linux-gnu)"
+    needs:
+      - check_date
+      - publish_build_container
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    runs-on: ubuntu-latest
+    container: "ghcr.io/${{ github.repository}}:build-environment-nightly"
+    env:
+      release_prefix: "x86_64-linux-gnu-conjure-oxide-nightly"
+      conjure_prefix: "linux"
+      conjure_version: 2.5.1
+
+    steps:
+      - name: Align with container ownership
+        run: chown root:root .
+
+      - uses: actions/checkout@v4
+
+      - name: Test
+        run: |
+          cargo test --release
+
+      - name: Build release
+        run: |
+          cargo build --release -p conjure_oxide
+          mkdir -p bin # place to store all the different stuff we want to add to the release
+          cp target/release/conjure_oxide bin
+
+      - name: Download Conjure release
+        run: |
+          CONJURE_FOLDER="conjure-v${{ env.conjure_version }}-${{ env.conjure_prefix }}-with-solvers"
+          CONJURE_ZIP="${CONJURE_FOLDER}.zip"
+
+          wget "https://github.com/conjure-cp/conjure/releases/download/v${{ env.conjure_version }}/${CONJURE_ZIP}"
+          unzip -d bin ${CONJURE_ZIP}
+          mv bin/${CONJURE_FOLDER}/* bin/
+          rm -rf bin/${CONJURE_FOLDER}
+
+      - name: Prepare releases
+        run: |
+          mkdir dist
+
           cd bin
           zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure_oxide
-          # zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure_oxide conjure
-          # zip "../dist/${{ env.release_prefix }}-with-solvers.zip" *
+          zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure_oxide conjure
+          zip "../dist/${{ env.release_prefix }}-with-solvers.zip" *
           cd ..
 
       - name: Save builds
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: ${{ env.release_prefix }}
           path: dist/*.zip
 
   create_release:
     runs-on: ubuntu-latest
     name: Create release
-    needs: build_nightly 
+    needs:
+      - build_nightly_mac
+      - build_nightly_linux
     steps:
       - uses: actions/checkout@v4
       - run: mkdir dist
@@ -197,21 +358,22 @@ jobs:
         with:
           merge-multiple: true # put all releases in the same folder
           path: dist/
-      
+
       - name: Publish nightly release
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: | 
+        run: |
           git config user.name "GitHub Actions"
           git config user.email "github-actions@users.noreply.github.com"
 
-          # delete nightly tag 
+          # delete nightly tag
           git push --delete origin nightly  || true
-          
-          # create new nightly tag 
+
+          # create new nightly tag
           git tag nightly -am "Nightly release: $(date -I)"
           git push origin nightly
 
           # create release
           gh release delete nightly || true # ensure release doesn't exist (don't fail if it doesn't, as it may not!)
           gh release create nightly --notes-from-tag --prerelease --title "nightly ($(date -I))" --verify-tag dist/*.zip
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+
+# 1) build-environment: a container that sets up the build environment needed
+#    to compile conjure oxide.
+#
+#    This stage can be used as the container for Github workflows that involve
+#    building Conjure Oxide e.g. nightly releases, testing.
+#
+#    This uses an older version of glibc, 2.8, to ensure the build binary is
+#    widely runnable on many linux systems. For more details on supported
+#    systems, see manylinux_2_28 documentation.
+
+# --platform=$TARGETPLATFORM is for podman compatibility
+FROM --platform=$TARGETPLATFORM 'quay.io/pypa/manylinux_2_28' as build-environment
+ARG TARGETPLATFORM
+
+# download wget for downloading node below, and zip for our nightly build CI.
+RUN yum install -y wget zip;
+
+# llvm / clang: for C++ dependencies (Minion, SAT) and bindgen.
+# using clang not gcc as Rust's bindgen library requires libclang
+RUN yum install -y llvm-toolset;
+
+# nodejs: required to build treesitter grammar
+
+# treesitter builds fail on the version of node found in this containers
+# package manager, as it is very old. Installing node from a binary download
+# instead.
+
+
+# FIXME: Conjure has no linux/arm64 builds yet, so neither can we! When Conjure
+# gets these, we can trivially make this container multi-platform by commenting
+# out the below elif.
+
+RUN if [ "$TARGETPLATFORM"  == "linux/amd64" ]; then ARCH="x64";\
+    # elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH="arm64";\
+    else exit 1; fi;\
+    wget https://nodejs.org/dist/v22.16.0/node-v22.16.0-linux-${ARCH}.tar.xz &&\
+    tar -xf node-v22.16.0-linux-${ARCH}.tar.xz &&\
+    cp node-v22.16.0-linux-${ARCH}/bin/* /usr/local/bin &&\
+    cp -r node-v22.16.0-linux-${ARCH}/share/* /usr/local/share &&\
+    cp -r node-v22.16.0-linux-${ARCH}/include/* /usr/local/include &&\
+    cp -r node-v22.16.0-linux-${ARCH}/lib/* /usr/local/lib &&\
+    rm -rf node-v22.16.0*;
+
+
+
+# rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y;
+
+ENV PATH "/root/.cargo/bin:$PATH"
+
+###########################################################
+# 2) builder: a container that builds conjure oxide.
+
+FROM build-environment as builder
+
+# grab conjure oxide source
+WORKDIR /build
+COPY . .
+RUN git submodule update  --init --remote --recursive;
+
+RUN cargo build --release;
+
+# install conjure from latest release
+RUN mkdir -p conjure-build;
+WORKDIR /conjure-build
+
+RUN wget https://github.com/conjure-cp/conjure/releases/download/v2.5.1/conjure-v2.5.1-linux-with-solvers.zip &&\
+    unzip conjure-v2.5.1-linux-with-solvers.zip &&\
+    mv conjure-v2.5.1-linux-with-solvers/* . &&\
+    rm -rf conjure-v2.5.1-linux-with-solvers*;
+
+
+###########################################################
+# 3) a container that contains conjure oxide and conjure.
+
+# as we are no longer building, we can use a more modern version of Linux :)
+FROM ubuntu:latest
+
+# java for savilerow
+RUN apt-get update && apt-get install -y openjdk-21-jdk;
+
+RUN mkdir -p /opt/conjure;
+WORKDIR /opt/conjure
+
+COPY --from=builder build/target/release/conjure_oxide .
+COPY --from=builder conjure-build/ .
+
+# see https://github.com/conjure-cp/conjure/blob/main/Dockerfile
+ENV PATH /opt/conjure:$PATH
+ENV LD_LIBRARY_PATH /opt/conjure/lib:$LD_LIBRARY_PATH
+ENV MZN_STDLIB_DIR /opt/conjure/share/minizinc
+
+RUN mkdir -p /root/;
+WORKDIR /root/


### PR DESCRIPTION
Fixes #840

* Add container images for Conjure Oxide and its build environment. Use the latter image as the build environment for nightly Linux builds of Conjure Oxide.

  These images are published to Github Container Registry through the nightly CI (nightly.yml). The build environment image is called conjure-oxide:nightly-build-environment, and the main container conjure-oxide:nightly, and conjure-oxide:sha-<commitsha>.

  RATIONALE

  We need a container image is so that we can run our build nightly Conjure Oxide in an older Linux environment than Github Actions offer as runners, in order for our builds to support Redhat and Debian (issue #840).

  Github Actions allows running workflows inside a container; however, this requires an image of the container to be accessible online (a Dockerfile does not suffice). Therefore, this commit  publishs containers images to Github Container Registry as part of the nightly CI, and uses the uploaded image to do the nightly Linux builds.

  Adding a container that contains a built copy of Conjure Oxide and runtime dependencies (Conjure, Savile Row), was easy once we had one containing a build environment, so this commit also includes that, and the CI necessary to publish that nightly.

  This container would be useful as runtime environments for CI workflows, as it would removes the need to build and install Conjure Oxide and Conjure manually in each CI job.

* Remove aarch64-linux-gnu builds. Conjure does not build for this platform, so the Dockerfile would've had to include a special case for this platform that does not download Conjure. As Conjure Oxide is not too useful without Conjure yet, I've disabled it instead.