### PR TITLE
fix: correctly pop bubbles inside root expression

### DIFF
--- a/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
@@ -207,8 +207,20 @@ allDiff(a[3,..]),
 
 --
 
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[3,..]),
+(a[1, 1] = 1),
 {(a[2, 3] = 1) @ false}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
+allDiff(a[..,1]),
+allDiff(a[..,2]),
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[3,..]),
+(a[1, 1] = 1),
 and([(a[2, 3] = 1),false;int(1..)]) 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
@@ -87,9 +87,21 @@ allDiff(a[3,..]),
 
 --
 
-{allDiff(a[..,3]) @ false}, 
+allDiff(a[..,1]),
+{allDiff(a[..,3]) @ false},
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[3,..]),
+(a[1, 1] = 1),
+(a[2, 2] = 1), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([allDiff(a[..,3]),false;int(1..)]) 
+allDiff(a[..,1]),
+and([allDiff(a[..,3]),false;int(1..)]),
+allDiff(a[1,..]),
+allDiff(a[2,..]),
+allDiff(a[3,..]),
+(a[1, 1] = 1),
+(a[2, 2] = 1) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
@@ -45,9 +45,17 @@ a#matrix_to_atom[i, i],
 
 --
 
-{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])}, 
+{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])},
+(a#matrix_to_atom[1, 2] = 1),
+(a#matrix_to_atom[2, 1] = 1),
+(a#matrix_to_atom[3, 1] = 1),
+(a#matrix_to_atom[3, 2] = 1), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]) 
+and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]),
+(a#matrix_to_atom[1, 2] = 1),
+(a#matrix_to_atom[2, 1] = 1),
+(a#matrix_to_atom[3, 1] = 1),
+(a#matrix_to_atom[3, 2] = 1) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
@@ -239,8 +239,22 @@ a#matrix_to_atom[i, i],
 
 --
 
+(a#matrix_to_atom[1, 2] = 1),
+(a#matrix_to_atom[1, 3] = 1),
+(a#matrix_to_atom[1, 4] = 1),
+(a#matrix_to_atom[2, 3] = 1),
+(a#matrix_to_atom[2, 4] = 1),
+(a#matrix_to_atom[3, 2] = 1),
+(a#matrix_to_atom[3, 4] = 1),
 {(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
+(a#matrix_to_atom[1, 2] = 1),
+(a#matrix_to_atom[1, 3] = 1),
+(a#matrix_to_atom[1, 4] = 1),
+(a#matrix_to_atom[2, 3] = 1),
+(a#matrix_to_atom[2, 4] = 1),
+(a#matrix_to_atom[3, 2] = 1),
+(a#matrix_to_atom[3, 4] = 1),
 and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]);int(1..)]) 
 
 --

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
@@ -83,9 +83,11 @@ UnsafeDiv(-(SafeDiv(y, z)), z),
 
 --
 
-{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])}, 
+{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])},
+(z != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]) 
+and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]),
+(z != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
@@ -124,9 +124,11 @@ sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)
 
 --
 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])},
+(f != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
+(f != 0) 
 
 --
 
@@ -219,9 +221,13 @@ sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)
 
 --
 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])},
+(h != 0),
+(f != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
+(h != 0),
+(f != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -69,9 +69,11 @@ UnsafeDiv(x, SafeDiv(y, z)),
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])},
+(z != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),
+(z != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -69,9 +69,11 @@ UnsafeDiv(x, SafeDiv(y, z)),
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])},
+(z != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),
+(z != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -69,9 +69,11 @@ x % SafeMod(y,z),
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])},
+(z != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),
+(z != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -69,9 +69,11 @@ x % SafeMod(y,z),
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
+{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])},
+(z != 0), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),
+(z != 0) 
 
 --
 

--- a/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
@@ -110,9 +110,15 @@ position#matrix_to_atom[sum([1,k;int(1..2)])],
 
 --
 
-{(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])) @ and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
+{(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])) @ and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])},
+(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
+allDiff(position#matrix_to_atom), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
+and([(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
+(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
+allDiff(position#matrix_to_atom) 
 
 --
 
@@ -189,9 +195,17 @@ position#matrix_to_atom[sum([2,k;int(1..2)])],
 
 --
 
-{(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])) @ and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
+(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+{(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])) @ and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])},
+(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
+allDiff(position#matrix_to_atom), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
+(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+and([(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
+(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
+allDiff(position#matrix_to_atom) 
 
 --
 
@@ -276,9 +290,19 @@ position#matrix_to_atom[sum([3,k;int(1..2)])],
 
 --
 
-{(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])) @ and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
+(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+__inDomain(sum([2,k;int(1..2)]),int(1..6)),
+{(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])) @ and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])},
+allDiff(position#matrix_to_atom), 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
+(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+__inDomain(sum([2,k;int(1..2)]),int(1..6)),
+and([(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
+allDiff(position#matrix_to_atom) 
 
 --
 


### PR DESCRIPTION
Fix the popping of bubbles inside the root expression.

Before this change, we would first bring root into the bubble with
the bubble_up rule, then expand it.

However, between the application of these two rules, the invariant that
the top level expression of a sub-model must be Expression::Root no
longer held. We assert this throughout this program, and this invariant
being broken caused these assertions to sometimes panic.

This commit adds special handling for expanding bubbles inside the root
expression.

I first encountered this issue on another branch, so cannot provide a
specific example of a crash. However, some integration tests use root
level bubbles and the old incorrect behaviour, and their expected
outputs have been updated as part of this commit.
