### PR TITLE
fix: infinite loop of bubble_up rule

### DIFF
--- a/conjure_oxide/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
@@ -316,20 +316,14 @@ n#matrix_to_atom[i],
 --
 
 ({n#matrix_to_atom[i] @ and([__inDomain(i,int(1..5));int(1..)])} <= 4), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(n#matrix_to_atom[i] <= 4) @ and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(n#matrix_to_atom[i] <= 4) @ and([__inDomain(i,int(1..5));int(1..)])} 
 
 --
 
-{(n#matrix_to_atom[i] <= 4) @ and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)])}, 
+{(n#matrix_to_atom[i] <= 4) @ and([__inDomain(i,int(1..5));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(n#matrix_to_atom[i] <= 4),and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-and([__inDomain(i,int(1..5));int(1..)]) 
+and([(n#matrix_to_atom[i] <= 4),and([__inDomain(i,int(1..5));int(1..)]);int(1..)]) 
 
 --
 
@@ -346,20 +340,14 @@ m#matrix_to_atom[i],
 --
 
 ({m#matrix_to_atom[i] @ and([__inDomain(i,int(1..5));int(1..)])} = i), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(m#matrix_to_atom[i] = i) @ and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(m#matrix_to_atom[i] = i) @ and([__inDomain(i,int(1..5));int(1..)])} 
 
 --
 
-{(m#matrix_to_atom[i] = i) @ and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)])}, 
+{(m#matrix_to_atom[i] = i) @ and([__inDomain(i,int(1..5));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(m#matrix_to_atom[i] = i),and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([and([__inDomain(i,int(1..5));int(1..)]);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-and([__inDomain(i,int(1..5));int(1..)]) 
+and([(m#matrix_to_atom[i] = i),and([__inDomain(i,int(1..5));int(1..)]);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
@@ -70,20 +70,14 @@ m#matrix_to_atom[x],
 --
 
 ({m#matrix_to_atom[x] @ and([__inDomain(x,int(1..5));int(1..)])} = x), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(m#matrix_to_atom[x] = x) @ and([and([__inDomain(x,int(1..5));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(m#matrix_to_atom[x] = x) @ and([__inDomain(x,int(1..5));int(1..)])} 
 
 --
 
-{(m#matrix_to_atom[x] = x) @ and([and([__inDomain(x,int(1..5));int(1..)]);int(1..)])}, 
+{(m#matrix_to_atom[x] = x) @ and([__inDomain(x,int(1..5));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(m#matrix_to_atom[x] = x),and([and([__inDomain(x,int(1..5));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([and([__inDomain(x,int(1..5));int(1..)]);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-and([__inDomain(x,int(1..5));int(1..)]) 
+and([(m#matrix_to_atom[x] = x),and([__inDomain(x,int(1..5));int(1..)]);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/01/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ UnsafeDiv(a, b),
 --
 
 ({SafeDiv(a, b) @ (b != 0)} = 2), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(a, b) = 2) @ and([(b != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(a, b) = 2) @ (b != 0)} 
 
 --
 
-{(SafeDiv(a, b) = 2) @ and([(b != 0);int(1..)])}, 
+{(SafeDiv(a, b) = 2) @ (b != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(a, b) = 2),and([(b != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(a, b) = 2),(b != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(a, b) = 2),and([(b != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(a, b) = 2),
-and([(b != 0);int(1..)]) 
-
---
-
-(SafeDiv(a, b) = 2),
-and([(b != 0);int(1..)]), 
+and([(SafeDiv(a, b) = 2),(b != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(a, b) = 2),
 (b != 0) 

--- a/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/03/input-expected-rule-trace-human.txt
@@ -15,26 +15,18 @@ UnsafeDiv(8, a),
 --
 
 (2 = {SafeDiv(8, a) @ (a != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(2 = SafeDiv(8, a)) @ and([(a != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(2 = SafeDiv(8, a)) @ (a != 0)} 
 
 --
 
-{(2 = SafeDiv(8, a)) @ and([(a != 0);int(1..)])}, 
+{(2 = SafeDiv(8, a)) @ (a != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(2 = SafeDiv(8, a)),and([(a != 0);int(1..)]);int(1..)]) 
+and([(2 = SafeDiv(8, a)),(a != 0);int(1..)]) 
 
 --
 
-and([(2 = SafeDiv(8, a)),and([(a != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(2 = SafeDiv(8, a)),
-and([(a != 0);int(1..)]) 
-
---
-
-(2 = SafeDiv(8, a)),
-and([(a != 0);int(1..)]), 
+and([(2 = SafeDiv(8, a)),(a != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (2 = SafeDiv(8, a)),
 (a != 0) 

--- a/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/04/input-expected-rule-trace-human.txt
@@ -17,20 +17,14 @@ UnsafeDiv(b, c),
 --
 
 (a = {SafeDiv(b, c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a = SafeDiv(b, c)) @ (c != 0)} 
 
 --
 
-{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
+{(a = SafeDiv(b, c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a = SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
-
---
-
-and([(c != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(c != 0) 
+and([(a = SafeDiv(b, c)),(c != 0);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/05/div-05-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ UnsafeDiv(b, c),
 --
 
 (a != {SafeDiv(b, c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a != SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a != SafeDiv(b, c)) @ (c != 0)} 
 
 --
 
-{(a != SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
+{(a != SafeDiv(b, c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a != SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
+and([(a != SafeDiv(b, c)),(c != 0);int(1..)]) 
 
 --
 
-and([(a != SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(a != SafeDiv(b, c)),
-and([(c != 0);int(1..)]) 
-
---
-
-(a != SafeDiv(b, c)),
-and([(c != 0);int(1..)]), 
+and([(a != SafeDiv(b, c)),(c != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (a != SafeDiv(b, c)),
 (c != 0) 

--- a/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/div/06/div-06-expected-rule-trace-human.txt
@@ -17,20 +17,14 @@ UnsafeDiv(b, c),
 --
 
 (a = {SafeDiv(b, c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a = SafeDiv(b, c)) @ (c != 0)} 
 
 --
 
-{(a = SafeDiv(b, c)) @ and([(c != 0);int(1..)])}, 
+{(a = SafeDiv(b, c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a = SafeDiv(b, c)),and([(c != 0);int(1..)]);int(1..)]) 
-
---
-
-and([(c != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(c != 0) 
+and([(a = SafeDiv(b, c)),(c != 0);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
@@ -184,25 +184,7 @@ allDiff(a[3,..]),
 --
 
 ({a[2, 3] @ false} = 1), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a[2, 3] = 1) @ and([false;int(1..)])} 
-
---
-
-allDiff(a[..,1]),
-allDiff(a[..,2]),
-allDiff(a[1,..]),
-allDiff(a[2,..]),
-allDiff(a[3,..]),
-(a[1, 1] = 1),
-{(a[2, 3] = 1) @ and([false;int(1..)])}, 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-allDiff(a[..,1]),
-allDiff(a[..,2]),
-allDiff(a[1,..]),
-allDiff(a[2,..]),
-allDiff(a[3,..]),
-(a[1, 1] = 1),
+   ~~> bubble_up ([("Bubble", 8800)]) 
 {(a[2, 3] = 1) @ false} 
 
 --

--- a/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
@@ -64,26 +64,8 @@ allDiff(a[3,..]),
 --
 
 allDiff({a[..,3] @ false}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{allDiff(a[..,3]) @ and([false;int(1..)])} 
-
---
-
-allDiff(a[..,1]),
-{allDiff(a[..,3]) @ and([false;int(1..)])},
-allDiff(a[1,..]),
-allDiff(a[2,..]),
-allDiff(a[3,..]),
-(a[1, 1] = 1),
-(a[2, 2] = 1), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-allDiff(a[..,1]),
-{allDiff(a[..,3]) @ false},
-allDiff(a[1,..]),
-allDiff(a[2,..]),
-allDiff(a[3,..]),
-(a[1, 1] = 1),
-(a[2, 2] = 1) 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{allDiff(a[..,3]) @ false} 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
@@ -40,34 +40,18 @@ a#matrix_to_atom[i, i],
 --
 
 ({a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)])} = i), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a#matrix_to_atom[i, i] = i) @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)])} 
 
 --
 
-{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)])}, 
+{(a#matrix_to_atom[i, i] = i) @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]) 
+and([(a#matrix_to_atom[i, i] = i),and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]) 
 
 --
 
-and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]);int(1..)]),
-(a#matrix_to_atom[1, 2] = 1),
-(a#matrix_to_atom[2, 1] = 1),
-(a#matrix_to_atom[3, 1] = 1),
-(a#matrix_to_atom[3, 2] = 1), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(a#matrix_to_atom[i, i] = i),
-and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]),
-(a#matrix_to_atom[1, 2] = 1),
-(a#matrix_to_atom[2, 1] = 1),
-(a#matrix_to_atom[3, 1] = 1),
-(a#matrix_to_atom[3, 2] = 1) 
-
---
-
-(a#matrix_to_atom[i, i] = i),
-and([and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]),
+and([(a#matrix_to_atom[i, i] = i),and([__inDomain(i,int(1..3)),__inDomain(i,int(1..2));int(1..)]);int(1..)]),
 (a#matrix_to_atom[1, 2] = 1),
 (a#matrix_to_atom[2, 1] = 1),
 (a#matrix_to_atom[3, 1] = 1),

--- a/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
@@ -234,14 +234,14 @@ a#matrix_to_atom[i, i],
 --
 
 ({a#matrix_to_atom[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)])} = i), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a#matrix_to_atom[i, i] = i) @ and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)])} 
 
 --
 
-{(a#matrix_to_atom[i, i] = i) @ and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)])}, 
+{(a#matrix_to_atom[i, i] = i) @ and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]);int(1..)]) 
+and([(a#matrix_to_atom[i, i] = i),and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]) 
 
 --
 
@@ -252,29 +252,7 @@ and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i
 (a#matrix_to_atom[2, 4] = 1),
 (a#matrix_to_atom[3, 2] = 1),
 (a#matrix_to_atom[3, 4] = 1),
-and([(a#matrix_to_atom[i, i] = i),and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(a#matrix_to_atom[1, 2] = 1),
-(a#matrix_to_atom[1, 3] = 1),
-(a#matrix_to_atom[1, 4] = 1),
-(a#matrix_to_atom[2, 3] = 1),
-(a#matrix_to_atom[2, 4] = 1),
-(a#matrix_to_atom[3, 2] = 1),
-(a#matrix_to_atom[3, 4] = 1),
-(a#matrix_to_atom[i, i] = i),
-and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]) 
-
---
-
-(a#matrix_to_atom[1, 2] = 1),
-(a#matrix_to_atom[1, 3] = 1),
-(a#matrix_to_atom[1, 4] = 1),
-(a#matrix_to_atom[2, 3] = 1),
-(a#matrix_to_atom[2, 4] = 1),
-(a#matrix_to_atom[3, 2] = 1),
-(a#matrix_to_atom[3, 4] = 1),
-(a#matrix_to_atom[i, i] = i),
-and([and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]), 
+and([(a#matrix_to_atom[i, i] = i),and([__inDomain(i,int(1..3)),__inDomain(i,int(2..4));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (a#matrix_to_atom[1, 2] = 1),
 (a#matrix_to_atom[1, 3] = 1),

--- a/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/01/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ a % b,
 --
 
 ({SafeMod(a,b) @ (b != 0)} = 1), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(a,b) = 1) @ and([(b != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(a,b) = 1) @ (b != 0)} 
 
 --
 
-{(SafeMod(a,b) = 1) @ and([(b != 0);int(1..)])}, 
+{(SafeMod(a,b) = 1) @ (b != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(a,b) = 1),and([(b != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(a,b) = 1),(b != 0);int(1..)]) 
 
 --
 
-and([(SafeMod(a,b) = 1),and([(b != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeMod(a,b) = 1),
-and([(b != 0);int(1..)]) 
-
---
-
-(SafeMod(a,b) = 1),
-and([(b != 0);int(1..)]), 
+and([(SafeMod(a,b) = 1),(b != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeMod(a,b) = 1),
 (b != 0) 

--- a/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/03/input-expected-rule-trace-human.txt
@@ -15,26 +15,18 @@ such that
 --
 
 (2 = {SafeMod(8,a) @ (a != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(2 = SafeMod(8,a)) @ and([(a != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(2 = SafeMod(8,a)) @ (a != 0)} 
 
 --
 
-{(2 = SafeMod(8,a)) @ and([(a != 0);int(1..)])}, 
+{(2 = SafeMod(8,a)) @ (a != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(2 = SafeMod(8,a)),and([(a != 0);int(1..)]);int(1..)]) 
+and([(2 = SafeMod(8,a)),(a != 0);int(1..)]) 
 
 --
 
-and([(2 = SafeMod(8,a)),and([(a != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(2 = SafeMod(8,a)),
-and([(a != 0);int(1..)]) 
-
---
-
-(2 = SafeMod(8,a)),
-and([(a != 0);int(1..)]), 
+and([(2 = SafeMod(8,a)),(a != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (2 = SafeMod(8,a)),
 (a != 0) 

--- a/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/04/input-expected-rule-trace-human.txt
@@ -17,20 +17,14 @@ b % c,
 --
 
 (a = {SafeMod(b,c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a = SafeMod(b,c)) @ (c != 0)} 
 
 --
 
-{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
+{(a = SafeMod(b,c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a = SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
-
---
-
-and([(c != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(c != 0) 
+and([(a = SafeMod(b,c)),(c != 0);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/05/mod-05-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ b % c,
 --
 
 (a != {SafeMod(b,c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a != SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a != SafeMod(b,c)) @ (c != 0)} 
 
 --
 
-{(a != SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
+{(a != SafeMod(b,c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a != SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
+and([(a != SafeMod(b,c)),(c != 0);int(1..)]) 
 
 --
 
-and([(a != SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(a != SafeMod(b,c)),
-and([(c != 0);int(1..)]) 
-
---
-
-(a != SafeMod(b,c)),
-and([(c != 0);int(1..)]), 
+and([(a != SafeMod(b,c)),(c != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (a != SafeMod(b,c)),
 (c != 0) 

--- a/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/mod/06/mod-06-expected-rule-trace-human.txt
@@ -17,20 +17,14 @@ b % c,
 --
 
 (a = {SafeMod(b,c) @ (c != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a = SafeMod(b,c)) @ (c != 0)} 
 
 --
 
-{(a = SafeMod(b,c)) @ and([(c != 0);int(1..)])}, 
+{(a = SafeMod(b,c)) @ (c != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a = SafeMod(b,c)),and([(c != 0);int(1..)]);int(1..)]) 
-
---
-
-and([(c != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(c != 0) 
+and([(a = SafeMod(b,c)),(c != 0);int(1..)]) 
 
 --
 

--- a/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/02-nested-neg/input-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ UnsafeDiv(-(y), z),
 --
 
 (x = {SafeDiv(-(y), z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = SafeDiv(-(y), z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x = SafeDiv(-(y), z)) @ (z != 0)} 
 
 --
 
-{(x = SafeDiv(-(y), z)) @ and([(z != 0);int(1..)])}, 
+{(x = SafeDiv(-(y), z)) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x = SafeDiv(-(y), z)),and([(z != 0);int(1..)]);int(1..)]) 
+and([(x = SafeDiv(-(y), z)),(z != 0);int(1..)]) 
 
 --
 
-and([(x = SafeDiv(-(y), z)),and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = SafeDiv(-(y), z)),
-and([(z != 0);int(1..)]) 
-
---
-
-(x = SafeDiv(-(y), z)),
-and([(z != 0);int(1..)]), 
+and([(x = SafeDiv(-(y), z)),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x = SafeDiv(-(y), z)),
 (z != 0) 

--- a/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/03-negated-expression/input-expected-rule-trace-human.txt
@@ -17,40 +17,24 @@ UnsafeDiv(y, z),
 --
 
 -({SafeDiv(y, z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{-(SafeDiv(y, z)) @ (z != 0)} 
 
 --
 
-(x = {-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = -(SafeDiv(y, z))) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+(x = {-(SafeDiv(y, z)) @ (z != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x = -(SafeDiv(y, z))) @ (z != 0)} 
 
 --
 
-{(x = -(SafeDiv(y, z))) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(x = -(SafeDiv(y, z))) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x = -(SafeDiv(y, z))),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(x = -(SafeDiv(y, z))),(z != 0);int(1..)]) 
 
 --
 
-and([(x = -(SafeDiv(y, z))),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = -(SafeDiv(y, z))),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(x = -(SafeDiv(y, z))),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = -(SafeDiv(y, z))),
-and([(z != 0);int(1..)]) 
-
---
-
-(x = -(SafeDiv(y, z))),
-and([(z != 0);int(1..)]), 
+and([(x = -(SafeDiv(y, z))),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x = -(SafeDiv(y, z))),
 (z != 0) 

--- a/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/neg/04-negated-expression-nested/input-expected-rule-trace-human.txt
@@ -17,54 +17,30 @@ UnsafeDiv(y, z),
 --
 
 -({SafeDiv(y, z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{-(SafeDiv(y, z)) @ (z != 0)} 
 
 --
 
-UnsafeDiv({-(SafeDiv(y, z)) @ and([(z != 0);int(1..)])}, z), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(-(SafeDiv(y, z)), z) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+UnsafeDiv({-(SafeDiv(y, z)) @ (z != 0)}, z), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{UnsafeDiv(-(SafeDiv(y, z)), z) @ (z != 0)} 
 
 --
 
-(x = {UnsafeDiv(-(SafeDiv(y, z)), z) @ and([and([(z != 0);int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)])} 
+(x = {UnsafeDiv(-(SafeDiv(y, z)), z) @ (z != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ (z != 0)} 
 
 --
 
-{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)])}, 
+{(x = UnsafeDiv(-(SafeDiv(y, z)), z)) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x = UnsafeDiv(-(SafeDiv(y, z)), z)),and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(x = UnsafeDiv(-(SafeDiv(y, z)), z)),(z != 0);int(1..)]) 
 
 --
 
-and([(x = UnsafeDiv(-(SafeDiv(y, z)), z)),and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([(z != 0);int(1..)]) 
-
---
-
-(x = UnsafeDiv(-(SafeDiv(y, z)), z)),
-and([(z != 0);int(1..)]), 
+and([(x = UnsafeDiv(-(SafeDiv(y, z)), z)),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x = UnsafeDiv(-(SafeDiv(y, z)), z)),
 (z != 0) 
@@ -78,28 +54,18 @@ UnsafeDiv(-(SafeDiv(y, z)), z),
 --
 
 (x = {SafeDiv(-(SafeDiv(y, z)), z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ (z != 0)} 
 
 --
 
-{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ and([(z != 0);int(1..)])}, 
+{(x = SafeDiv(-(SafeDiv(y, z)), z)) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]) 
+and([(x = SafeDiv(-(SafeDiv(y, z)), z)),(z != 0);int(1..)]) 
 
 --
 
-and([(x = SafeDiv(-(SafeDiv(y, z)), z)),and([(z != 0);int(1..)]);int(1..)]),
-(z != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x = SafeDiv(-(SafeDiv(y, z)), z)),
-and([(z != 0);int(1..)]),
-(z != 0) 
-
---
-
-(x = SafeDiv(-(SafeDiv(y, z)), z)),
-and([(z != 0);int(1..)]),
+and([(x = SafeDiv(-(SafeDiv(y, z)), z)),(z != 0);int(1..)]),
 (z != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x = SafeDiv(-(SafeDiv(y, z)), z)),

--- a/conjure_oxide/tests/integration/basic/pow/01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/01-simple/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ UnsafePow(x, y),
 --
 
 ({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 4), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafePow(x, y) = 4) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
+{(SafePow(x, y) = 4) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(SafePow(x, y) = 4),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
 
 --
 
-and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafePow(x, y) = 4),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
-
---
-
-(SafePow(x, y) = 4),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
+and([(SafePow(x, y) = 4),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafePow(x, y) = 4),
 and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 

--- a/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/02-exponent-zero/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ UnsafePow(x, y),
 --
 
 ({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 4), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafePow(x, y) = 4) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 4) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
+{(SafePow(x, y) = 4) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(SafePow(x, y) = 4),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
 
 --
 
-and([(SafePow(x, y) = 4),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafePow(x, y) = 4),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
-
---
-
-(SafePow(x, y) = 4),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
+and([(SafePow(x, y) = 4),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafePow(x, y) = 4),
 and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 

--- a/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/03-negative-exponent/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ UnsafePow(x, y),
 --
 
 ({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = 2), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = 2) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafePow(x, y) = 2) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = 2) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
+{(SafePow(x, y) = 2) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafePow(x, y) = 2),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(SafePow(x, y) = 2),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
 
 --
 
-and([(SafePow(x, y) = 2),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafePow(x, y) = 2),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
-
---
-
-(SafePow(x, y) = 2),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
+and([(SafePow(x, y) = 2),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafePow(x, y) = 2),
 and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 

--- a/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/04-flatten/input-expected-rule-trace-human.txt
@@ -28,26 +28,18 @@ UnsafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)),
 --
 
 ({SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) @ and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)])} = 4), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4) @ and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4) @ and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)])} 
 
 --
 
-{(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4) @ and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)])}, 
+{(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4) @ and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]) 
 
 --
 
-and([(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),
-and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]) 
-
---
-
-(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),
-and([and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]), 
+and([(SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafePow(sum([x,2;int(1..2)]), SafeDiv(y, 2)) = 4),
 and([or([(sum([x,2;int(1..2)]) != 0),(SafeDiv(y, 2) != 0);int(1..)]),(SafeDiv(y, 2) >= 0);int(1..)]) 

--- a/conjure_oxide/tests/integration/basic/pow/05-negative-base/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/pow/05-negative-base/input-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ UnsafePow(x, y),
 --
 
 ({SafePow(x, y) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} = z), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafePow(x, y) = z) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafePow(x, y) = z) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])} 
 
 --
 
-{(SafePow(x, y) = z) @ and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)])}, 
+{(SafePow(x, y) = z) @ and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafePow(x, y) = z),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(SafePow(x, y) = z),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
 
 --
 
-and([(SafePow(x, y) = z),and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafePow(x, y) = z),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]) 
-
---
-
-(SafePow(x, y) = z),
-and([and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
+and([(SafePow(x, y) = z),and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafePow(x, y) = z),
 and([or([(x != 0),(y != 0);int(1..)]),(y >= 0);int(1..)]) 

--- a/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/sum/02-sum-put-in-aux-var/input-expected-rule-trace-human.txt
@@ -24,26 +24,18 @@ UnsafeDiv(sum([x,y,z;int(1..2)]), a),
 --
 
 ({SafeDiv(sum([x,y,z;int(1..2)]), a) @ (a != 0)} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3) @ and([(a != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3) @ (a != 0)} 
 
 --
 
-{(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3) @ and([(a != 0);int(1..)])}, 
+{(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3) @ (a != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),and([(a != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),(a != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),and([(a != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),
-and([(a != 0);int(1..)]) 
-
---
-
-(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),
-and([(a != 0);int(1..)]), 
+and([(SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),(a != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(sum([x,y,z;int(1..2)]), a) = 3),
 (a != 0) 

--- a/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/weighted-sum/05-flattening/input-expected-rule-trace-human.txt
@@ -34,54 +34,30 @@ UnsafeDiv(e, f),
 --
 
 [product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),{SafeDiv(e, f) @ (f != 0)},product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ and([(f != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ (f != 0)} 
 
 --
 
-sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ and([(f != 0);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ and([and([(f != 0);int(1..)]);int(1..)])} 
+sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ (f != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ (f != 0)} 
 
 --
 
-({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ and([and([(f != 0);int(1..)]);int(1..)])} <= 18), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)])} 
+({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ (f != 0)} <= 18), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ (f != 0)} 
 
 --
 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)])}, 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ (f != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),(f != 0);int(1..)]) 
 
 --
 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(f != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(f != 0);int(1..)]);int(1..)]) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(f != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([(f != 0);int(1..)]) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([(f != 0);int(1..)]), 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),(f != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,UnsafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
 (f != 0) 
@@ -95,92 +71,42 @@ UnsafeDiv(g, h),
 --
 
 [6,{SafeDiv(g, h) @ (h != 0)};int(1..2)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[6,SafeDiv(g, h);int(1..2)] @ and([(h != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[6,SafeDiv(g, h);int(1..2)] @ (h != 0)} 
 
 --
 
-product({[6,SafeDiv(g, h);int(1..2)] @ and([(h != 0);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{product([6,SafeDiv(g, h);int(1..2)]) @ and([and([(h != 0);int(1..)]);int(1..)])} 
+product({[6,SafeDiv(g, h);int(1..2)] @ (h != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{product([6,SafeDiv(g, h);int(1..2)]) @ (h != 0)} 
 
 --
 
-[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),{product([6,SafeDiv(g, h);int(1..2)]) @ and([and([(h != 0);int(1..)]);int(1..)])},-(a),-(UnsafeDiv(g, h));int(1..2)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])} 
+[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),{product([6,SafeDiv(g, h);int(1..2)]) @ (h != 0)},-(a),-(UnsafeDiv(g, h));int(1..2)], 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ (h != 0)} 
 
 --
 
-sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])} 
+sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)] @ (h != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ (h != 0)} 
 
 --
 
-({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])} <= 18), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])} 
+({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) @ (h != 0)} <= 18), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ (h != 0)} 
 
 --
 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18) @ (h != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),(h != 0);int(1..)]) 
 
 --
 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(h != 0);int(1..)]);int(1..)]),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(h != 0);int(1..)]);int(1..)]),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([(h != 0);int(1..)]),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
-and([(h != 0);int(1..)]),
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),(h != 0);int(1..)]),
 (f != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(UnsafeDiv(g, h));int(1..2)]) <= 18),
@@ -196,84 +122,36 @@ UnsafeDiv(g, h),
 --
 
 -({SafeDiv(g, h) @ (h != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{-(SafeDiv(g, h)) @ and([(h != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{-(SafeDiv(g, h)) @ (h != 0)} 
 
 --
 
-[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),{-(SafeDiv(g, h)) @ and([(h != 0);int(1..)])};int(1..2)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)] @ and([and([(h != 0);int(1..)]);int(1..)])} 
+[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),{-(SafeDiv(g, h)) @ (h != 0)};int(1..2)], 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)] @ (h != 0)} 
 
 --
 
-sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)] @ and([and([(h != 0);int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])} 
+sum({[product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)] @ (h != 0)}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) @ (h != 0)} 
 
 --
 
-({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) @ and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)])} <= 18), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])} 
+({sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) @ (h != 0)} <= 18), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ (h != 0)} 
 
 --
 
-{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18) @ (h != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),(h != 0);int(1..)]) 
 
 --
 
-and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([and([(h != 0);int(1..)]);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(h != 0);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([and([(h != 0);int(1..)]);int(1..)]),
-(h != 0),
-(f != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([(h != 0);int(1..)]),
-(h != 0),
-(f != 0) 
-
---
-
-(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),
-and([(h != 0);int(1..)]),
+and([(sum([product([2,a;int(1..2)]),product([2,b;int(1..2)]),product([3,c,d;int(1..2)]),SafeDiv(e, f),product([6,SafeDiv(g, h);int(1..2)]),-(a),-(SafeDiv(g, h));int(1..2)]) <= 18),(h != 0);int(1..)]),
 (h != 0),
 (f != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 

--- a/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
@@ -56,14 +56,14 @@ a#matrix_to_atom[i],
 --
 
 ({a#matrix_to_atom[i] @ and([__inDomain(i,int(1..3));int(1..)])} = i), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(a#matrix_to_atom[i] = i) @ and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(a#matrix_to_atom[i] = i) @ and([__inDomain(i,int(1..3));int(1..)])} 
 
 --
 
-{(a#matrix_to_atom[i] = i) @ and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)])}, 
+{(a#matrix_to_atom[i] = i) @ and([__inDomain(i,int(1..3));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(a#matrix_to_atom[i] = i),and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)]);int(1..)]) 
+and([(a#matrix_to_atom[i] = i),and([__inDomain(i,int(1..3));int(1..)]);int(1..)]) 
 
 --
 
@@ -71,25 +71,7 @@ and([given i: DOM
 
 such that
 
-and([(a#matrix_to_atom[i] = i),and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)]);int(1..)])
- | i: DOM,]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-and([given i: DOM
-
-such that
-
-(a#matrix_to_atom[i] = i),
-and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)])
- | i: DOM,]) 
-
---
-
-and([given i: DOM
-
-such that
-
-(a#matrix_to_atom[i] = i),
-and([and([__inDomain(i,int(1..3));int(1..)]);int(1..)])
+and([(a#matrix_to_atom[i] = i),and([__inDomain(i,int(1..3));int(1..)]);int(1..)])
  | i: DOM,]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 and([given i: DOM

--- a/conjure_oxide/tests/integration/bugs/infinite-bubble-up/input.eprime.disabled
+++ b/conjure_oxide/tests/integration/bugs/infinite-bubble-up/input.eprime.disabled
@@ -1,0 +1,35 @@
+
+$ disabled as this is a very slow test
+
+$ This input model was infinitely calling bubbling_up, keeping the expression
+$ inside the bubble the same.
+
+$ --
+
+$ {{sum([[81,3,35,28,94,86,69,75,4,11;int(1..10)][j],-([81,3,35,28,94,86,69,75,4,11;int(1..10)][i]);int(1..)]) @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(j,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])} @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(i,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])},
+$    ~~> bubble_up ([("Bubble", 8900)])
+$ {{sum([[81,3,35,28,94,86,69,75,4,11;int(1..10)][j],-([81,3,35,28,94,86,69,75,4,11;int(1..10)][i]);int(1..)]) @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(i,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])} @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(j,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])}
+
+$ --
+
+$ {{sum([[81,3,35,28,94,86,69,75,4,11;int(1..10)][j],-([81,3,35,28,94,86,69,75,4,11;int(1..10)][i]);int(1..)]) @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(i,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])} @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(j,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])},
+$    ~~> bubble_up ([("Bubble", 8900)])
+$ {{sum([[81,3,35,28,94,86,69,75,4,11;int(1..10)][j],-([81,3,35,28,94,86,69,75,4,11;int(1..10)][i]);int(1..)]) @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(j,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])} @ and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([and([__inDomain(i,int(1..10));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)])}
+
+$ --
+
+letting n be 5
+letting number_of_clusters be 3
+letting x be [81,3,35,28,94]
+letting y be [14,94,31,17,13]
+
+
+find colour : matrix [int(1..n), int(1..n)] of int(0..number_of_clusters)
+
+such that
+$ Colinear sequences must not reuse the same colour on adjacent edges
+    forAll i, j, k : int(1..n) .
+        i != j /\ j != k /\ i != k /\
+        ( (x[j] - x[i]) * (y[k] - y[i]) = (x[k] - x[i]) * (y[j] - y[i]) ) ->
+            !(colour[i,j] != 0 /\ colour[j,k] != 0 /\ colour[i,j] = colour[j,k])
+

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ UnsafeDiv(x, y),
 --
 
 ({SafeDiv(x, y) @ (y != 0)} = 5), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, y) = 5) @ and([(y != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(x, y) = 5) @ (y != 0)} 
 
 --
 
-{(SafeDiv(x, y) = 5) @ and([(y != 0);int(1..)])}, 
+{(SafeDiv(x, y) = 5) @ (y != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, y) = 5),and([(y != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, y) = 5),(y != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(x, y) = 5),and([(y != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(x, y) = 5),
-and([(y != 0);int(1..)]) 
-
---
-
-(SafeDiv(x, y) = 5),
-and([(y != 0);int(1..)]), 
+and([(SafeDiv(x, y) = 5),(y != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(x, y) = 5),
 (y != 0) 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ UnsafeDiv(x, y),
 --
 
 ({SafeDiv(x, y) @ (y != 0)} = z), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, y) = z) @ and([(y != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(x, y) = z) @ (y != 0)} 
 
 --
 
-{(SafeDiv(x, y) = z) @ and([(y != 0);int(1..)])}, 
+{(SafeDiv(x, y) = z) @ (y != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, y) = z),and([(y != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, y) = z),(y != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(x, y) = z),and([(y != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(x, y) = z),
-and([(y != 0);int(1..)]) 
-
---
-
-(SafeDiv(x, y) = z),
-and([(y != 0);int(1..)]), 
+and([(SafeDiv(x, y) = z),(y != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(x, y) = z),
 (y != 0) 

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -17,40 +17,24 @@ UnsafeDiv(y, z),
 --
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} = 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} = 10), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ (z != 0)} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),(z != 0);int(1..)]) 
 
 --
 
-and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(UnsafeDiv(x, SafeDiv(y, z)) = 10),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(UnsafeDiv(x, SafeDiv(y, z)) = 10),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(UnsafeDiv(x, SafeDiv(y, z)) = 10),
-and([(z != 0);int(1..)]) 
-
---
-
-(UnsafeDiv(x, SafeDiv(y, z)) = 10),
-and([(z != 0);int(1..)]), 
+and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (UnsafeDiv(x, SafeDiv(y, z)) = 10),
 (z != 0) 
@@ -64,28 +48,18 @@ UnsafeDiv(x, SafeDiv(y, z)),
 --
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} = 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ (SafeDiv(y, z) != 0)} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ (SafeDiv(y, z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),
-(z != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(x, SafeDiv(y, z)) = 10),
-and([(SafeDiv(y, z) != 0);int(1..)]),
-(z != 0) 
-
---
-
-(SafeDiv(x, SafeDiv(y, z)) = 10),
-and([(SafeDiv(y, z) != 0);int(1..)]),
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0);int(1..)]),
 (z != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(x, SafeDiv(y, z)) = 10),

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -17,40 +17,24 @@ UnsafeDiv(y, z),
 --
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} != 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} != 10), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ (z != 0)} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) != 10) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(UnsafeDiv(x, SafeDiv(y, z)) != 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) != 10),(z != 0);int(1..)]) 
 
 --
 
-and([(UnsafeDiv(x, SafeDiv(y, z)) != 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(UnsafeDiv(x, SafeDiv(y, z)) != 10),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(UnsafeDiv(x, SafeDiv(y, z)) != 10),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(UnsafeDiv(x, SafeDiv(y, z)) != 10),
-and([(z != 0);int(1..)]) 
-
---
-
-(UnsafeDiv(x, SafeDiv(y, z)) != 10),
-and([(z != 0);int(1..)]), 
+and([(UnsafeDiv(x, SafeDiv(y, z)) != 10),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (UnsafeDiv(x, SafeDiv(y, z)) != 10),
 (z != 0) 
@@ -64,28 +48,18 @@ UnsafeDiv(x, SafeDiv(y, z)),
 --
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} != 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(x, SafeDiv(y, z)) != 10) @ (SafeDiv(y, z) != 0)} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) != 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) != 10) @ (SafeDiv(y, z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) != 10),(SafeDiv(y, z) != 0);int(1..)]) 
 
 --
 
-and([(SafeDiv(x, SafeDiv(y, z)) != 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),
-(z != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeDiv(x, SafeDiv(y, z)) != 10),
-and([(SafeDiv(y, z) != 0);int(1..)]),
-(z != 0) 
-
---
-
-(SafeDiv(x, SafeDiv(y, z)) != 10),
-and([(SafeDiv(y, z) != 0);int(1..)]),
+and([(SafeDiv(x, SafeDiv(y, z)) != 10),(SafeDiv(y, z) != 0);int(1..)]),
 (z != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeDiv(x, SafeDiv(y, z)) != 10),

--- a/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -17,32 +17,20 @@ UnsafeDiv(y, z),
 --
 
 UnsafeDiv(x, {SafeDiv(y, z) @ (z != 0)}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} 
 
 --
 
-({UnsafeDiv(x, SafeDiv(y, z)) @ and([(z != 0);int(1..)])} = 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({UnsafeDiv(x, SafeDiv(y, z)) @ (z != 0)} = 10), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ (z != 0)} 
 
 --
 
-{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(UnsafeDiv(x, SafeDiv(y, z)) = 10) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-and([(z != 0);int(1..)]) 
-
---
-
-and([(z != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(z != 0) 
+and([(UnsafeDiv(x, SafeDiv(y, z)) = 10),(z != 0);int(1..)]) 
 
 --
 
@@ -53,18 +41,18 @@ UnsafeDiv(x, SafeDiv(y, z)),
 --
 
 ({SafeDiv(x, SafeDiv(y, z)) @ (SafeDiv(y, z) != 0)} = 10), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ (SafeDiv(y, z) != 0)} 
 
 --
 
-{(SafeDiv(x, SafeDiv(y, z)) = 10) @ and([(SafeDiv(y, z) != 0);int(1..)])}, 
+{(SafeDiv(x, SafeDiv(y, z)) = 10) @ (SafeDiv(y, z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]) 
+and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0);int(1..)]) 
 
 --
 
-and([and([(SafeDiv(x, SafeDiv(y, z)) = 10),and([(SafeDiv(y, z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
+and([and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(SafeDiv(x, SafeDiv(y, z)) = 10),(SafeDiv(y, z) != 0),(z != 0);int(1..)]) 
 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-01-simple/input-expected-rule-trace-human.txt
@@ -16,26 +16,18 @@ x % y,
 --
 
 ({SafeMod(x,y) @ (y != 0)} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,y) = 3) @ and([(y != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(x,y) = 3) @ (y != 0)} 
 
 --
 
-{(SafeMod(x,y) = 3) @ and([(y != 0);int(1..)])}, 
+{(SafeMod(x,y) = 3) @ (y != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,y) = 3),and([(y != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,y) = 3),(y != 0);int(1..)]) 
 
 --
 
-and([(SafeMod(x,y) = 3),and([(y != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeMod(x,y) = 3),
-and([(y != 0);int(1..)]) 
-
---
-
-(SafeMod(x,y) = 3),
-and([(y != 0);int(1..)]), 
+and([(SafeMod(x,y) = 3),(y != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeMod(x,y) = 3),
 (y != 0) 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-02-zero/input-expected-rule-trace-human.txt
@@ -17,26 +17,18 @@ x % y,
 --
 
 ({SafeMod(x,y) @ (y != 0)} = z), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,y) = z) @ and([(y != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(x,y) = z) @ (y != 0)} 
 
 --
 
-{(SafeMod(x,y) = z) @ and([(y != 0);int(1..)])}, 
+{(SafeMod(x,y) = z) @ (y != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,y) = z),and([(y != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,y) = z),(y != 0);int(1..)]) 
 
 --
 
-and([(SafeMod(x,y) = z),and([(y != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeMod(x,y) = z),
-and([(y != 0);int(1..)]) 
-
---
-
-(SafeMod(x,y) = z),
-and([(y != 0);int(1..)]), 
+and([(SafeMod(x,y) = z),(y != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeMod(x,y) = z),
 (y != 0) 

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-03-nested/input-expected-rule-trace-human.txt
@@ -17,40 +17,24 @@ y % z,
 --
 
 x % {SafeMod(y,z) @ (z != 0)}, 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{x % SafeMod(y,z) @ (z != 0)} 
 
 --
 
-({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({x % SafeMod(y,z) @ (z != 0)} = 3), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x % SafeMod(y,z) = 3) @ (z != 0)} 
 
 --
 
-{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(x % SafeMod(y,z) = 3) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x % SafeMod(y,z) = 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(x % SafeMod(y,z) = 3),(z != 0);int(1..)]) 
 
 --
 
-and([(x % SafeMod(y,z) = 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x % SafeMod(y,z) = 3),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(x % SafeMod(y,z) = 3),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x % SafeMod(y,z) = 3),
-and([(z != 0);int(1..)]) 
-
---
-
-(x % SafeMod(y,z) = 3),
-and([(z != 0);int(1..)]), 
+and([(x % SafeMod(y,z) = 3),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x % SafeMod(y,z) = 3),
 (z != 0) 
@@ -64,28 +48,18 @@ x % SafeMod(y,z),
 --
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ (SafeMod(y,z) != 0)} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ (SafeMod(y,z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0);int(1..)]) 
 
 --
 
-and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),
-(z != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeMod(x,SafeMod(y,z)) = 3),
-and([(SafeMod(y,z) != 0);int(1..)]),
-(z != 0) 
-
---
-
-(SafeMod(x,SafeMod(y,z)) = 3),
-and([(SafeMod(y,z) != 0);int(1..)]),
+and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0);int(1..)]),
 (z != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeMod(x,SafeMod(y,z)) = 3),

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/input-expected-rule-trace-human.txt
@@ -17,40 +17,24 @@ y % z,
 --
 
 x % {SafeMod(y,z) @ (z != 0)}, 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{x % SafeMod(y,z) @ (z != 0)} 
 
 --
 
-({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} != 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) != 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({x % SafeMod(y,z) @ (z != 0)} != 3), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x % SafeMod(y,z) != 3) @ (z != 0)} 
 
 --
 
-{(x % SafeMod(y,z) != 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(x % SafeMod(y,z) != 3) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x % SafeMod(y,z) != 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
+and([(x % SafeMod(y,z) != 3),(z != 0);int(1..)]) 
 
 --
 
-and([(x % SafeMod(y,z) != 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x % SafeMod(y,z) != 3),
-and([and([(z != 0);int(1..)]);int(1..)]) 
-
---
-
-(x % SafeMod(y,z) != 3),
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(x % SafeMod(y,z) != 3),
-and([(z != 0);int(1..)]) 
-
---
-
-(x % SafeMod(y,z) != 3),
-and([(z != 0);int(1..)]), 
+and([(x % SafeMod(y,z) != 3),(z != 0);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (x % SafeMod(y,z) != 3),
 (z != 0) 
@@ -64,28 +48,18 @@ x % SafeMod(y,z),
 --
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} != 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(x,SafeMod(y,z)) != 3) @ (SafeMod(y,z) != 0)} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) != 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
+{(SafeMod(x,SafeMod(y,z)) != 3) @ (SafeMod(y,z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,SafeMod(y,z)) != 3),(SafeMod(y,z) != 0);int(1..)]) 
 
 --
 
-and([(SafeMod(x,SafeMod(y,z)) != 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),
-(z != 0), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(SafeMod(x,SafeMod(y,z)) != 3),
-and([(SafeMod(y,z) != 0);int(1..)]),
-(z != 0) 
-
---
-
-(SafeMod(x,SafeMod(y,z)) != 3),
-and([(SafeMod(y,z) != 0);int(1..)]),
+and([(SafeMod(x,SafeMod(y,z)) != 3),(SafeMod(y,z) != 0);int(1..)]),
 (z != 0), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (SafeMod(x,SafeMod(y,z)) != 3),

--- a/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/input-expected-rule-trace-human.txt
@@ -17,32 +17,20 @@ y % z,
 --
 
 x % {SafeMod(y,z) @ (z != 0)}, 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{x % SafeMod(y,z) @ and([(z != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{x % SafeMod(y,z) @ (z != 0)} 
 
 --
 
-({x % SafeMod(y,z) @ and([(z != 0);int(1..)])} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])} 
+({x % SafeMod(y,z) @ (z != 0)} = 3), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(x % SafeMod(y,z) = 3) @ (z != 0)} 
 
 --
 
-{(x % SafeMod(y,z) = 3) @ and([and([(z != 0);int(1..)]);int(1..)])}, 
+{(x % SafeMod(y,z) = 3) @ (z != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(x % SafeMod(y,z) = 3),and([and([(z != 0);int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([and([(z != 0);int(1..)]);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-and([(z != 0);int(1..)]) 
-
---
-
-and([(z != 0);int(1..)]), 
-   ~~> remove_unit_vector_and ([("Base", 8800)]) 
-(z != 0) 
+and([(x % SafeMod(y,z) = 3),(z != 0);int(1..)]) 
 
 --
 
@@ -53,18 +41,18 @@ x % SafeMod(y,z),
 --
 
 ({SafeMod(x,SafeMod(y,z)) @ (SafeMod(y,z) != 0)} = 3), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ (SafeMod(y,z) != 0)} 
 
 --
 
-{(SafeMod(x,SafeMod(y,z)) = 3) @ and([(SafeMod(y,z) != 0);int(1..)])}, 
+{(SafeMod(x,SafeMod(y,z)) = 3) @ (SafeMod(y,z) != 0)}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]) 
+and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0);int(1..)]) 
 
 --
 
-and([and([(SafeMod(x,SafeMod(y,z)) = 3),and([(SafeMod(y,z) != 0);int(1..)]);int(1..)]),(z != 0);int(1..)]), 
+and([and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0);int(1..)]),(z != 0);int(1..)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(SafeMod(x,SafeMod(y,z)) = 3),(SafeMod(y,z) != 0),(z != 0);int(1..)]) 
 

--- a/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
@@ -104,56 +104,9 @@ position#matrix_to_atom[sum([1,k;int(1..2)])],
 
 --
 
-({position#matrix_to_atom[sum([1,k;int(1..2)])] @ and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)])} = sum([position#matrix_to_atom[1],1,1;int(1..2)])), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])) @ and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])} 
-
---
-
-{(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])) @ and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
-   ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-and([(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-and([and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
+and([__inDomain(sum([1,k;int(1..2)]),int(1..6));int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+__inDomain(sum([1,k;int(1..2)]),int(1..6)) 
 
 --
 
@@ -163,14 +116,12 @@ position#matrix_to_atom[1],
 
 --
 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([{position#matrix_to_atom[1] @ and([__inDomain(1,int(1..6));int(1..)])},1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([{position#matrix_to_atom[1] @ and([__inDomain(1,int(1..6));int(1..)])},1,1;int(1..2)])),
 (position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
 (position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
 (position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
 (position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
@@ -183,62 +134,9 @@ position#matrix_to_atom[sum([2,k;int(1..2)])],
 
 --
 
-({position#matrix_to_atom[sum([2,k;int(1..2)])] @ and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)])} = sum([position#matrix_to_atom[2],2,1;int(1..2)])), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])) @ and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])} 
-
---
-
-{(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])) @ and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
-   ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-and([(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-and([and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-allDiff(position#matrix_to_atom) 
+and([__inDomain(sum([2,k;int(1..2)]),int(1..6));int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+__inDomain(sum([2,k;int(1..2)]),int(1..6)) 
 
 --
 
@@ -248,17 +146,13 @@ position#matrix_to_atom[2],
 
 --
 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([{position#matrix_to_atom[2] @ and([__inDomain(2,int(1..6));int(1..)])},2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([{position#matrix_to_atom[2] @ and([__inDomain(2,int(1..6));int(1..)])},2,1;int(1..2)])),
 (position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
 (position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
@@ -270,68 +164,9 @@ position#matrix_to_atom[sum([3,k;int(1..2)])],
 
 --
 
-({position#matrix_to_atom[sum([3,k;int(1..2)])] @ and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)])} = sum([position#matrix_to_atom[3],3,1;int(1..2)])), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])) @ and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])} 
-
---
-
-{(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])) @ and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)])}, 
-   ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-and([(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]);int(1..)]),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-and([and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]);int(1..)]),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]),
-allDiff(position#matrix_to_atom) 
-
---
-
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
-allDiff(position#matrix_to_atom) 
+and([__inDomain(sum([3,k;int(1..2)]),int(1..6));int(1..)]), 
+   ~~> remove_unit_vector_and ([("Base", 8800)]) 
+__inDomain(sum([3,k;int(1..2)]),int(1..6)) 
 
 --
 
@@ -341,38 +176,26 @@ position#matrix_to_atom[3],
 
 --
 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([{position#matrix_to_atom[3] @ and([__inDomain(3,int(1..6));int(1..)])},3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([{position#matrix_to_atom[3] @ and([__inDomain(3,int(1..6));int(1..)])},3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[1],1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[2],2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom[3],3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> index_matrix_to_atom ([("Base", 5000)]) 
-(position#matrix_to_atom[sum([1,k;int(1..2)])] = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,k;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
@@ -383,38 +206,44 @@ k,
 
 --
 
-(position#matrix_to_atom[sum([1,3;int(1..2)])] = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([1,3;int(1..2)])] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom[4] = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[4] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
 
-(position#matrix_to_atom[4] = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[4] @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> index_matrix_to_atom ([("Base", 5000)]) 
+({position#matrix_to_atom_4 @ __inDomain(sum([1,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
+allDiff(position#matrix_to_atom) 
+
+--
+
+k, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+3 
+
+--
+
+({position#matrix_to_atom_4 @ __inDomain(sum([1,3;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
+allDiff(position#matrix_to_atom), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([2,k;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
@@ -426,56 +255,43 @@ k,
 --
 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-__inDomain(sum([1,3;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([2,3;int(1..2)])] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom[sum([2,k;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
-allDiff(position#matrix_to_atom) 
-
---
-
-k, 
-   ~~> substitute_value_lettings ([("Base", 5000)]) 
-3 
-
---
-
-(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom[sum([2,3;int(1..2)])] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom[5] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[5] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom[5] = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[5] @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> index_matrix_to_atom ([("Base", 5000)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom_5 @ __inDomain(sum([2,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
+allDiff(position#matrix_to_atom) 
+
+--
+
+k, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+3 
+
+--
+
+(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
+({position#matrix_to_atom_5 @ __inDomain(sum([2,3;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
+allDiff(position#matrix_to_atom), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,k;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([3,k;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
@@ -488,49 +304,24 @@ k,
 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-__inDomain(sum([2,3;int(1..2)]),int(1..6)),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[sum([3,3;int(1..2)])] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,k;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
-allDiff(position#matrix_to_atom) 
-
---
-
-k, 
-   ~~> substitute_value_lettings ([("Base", 5000)]) 
-3 
-
---
-
-(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom[sum([3,3;int(1..2)])] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
-allDiff(position#matrix_to_atom), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
-(position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom[6] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[6] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom[6] = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom[6] @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> index_matrix_to_atom ([("Base", 5000)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom_6 = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,k;int(1..2)]),int(1..6)),
+({position#matrix_to_atom_6 @ __inDomain(sum([3,k;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom) 
 
 --
@@ -543,8 +334,7 @@ k,
 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),
 (position#matrix_to_atom_5 = sum([position#matrix_to_atom_2,2,1;int(1..2)])),
-(position#matrix_to_atom_6 = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
-__inDomain(sum([3,3;int(1..2)]),int(1..6)),
+({position#matrix_to_atom_6 @ __inDomain(sum([3,3;int(1..2)]),int(1..6))} = sum([position#matrix_to_atom_3,3,1;int(1..2)])),
 allDiff(position#matrix_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (position#matrix_to_atom_4 = sum([position#matrix_to_atom_1,1,1;int(1..2)])),

--- a/conjure_oxide/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
@@ -136,18 +136,18 @@ q2#matrix_to_atom[i],
 --
 
 ({q2#matrix_to_atom[i] @ and([__inDomain(i,int(0..7));int(1..)])} = sum([q1#matrix_to_atom[i],-(i);int(1..)])), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])}, 
+{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([__inDomain(i,int(0..7));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]) 
+and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]) 
 
 --
 
-and([and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]), 
+and([and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]) 
 
@@ -160,30 +160,30 @@ q1#matrix_to_atom[i],
 --
 
 [{q1#matrix_to_atom[i] @ and([__inDomain(i,int(0..7));int(1..)])},-(i);int(1..)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[q1#matrix_to_atom[i],-(i);int(1..)] @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[q1#matrix_to_atom[i],-(i);int(1..)] @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-sum({[q1#matrix_to_atom[i],-(i);int(1..)] @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{sum([q1#matrix_to_atom[i],-(i);int(1..)]) @ and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)])} 
+sum({[q1#matrix_to_atom[i],-(i);int(1..)] @ and([__inDomain(i,int(0..7));int(1..)])}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{sum([q1#matrix_to_atom[i],-(i);int(1..)]) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-(q2#matrix_to_atom[i] = {sum([q1#matrix_to_atom[i],-(i);int(1..)]) @ and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)])} 
+(q2#matrix_to_atom[i] = {sum([q1#matrix_to_atom[i],-(i);int(1..)]) @ and([__inDomain(i,int(0..7));int(1..)])}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])) @ and([__inDomain(i,int(0..7));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]) 
 
 --
 
-and([and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]), 
+and([and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)]) 
 
@@ -196,18 +196,18 @@ q3#matrix_to_atom[i],
 --
 
 ({q3#matrix_to_atom[i] @ and([__inDomain(i,int(0..7));int(1..)])} = sum([q1#matrix_to_atom[i],i;int(1..2)])), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])}, 
+{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([__inDomain(i,int(0..7));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]) 
+and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]) 
 
 --
 
-and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..2)]), 
+and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),__inDomain(i,int(0..7));int(1..2)]) 
 
@@ -220,30 +220,30 @@ q1#matrix_to_atom[i],
 --
 
 [{q1#matrix_to_atom[i] @ and([__inDomain(i,int(0..7));int(1..)])},i;int(1..2)], 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{[q1#matrix_to_atom[i],i;int(1..2)] @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])} 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{[q1#matrix_to_atom[i],i;int(1..2)] @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-sum({[q1#matrix_to_atom[i],i;int(1..2)] @ and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{sum([q1#matrix_to_atom[i],i;int(1..2)]) @ and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)])} 
+sum({[q1#matrix_to_atom[i],i;int(1..2)] @ and([__inDomain(i,int(0..7));int(1..)])}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{sum([q1#matrix_to_atom[i],i;int(1..2)]) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-(q3#matrix_to_atom[i] = {sum([q1#matrix_to_atom[i],i;int(1..2)]) @ and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)])}), 
-   ~~> bubble_up ([("Bubble", 8900)]) 
-{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)])} 
+(q3#matrix_to_atom[i] = {sum([q1#matrix_to_atom[i],i;int(1..2)]) @ and([__inDomain(i,int(0..7));int(1..)])}), 
+   ~~> bubble_up ([("Bubble", 8800)]) 
+{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([__inDomain(i,int(0..7));int(1..)])} 
 
 --
 
-{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)])}, 
+{(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])) @ and([__inDomain(i,int(0..7));int(1..)])}, 
    ~~> expand_bubble ([("Bubble", 8900)]) 
-and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]) 
+and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]) 
 
 --
 
-and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([and([and([and([__inDomain(i,int(0..7));int(1..)]);int(1..)]);int(1..)]);int(1..)]);int(1..)]),__inDomain(i,int(0..7));int(1..2)]), 
+and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),and([(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),and([__inDomain(i,int(0..7));int(1..)]);int(1..)]),__inDomain(i,int(0..7));int(1..2)]), 
    ~~> normalise_associative_commutative ([("Base", 8900)]) 
 and([(q2#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],-(i);int(1..)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)])),__inDomain(i,int(0..7)),__inDomain(i,int(0..7));int(1..2)]) 
 

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -768,6 +768,7 @@ impl Expression {
                 | Expression::UnsafeMod(_, _, _)
                 | Expression::UnsafePow(_, _, _)
                 | Expression::UnsafeIndex(_, _, _)
+                | Expression::Bubble(_, _, _)
                 | Expression::UnsafeSlice(_, _, _) => {
                     return false;
                 }


### PR DESCRIPTION
* Fix infinite loop of bubble_up rule by disallowing bubbling up a
  bubble inside a bubble. See test case for more details.

* Also, make bubble an "unsafe expression", as it should always have
  been. This prevents the rewriting of !({a @ b} = c) ~> {a @ b} !=c.

* The provided test is disabled due to it being slow, to be re-enabled
  once we have a way to run "expensive tests" separately from the rest.
