### PR TITLE
fix(ci): do not run tests in nightly CI workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,9 +251,6 @@ jobs:
       - name: Install rust
         run: rustup update stable && rustup default stable
 
-      - name: Test
-        run: |
-          cargo test --release
 
       - name: Build release
         run: |
@@ -306,10 +303,6 @@ jobs:
         run: chown root:root .
 
       - uses: actions/checkout@v4
-
-      - name: Test
-        run: |
-          cargo test --release
 
       - name: Build release
         run: |


### PR DESCRIPTION
Do not run tests in the nightly CI workflow.

These test runs were failing due to Conjure not being installed;
however, the Linux build environment cannot run Conjure due to Conjure
requiring glibc 2.29, and the build environment using glibc 2.28.
(unfortunately a glibc 2.29 docker image is not available).

In the future, we will run tests nightly using the existing workflow,
and only trigger the nightly CI workflow if this passes. This how
Conjure does it. See #857.
