### PR TITLE
 perf: reduce size of AST types 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ members = [
 unwrap_used = "allow"
 expect_used = "allow"
 wildcard_imports = "warn"
+
+[profile.profiling] 
+inherits = "release"
+debug = true

--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -102,7 +102,7 @@ pub fn get_minion_solutions(
         *sol = sol
             .clone()
             .into_iter()
-            .filter(|(name, _)| !matches!(name, Name::RepresentedName(_, _, _)))
+            .filter(|(name, _)| !matches!(name, Name::RepresentedName(_)))
             .collect();
     }
 

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -263,7 +263,8 @@ pub fn normalize_solutions_for_comparison(
                         // make all domains the same (this is just in the tester so the types dont
                         // actually matter)
 
-                        let mut matrix = AbstractLiteral::Matrix(elems, Domain::IntDomain(vec![]));
+                        let mut matrix =
+                            AbstractLiteral::Matrix(elems, Box::new(Domain::IntDomain(vec![])));
                         matrix =
                             matrix.transform(Arc::new(
                                 move |x: AbstractLiteral<Literal>| match x {
@@ -277,7 +278,10 @@ pub fn normalize_solutions_for_comparison(
                                             })
                                             .collect_vec();
 
-                                        AbstractLiteral::Matrix(items, Domain::IntDomain(vec![]))
+                                        AbstractLiteral::Matrix(
+                                            items,
+                                            Box::new(Domain::IntDomain(vec![])),
+                                        )
                                     }
                                     x => x,
                                 },

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -105,7 +105,7 @@ impl Domain {
                 if index_domains
                     .pop()
                     .expect("a matrix should have atleast one index domain")
-                    != *idx_domain
+                    != **idx_domain
                 {
                     return Some(false);
                 };

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -858,7 +858,7 @@ impl Expression {
     pub fn unwrap_matrix_unchecked(self) -> Option<(Vec<Expression>, Domain)> {
         match self {
             Expression::AbstractLiteral(_, AbstractLiteral::Matrix(elems, domain)) => {
-                Some((elems.clone(), domain))
+                Some((elems.clone(), *domain))
             }
             Expression::Atomic(
                 _,
@@ -869,7 +869,7 @@ impl Expression {
                     .into_iter()
                     .map(|x: Literal| Expression::Atomic(Metadata::new(), Atom::Literal(x)))
                     .collect_vec(),
-                domain,
+                *domain,
             )),
 
             _ => None,

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -38,7 +38,7 @@ pub enum AbstractLiteral<T: AbstractLiteralValue> {
     Set(Vec<T>),
 
     /// A 1 dimensional matrix slice with an index domain.
-    Matrix(Vec<T>, Domain),
+    Matrix(Vec<T>, Box<Domain>),
 
     // a tuple of literals
     Tuple(Vec<T>),
@@ -79,7 +79,10 @@ where
     ///
     /// This acts as a variable sized list.
     pub fn matrix_implied_indices(elems: Vec<T>) -> Self {
-        AbstractLiteral::Matrix(elems, Domain::IntDomain(vec![Range::UnboundedR(1)]))
+        AbstractLiteral::Matrix(
+            elems,
+            Box::new(Domain::IntDomain(vec![Range::UnboundedR(1)])),
+        )
     }
 
     /// If the AbstractLiteral is a list, returns its elements.
@@ -87,7 +90,11 @@ where
     /// A list is any a matrix with the domain `int(1..)`. This includes matrix literals without
     /// any explicitly specified domain.
     pub fn unwrap_list(&self) -> Option<&Vec<T>> {
-        let AbstractLiteral::Matrix(elems, Domain::IntDomain(ranges)) = self else {
+        let AbstractLiteral::Matrix(elems, domain) = self else {
+            return None;
+        };
+
+        let Domain::IntDomain(ranges) = domain.as_ref() else {
             return None;
         };
 
@@ -398,7 +405,7 @@ mod tests {
             let mut res = vec![];
             res.extend(children.into_iter().flatten());
             if let AbstractLiteral::Matrix(_, index_domain) = elem {
-                res.push(index_domain);
+                res.push(*index_domain);
             }
 
             res

--- a/crates/conjure_core/src/ast/matrix.rs
+++ b/crates/conjure_core/src/ast/matrix.rs
@@ -131,7 +131,7 @@ pub fn index_domains(matrix: AbstractLiteral<Literal>) -> Vec<Domain> {
             match element {
                 AbstractLiteral::Set(_) => vec![],
                 AbstractLiteral::Matrix(_, domain) => {
-                    let mut index_domains = vec![domain];
+                    let mut index_domains = vec![*domain];
                     index_domains.extend(child_index_domains);
                     index_domains
                 }

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -94,7 +94,7 @@ macro_rules! into_matrix {
         $crate::ast::AbstractLiteral::matrix_implied_indices($x)
     );
     ($x:expr;$domain:expr) => (
-        $crate::ast::AbstractLiteral::Matrix($x,$domain)
+        $crate::ast::AbstractLiteral::Matrix($x,::std::boxed::Box::new($domain))
     );
 }
 

--- a/crates/conjure_core/src/ast/name.rs
+++ b/crates/conjure_core/src/ast/name.rs
@@ -12,12 +12,16 @@ pub enum Name {
 
     /// A representation variable.
     RepresentedName(
-        /// The source variable
-        Box<Name>,
-        /// The representation rule used
-        String,
-        /// Additional, rule dependent, information
-        String,
+        // box these fields to make the size of name smaller
+        // this in turn makes the size of atom, expression, domain, ... smaller
+        Box<(
+            // The source variable
+            Name,
+            // The representation rule used
+            String,
+            // Additional, rule dependent, information
+            String,
+        )>,
     ),
 
     WithRepresentation(
@@ -34,7 +38,8 @@ impl Display for Name {
         match self {
             Name::UserName(s) => write!(f, "{}", s),
             Name::MachineName(i) => write!(f, "__{}", i),
-            Name::RepresentedName(name, rule_string, suffix) => {
+            Name::RepresentedName(fields) => {
+                let (name, rule_string, suffix) = fields.as_ref();
                 write!(f, "{name}#{rule_string}_{suffix}")
             }
             Name::WithRepresentation(name, items) => {

--- a/crates/conjure_core/src/solver/adaptors/minion/adaptor.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/adaptor.rs
@@ -48,11 +48,11 @@ fn parse_name(minion_name: &str) -> Name {
     if let Some(caps) = MACHINE_NAME_RE.captures(minion_name) {
         conjure_ast::Name::MachineName(caps[1].parse::<i32>().unwrap())
     } else if let Some(caps) = REPRESENTED_NAME_RE.captures(minion_name) {
-        conjure_ast::Name::RepresentedName(
-            Box::new(parse_name(&caps[1])),
+        conjure_ast::Name::RepresentedName(Box::new((
+            parse_name(&caps[1]),
             caps[2].to_string(),
             caps[3].to_string(),
-        )
+        )))
     } else {
         conjure_ast::Name::UserName(minion_name.to_string())
     }

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -204,8 +204,9 @@ fn name_to_string(name: conjure_ast::Name) -> String {
     match name {
         // print machine names in a custom, easier to regex, way.
         conjure_ast::Name::MachineName(x) => format!("__conjure_machine_name_{}", x),
-        conjure_ast::Name::RepresentedName(name, rule, suffix) => {
-            let name = name_to_string(*name);
+        conjure_ast::Name::RepresentedName(fields) => {
+            let (name, rule, suffix) = *fields;
+            let name = name_to_string(name);
             format!("__conjure_represented_name##{name}##{rule}___{suffix}")
         }
         x => format!("{x}"),

--- a/crates/conjure_rules/src/matrix/repr_matrix.rs
+++ b/crates/conjure_rules/src/matrix/repr_matrix.rs
@@ -69,11 +69,11 @@ fn index_matrix_to_atom_impl(expr: &Expr, symbols: &SymbolTable) -> ApplicationR
     if indices_are_const {
         // indices are constant -> find the element being indexed and only return that variable.
         //
-        let indices_as_name = Name::RepresentedName(
-            name.clone(),
+        let indices_as_name = Name::RepresentedName(Box::new((
+            name.as_ref().clone(),
             "matrix_to_atom".into(),
             indices_as_lits.iter().join("_"),
-        );
+        )));
 
         let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
 
@@ -187,11 +187,11 @@ fn index_matrix_to_atom_impl(expr: &Expr, symbols: &SymbolTable) -> ApplicationR
         let repr_exprs = repr.expression_down(symbols)?;
         let flat_elems = matrix::enumerate_indices(index_domains.clone())
             .map(|xs| {
-                Name::RepresentedName(
-                    name.clone(),
+                Name::RepresentedName(Box::new((
+                    name.as_ref().clone(),
                     "matrix_to_atom".into(),
                     xs.into_iter().join("_"),
-                )
+                )))
             })
             .map(|x| repr_exprs[&x].clone())
             .collect_vec();
@@ -261,11 +261,11 @@ fn slice_matrix_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult
         .map(|i| {
             let mut indices_as_lits = indices_as_lits.clone();
             indices_as_lits[hole_dim as usize] = Some(i);
-            let name = Name::RepresentedName(
-                name.clone(),
+            let name = Name::RepresentedName(Box::new((
+                name.as_ref().clone(),
                 "matrix_to_atom".into(),
                 indices_as_lits.into_iter().map(|x| x.unwrap()).join("_"),
-            );
+            )));
             repr_values[&name].clone()
         })
         .collect_vec();
@@ -318,11 +318,11 @@ fn matrix_ref_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
 
         let flat_values = matrix::enumerate_indices(index_domains)
             .map(|i| {
-                matrix_values[&Name::RepresentedName(
-                    name.clone(),
+                matrix_values[&Name::RepresentedName(Box::new((
+                    name.as_ref().clone(),
                     "matrix_to_atom".into(),
                     i.iter().join("_"),
-                )]
+                )))]
                     .clone()
             })
             .collect_vec();

--- a/crates/conjure_rules/src/records.rs
+++ b/crates/conjure_rules/src/records.rs
@@ -60,8 +60,11 @@ fn index_record_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult
         return Err(RuleNotApplicable); // we don't support non-literal indices
     };
 
-    let indices_as_name =
-        Name::RepresentedName(name.clone(), "record_to_atom".into(), index.to_string());
+    let indices_as_name = Name::RepresentedName(Box::new((
+        name.as_ref().clone(),
+        "record_to_atom".into(),
+        index.to_string(),
+    )));
 
     let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
 

--- a/crates/conjure_rules/src/representation/matrix_to_atom.rs
+++ b/crates/conjure_rules/src/representation/matrix_to_atom.rs
@@ -28,22 +28,24 @@ impl MatrixToAtom {
 
     /// Gets the representation variable name for a specific set of indices.
     fn indices_to_name(&self, indices: &[Literal]) -> Name {
-        Name::RepresentedName(
-            Box::new(self.src_var.clone()),
+        Name::RepresentedName(Box::new((
+            self.src_var.clone(),
             self.repr_name().to_string(),
             indices.iter().join("_"),
-        )
+        )))
     }
 
     /// Panics if name is invalid.
     #[allow(dead_code)]
     fn name_to_indices(&self, name: &Name) -> Vec<Literal> {
-        let Name::RepresentedName(src_var, rule_string, suffix) = name else {
+        let Name::RepresentedName(fields) = name else {
             bug!("representation name should be Name::RepresentationOf");
         };
 
+        let (src_var, rule_string, suffix) = fields.as_ref();
+
         assert_eq!(
-            src_var.as_ref(),
+            src_var,
             self.variable_name(),
             "name should have the same source var as self"
         );
@@ -125,7 +127,7 @@ impl Representation for MatrixToAtom {
             return Err(RuleNotApplicable);
         };
 
-        if index_domain != &self.index_domains[0] {
+        if index_domain.as_ref() != &self.index_domains[0] {
             return Err(RuleNotApplicable);
         }
 

--- a/crates/conjure_rules/src/representation/record_to_atom.rs
+++ b/crates/conjure_rules/src/representation/record_to_atom.rs
@@ -28,11 +28,11 @@ impl RecordToAtom {
 
     /// Gets the representation variable name for a specific set of indices.
     fn indices_to_name(&self, indices: &[Literal]) -> Name {
-        Name::RepresentedName(
-            Box::new(self.src_var.clone()),
+        Name::RepresentedName(Box::new((
+            self.src_var.clone(),
             self.repr_name().to_string(),
             indices.iter().join("_"),
-        )
+        )))
     }
 }
 
@@ -95,9 +95,12 @@ impl Representation for RecordToAtom {
             let value = values
                 .get(&name)
                 .ok_or(ApplicationError::RuleNotApplicable)?;
-            let Name::RepresentedName(_, _, idx) = name.clone() else {
+            let Name::RepresentedName(fields) = name.clone() else {
                 return Err(ApplicationError::RuleNotApplicable);
             };
+
+            let (_, _, idx) = *fields;
+
             let idx: usize = idx
                 .parse()
                 .map_err(|_| ApplicationError::RuleNotApplicable)?;

--- a/crates/conjure_rules/src/representation/tuple_to_atom.rs
+++ b/crates/conjure_rules/src/representation/tuple_to_atom.rs
@@ -25,11 +25,11 @@ impl TupleToAtom {
 
     /// Gets the representation variable name for a specific set of indices.
     fn indices_to_name(&self, indices: &[Literal]) -> Name {
-        Name::RepresentedName(
-            Box::new(self.src_var.clone()),
+        Name::RepresentedName(Box::new((
+            self.src_var.clone(),
             self.repr_name().to_string(),
             indices.iter().join("_"),
-        )
+        )))
     }
 }
 

--- a/crates/conjure_rules/src/tuple.rs
+++ b/crates/conjure_rules/src/tuple.rs
@@ -56,11 +56,11 @@ fn index_tuple_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult 
         indices_as_lit = index;
     }
 
-    let indices_as_name = Name::RepresentedName(
-        name.clone(),
+    let indices_as_name = Name::RepresentedName(Box::new((
+        name.as_ref().clone(),
         "tuple_to_atom".into(),
         indices_as_lit.to_string(),
-    );
+    )));
 
     let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
 


### PR DESCRIPTION
Reduce the size of `Name` and `AbstractLiteral` types by boxing large
fields. This causes a reduction in the sizes of `Literal`, `Atom` and
`Expression`.

## Details

+ `Name` was reduced from 56 bytes to 32 bytes

+ `AbstractLiteral` was reduced from 80 bytes to 32 bytes

+ `Literal` was reduced from 80 bytes to 32  bytes

+ `Atom` was reduced from 80 bytes to 40 bytes

+ `Expression` was reduced from 272 bytes to 152 bytes

## Motivation

As an enum has the size of its largest variants, having a few large
outlier variants in an enum wastes space. As we clone our AST types a
lot during rewriting, reducing their size also improves performance by
making memory copying of them faster.

The largest variants of the `Expression` type are those that contain 3
atom fields (FlatIneq, FlatProductEq, MinionDivEqUndefZero,...);
reducing the size of `Atom` and its constituent types was useful to
bring down the size of these variants.

## Performance

This change improves wall-time as well as memory usage, and all
benchmarks (in the standard suite, see the `perf_benchmarks/` folder)
show speedups compared to main. The speedup is more pronounced for
smaller models, but is still present in larger ones:

| Benchmark                          | Speedup vs main |
| ---------------------------------- | --------------- |
| fast/langford.eprime               | 23%             |
| fast/nqueens_8.eprime              | 10%             |
| fast/xkcd.eprime                   | 21%             |
| slow/nqueens_20.eprime             | 04%             |
| slow/pythagorean_triples_75.eprime | 03%             |

## Future Work

While the variants of `Name`, `Literal`, and `Atom` are now mostly of
uniform size, there remain some outlier variants of `Expression` that
could be shrunk. Despite `Expression` being 152 bytes, only the Minion /
flat expression variants are over 72 bytes. They are listed below:

  + 144 bytes: FlatProductEq,
    MinionDivEqUndefZero,MinionModuloEqUndefZero,MinionPow

  + 136 bytes: FlatIneq

  + 128 bytes: MinionElementOne

  + 112 bytes: FlatWeightedSumLeq, FlatWeightedSumGeq

  + 104 bytes: FlatAbsEq, FlatMinusEq

As we don't see these expression variants until late in the rewriting
process, I believe the performance costs of boxing these fields would be
less than the improvements we could get in rewriting speed due to a
smaller `Expression` type.

Although boxed fields are harder to pattern match over, I do not think
this will negatively impact the ergonomics of rule writing much, as
Minion/flat constraints represent the end product of rewriting, so
should not have many rules applying to them (except constant/partial
evaluator).

## See also

+ For more information on type sizes, see:
  https://nnethercote.github.io/perf-book/type-sizes.html.

+ To measure and list the type sizes for Conjure Oxide, I used the
  `top-type-sizes` crate. For more information, see its README:
  https://crates.io/crates/top-type-sizes.