### PR TITLE
perf: further reduce size of `Expression` from 152 to 96 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "static_assertions",
  "strum",
  "strum_macros",
  "thiserror 2.0.12",
@@ -2186,6 +2187,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -321,15 +321,16 @@ fn reduce_solve_xyz() {
         .apply(&expr2, &SymbolTable::new())
         .unwrap()
         .new_expression;
-    assert_eq!(
-        expr2,
-        Expression::FlatIneq(
-            Metadata::new(),
-            Atom::Reference(Name::UserName(String::from("a"))),
-            Atom::Reference(Name::UserName(String::from("b"))),
-            Literal::Int(-1),
-        )
-    );
+
+    assert!(matches!(expr2, Expression::FlatIneq(_, _, _, _)));
+
+    let Expression::FlatIneq(_, a, b, v) = expr2.clone() else {
+        unreachable!();
+    };
+
+    assert_eq!(*a, Atom::Reference(Name::UserName(String::from("a"))));
+    assert_eq!(*b, Atom::Reference(Name::UserName(String::from("b"))));
+    assert_eq!(*v, Literal::Int(-1));
 
     let mut model = Model::new(Default::default());
     *model.as_submodel_mut().constraints_mut() = vec![expr1, expr2];

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -37,6 +37,7 @@ rustsat-minisat = "0.7.2"
 rustsat = "0.7.2"
 tree-morph = { path = "../tree_morph" }
 paste = "1.0.15"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 conjure_essence_macros = { path = "../conjure_essence_macros" }

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -172,6 +172,23 @@ impl TryFrom<Atom> for i32 {
     }
 }
 
+impl TryFrom<&Box<Atom>> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: &Box<Atom>) -> Result<Self, Self::Error> {
+        TryFrom::<&Atom>::try_from(value.as_ref())
+    }
+}
+
+impl TryFrom<Box<Atom>> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: Box<Atom>) -> Result<Self, Self::Error> {
+        let lit: Literal = (*value).try_into()?;
+        lit.try_into()
+    }
+}
+
 impl TryFrom<&Atom> for i32 {
     type Error = &'static str;
 

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -24,6 +24,23 @@ use super::comprehension::Comprehension;
 use super::records::RecordValue;
 use super::{Domain, Range, SubModel, Typeable};
 
+// Ensure that this type doesn't get too big
+//
+// If you triggered this assertion, you either made a variant of this enum that is too big, or you
+// made Name,Literal,AbstractLiteral,Atom bigger, which made this bigger! To fix this, put some
+// stuff in boxes.
+//
+// Enums take the size of their largest variant, so an enum with mostly small variants and a few
+// large ones wastes memory... A larger Expression type also slows down Oxide.
+//
+// For more information, and more details on type sizes and how to measure them, see the commit
+// message for 6012de809 (perf: reduce size of AST types, 2025-06-18).
+//
+// https://github.com/conjure-cp/conjure-oxide/commit/6012de8096ca491ded91ecec61352fdf4e994f2e
+
+// expect size of Expression to be 96 bytes
+static_assertions::assert_eq_size!([u8; 96], Expression);
+
 /// Represents different types of expressions used to define rules and constraints in the model.
 ///
 /// The `Expression` enum includes operations, constants, and variable references

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -234,7 +234,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#abs)
     #[compatible(Minion)]
-    FlatAbsEq(Metadata, Atom, Atom),
+    FlatAbsEq(Metadata, Box<Atom>, Box<Atom>),
 
     /// Ensures that `alldiff([a,b,...])`.
     ///
@@ -274,7 +274,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#ineq)
     #[compatible(Minion)]
-    FlatIneq(Metadata, Atom, Atom, Literal),
+    FlatIneq(Metadata, Box<Atom>, Box<Atom>, Box<Literal>),
 
     /// `w-literal(x,k)` ensures that x == k, where x is a variable and k a constant.
     ///
@@ -302,7 +302,7 @@ pub enum Expression {
     ///
     /// + [Minion
     /// documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#weightedsumleq)
-    FlatWeightedSumLeq(Metadata, Vec<Literal>, Vec<Atom>, Atom),
+    FlatWeightedSumLeq(Metadata, Vec<Literal>, Vec<Atom>, Box<Atom>),
 
     /// `weightedsumgeq(cs,xs,total)` ensures that cs.xs >= total, where cs.xs is the scalar dot
     /// product of cs and xs.
@@ -315,7 +315,7 @@ pub enum Expression {
     ///
     /// + [Minion
     /// documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#weightedsumleq)
-    FlatWeightedSumGeq(Metadata, Vec<Literal>, Vec<Atom>, Atom),
+    FlatWeightedSumGeq(Metadata, Vec<Literal>, Vec<Atom>, Box<Atom>),
 
     /// Ensures that x =-y, where x and y are atoms.
     ///
@@ -325,7 +325,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#minuseq)
     #[compatible(Minion)]
-    FlatMinusEq(Metadata, Atom, Atom),
+    FlatMinusEq(Metadata, Box<Atom>, Box<Atom>),
 
     /// Ensures that x*y=z.
     ///
@@ -335,7 +335,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#product)
     #[compatible(Minion)]
-    FlatProductEq(Metadata, Atom, Atom, Atom),
+    FlatProductEq(Metadata, Box<Atom>, Box<Atom>, Box<Atom>),
 
     /// Ensures that floor(x/y)=z. Always true when y=0.
     ///
@@ -345,7 +345,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#div_undefzero)
     #[compatible(Minion)]
-    MinionDivEqUndefZero(Metadata, Atom, Atom, Atom),
+    MinionDivEqUndefZero(Metadata, Box<Atom>, Box<Atom>, Box<Atom>),
 
     /// Ensures that x%y=z. Always true when y=0.
     ///
@@ -355,7 +355,7 @@ pub enum Expression {
     ///
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#mod_undefzero)
     #[compatible(Minion)]
-    MinionModuloEqUndefZero(Metadata, Atom, Atom, Atom),
+    MinionModuloEqUndefZero(Metadata, Box<Atom>, Box<Atom>, Box<Atom>),
 
     /// Ensures that `x**y = z`.
     ///
@@ -368,7 +368,7 @@ pub enum Expression {
     ///
     /// + [Github comment about `pow` semantics](https://github.com/minion/minion/issues/40#issuecomment-2595914891)
     /// + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#pow)
-    MinionPow(Metadata, Atom, Atom, Atom),
+    MinionPow(Metadata, Box<Atom>, Box<Atom>, Box<Atom>),
 
     /// `reify(constraint,r)` ensures that r=1 iff `constraint` is satisfied, where r is a 0/1
     /// variable.
@@ -400,7 +400,7 @@ pub enum Expression {
     /// Low-level Minion constraint.
     ///
     /// # See also
-    ///
+    ///>
     ///  + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#w-inintervalset)
     #[compatible(Minion)]
     MinionWInIntervalSet(Metadata, Atom, Vec<i32>),
@@ -428,7 +428,7 @@ pub enum Expression {
     ///
     ///  + [Minion documentation](https://minion-solver.readthedocs.io/en/stable/usage/constraints.html#element_one)
     #[compatible(Minion)]
-    MinionElementOne(Metadata, Vec<Atom>, Atom, Atom),
+    MinionElementOne(Metadata, Vec<Atom>, Box<Atom>, Box<Atom>),
 
     /// Declaration of an auxiliary variable.
     ///

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -265,6 +265,22 @@ impl TryFrom<Literal> for i32 {
     }
 }
 
+impl TryFrom<Box<Literal>> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: Box<Literal>) -> Result<Self, Self::Error> {
+        (*value).try_into()
+    }
+}
+
+impl TryFrom<&Box<Literal>> for i32 {
+    type Error = &'static str;
+
+    fn try_from(value: &Box<Literal>) -> Result<Self, Self::Error> {
+        TryFrom::<&Literal>::try_from(value.as_ref())
+    }
+}
+
 impl TryFrom<&Literal> for i32 {
     type Error = &'static str;
 

--- a/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/parse_model.rs
@@ -274,21 +274,24 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
             minion_ast::Constraint::SumGeq(parse_atoms(lhs)?, parse_atom(rhs)?),
         ),
         conjure_ast::Expression::FlatIneq(_metadata, a, b, c) => Ok(minion_ast::Constraint::Ineq(
-            parse_atom(a)?,
-            parse_atom(b)?,
-            parse_literal(c)?,
+            parse_atom(*a)?,
+            parse_atom(*b)?,
+            parse_literal(*c)?,
         )),
         conjure_ast::Expression::Neq(_metadata, a, b) => Ok(minion_ast::Constraint::DisEq(
             parse_atomic_expr(*a)?,
             parse_atomic_expr(*b)?,
         )),
-        conjure_ast::Expression::MinionDivEqUndefZero(_metadata, a, b, c) => Ok(
-            minion_ast::Constraint::DivUndefZero((parse_atom(a)?, parse_atom(b)?), parse_atom(c)?),
-        ),
+        conjure_ast::Expression::MinionDivEqUndefZero(_metadata, a, b, c) => {
+            Ok(minion_ast::Constraint::DivUndefZero(
+                (parse_atom(*a)?, parse_atom(*b)?),
+                parse_atom(*c)?,
+            ))
+        }
         conjure_ast::Expression::MinionModuloEqUndefZero(_metadata, a, b, c) => {
             Ok(minion_ast::Constraint::ModuloUndefZero(
-                (parse_atom(a)?, parse_atom(b)?),
-                parse_atom(c)?,
+                (parse_atom(*a)?, parse_atom(*b)?),
+                parse_atom(*c)?,
             ))
         }
         conjure_ast::Expression::MinionWInIntervalSet(_metadata, a, xs) => {
@@ -308,7 +311,7 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
             ))
         }
         conjure_ast::Expression::MinionElementOne(_, vec, i, e) => Ok(
-            minion_ast::Constraint::ElementOne(parse_atoms(vec)?, parse_atom(i)?, parse_atom(e)?),
+            minion_ast::Constraint::ElementOne(parse_atoms(vec)?, parse_atom(*i)?, parse_atom(*e)?),
         ),
 
         conjure_ast::Expression::Or(_metadata, e) => Ok(minion_ast::Constraint::WatchedOr(
@@ -357,32 +360,33 @@ fn parse_expr(expr: conjure_ast::Expression) -> Result<minion_ast::Constraint, S
         ),
 
         conjure_ast::Expression::FlatMinusEq(_metadata, a, b) => Ok(
-            minion_ast::Constraint::MinusEq(parse_atom(a)?, parse_atom(b)?),
+            minion_ast::Constraint::MinusEq(parse_atom(*a)?, parse_atom(*b)?),
         ),
 
         conjure_ast::Expression::FlatProductEq(_metadata, a, b, c) => Ok(
-            minion_ast::Constraint::Product((parse_atom(a)?, parse_atom(b)?), parse_atom(c)?),
+            minion_ast::Constraint::Product((parse_atom(*a)?, parse_atom(*b)?), parse_atom(*c)?),
         ),
         conjure_ast::Expression::FlatWeightedSumLeq(_metadata, coeffs, vars, total) => {
             Ok(minion_ast::Constraint::WeightedSumLeq(
                 parse_literals(coeffs)?,
                 parse_atoms(vars)?,
-                parse_atom(total)?,
+                parse_atom(*total)?,
             ))
         }
         conjure_ast::Expression::FlatWeightedSumGeq(_metadata, coeffs, vars, total) => {
             Ok(minion_ast::Constraint::WeightedSumGeq(
                 parse_literals(coeffs)?,
                 parse_atoms(vars)?,
-                parse_atom(total)?,
+                parse_atom(*total)?,
             ))
         }
-        conjure_ast::Expression::FlatAbsEq(_metadata, x, y) => {
-            Ok(minion_ast::Constraint::Abs(parse_atom(x)?, parse_atom(y)?))
-        }
+        conjure_ast::Expression::FlatAbsEq(_metadata, x, y) => Ok(minion_ast::Constraint::Abs(
+            parse_atom(*x)?,
+            parse_atom(*y)?,
+        )),
         conjure_ast::Expression::MinionPow(_, x, y, z) => Ok(minion_ast::Constraint::Pow(
-            (parse_atom(x)?, parse_atom(y)?),
-            parse_atom(z)?,
+            (parse_atom(*x)?, parse_atom(*y)?),
+            parse_atom(*z)?,
         )),
         x => Err(ModelFeatureNotSupported(format!("{:?}", x))),
     }

--- a/crates/conjure_rules/src/minion.rs
+++ b/crates/conjure_rules/src/minion.rs
@@ -116,15 +116,19 @@ fn introduce_producteq(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult 
 
         symbols.insert(Rc::new(Declaration::new_var(aux_var.clone(), aux_domain)));
 
-        let new_top_expr =
-            Expr::FlatProductEq(Metadata::new(), y, next_factor_atom, aux_var.clone().into());
+        let new_top_expr = Expr::FlatProductEq(
+            Metadata::new(),
+            Box::new(y),
+            Box::new(next_factor_atom),
+            Box::new(aux_var.clone().into()),
+        );
 
         new_tops.push(new_top_expr);
         y = aux_var.into();
     }
 
     Ok(Reduction::new(
-        Expr::FlatProductEq(Metadata::new(), x, y, val),
+        Expr::FlatProductEq(Metadata::new(), Box::new(x), Box::new(y), Box::new(val)),
         new_tops,
         symbols,
     ))
@@ -331,9 +335,9 @@ fn introduce_weighted_sumleq_sumgeq(expr: &Expr, symtab: &SymbolTable) -> Applic
                     Metadata::new(),
                     coefficients.clone(),
                     vars.clone(),
-                    total.clone(),
+                    Box::new(total.clone()),
                 ),
-                Expr::FlatWeightedSumGeq(Metadata::new(), coefficients, vars, total),
+                Expr::FlatWeightedSumGeq(Metadata::new(), coefficients, vars, Box::new(total)),
             ]),
         ),
         (EqualityKind::Eq, false) => Expr::And(
@@ -344,11 +348,11 @@ fn introduce_weighted_sumleq_sumgeq(expr: &Expr, symtab: &SymbolTable) -> Applic
             ]),
         ),
         (EqualityKind::Leq, true) => {
-            Expr::FlatWeightedSumLeq(Metadata::new(), coefficients, vars, total)
+            Expr::FlatWeightedSumLeq(Metadata::new(), coefficients, vars, Box::new(total))
         }
         (EqualityKind::Leq, false) => Expr::FlatSumLeq(Metadata::new(), vars, total),
         (EqualityKind::Geq, true) => {
-            Expr::FlatWeightedSumGeq(Metadata::new(), coefficients, vars, total)
+            Expr::FlatWeightedSumGeq(Metadata::new(), coefficients, vars, Box::new(total))
         }
         (EqualityKind::Geq, false) => Expr::FlatSumGeq(Metadata::new(), vars, total),
     };
@@ -528,9 +532,9 @@ fn introduce_diveq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::MinionDivEqUndefZero(
         meta.clone_dirty(),
-        a.clone(),
-        b.clone(),
-        val,
+        Box::new(a.clone()),
+        Box::new(b.clone()),
+        Box::new(val),
     )))
 }
 
@@ -579,9 +583,9 @@ fn introduce_modeq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::MinionModuloEqUndefZero(
         meta.clone_dirty(),
-        a.clone(),
-        b.clone(),
-        val,
+        Box::new(a.clone()),
+        Box::new(b.clone()),
+        Box::new(val),
     )))
 }
 
@@ -612,7 +616,11 @@ fn introduce_abseq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     let y: Atom = (*y).try_into().or(Err(RuleNotApplicable))?;
 
-    Ok(Reduction::pure(Expr::FlatAbsEq(Metadata::new(), x, y)))
+    Ok(Reduction::pure(Expr::FlatAbsEq(
+        Metadata::new(),
+        Box::new(x),
+        Box::new(y),
+    )))
 }
 
 /// Introduces a `MinionPowEq` constraint from a `SafePow`
@@ -637,9 +645,9 @@ fn introduce_poweq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::MinionPow(
         Metadata::new(),
-        a,
-        b,
-        total,
+        Box::new(a),
+        Box::new(b),
+        Box::new(total),
     )))
 }
 
@@ -695,7 +703,11 @@ fn introduce_minuseq_from_eq(expr: &Expr, _: &SymbolTable) -> ApplicationResult 
         return Err(RuleNotApplicable);
     };
 
-    Ok(Reduction::pure(Expr::FlatMinusEq(Metadata::new(), x, y)))
+    Ok(Reduction::pure(Expr::FlatMinusEq(
+        Metadata::new(),
+        Box::new(x),
+        Box::new(y),
+    )))
 }
 
 /// Introduces a Minion `MinusEq` constraint from `x =aux -y`, where x and y are atoms.
@@ -723,7 +735,11 @@ fn introduce_minuseq_from_aux_decl(expr: &Expr, _: &SymbolTable) -> ApplicationR
         return Err(RuleNotApplicable);
     };
 
-    Ok(Reduction::pure(Expr::FlatMinusEq(Metadata::new(), a, b)))
+    Ok(Reduction::pure(Expr::FlatMinusEq(
+        Metadata::new(),
+        Box::new(a),
+        Box::new(b),
+    )))
 }
 
 /// Converts an implication to either `ineq` or `reifyimply`
@@ -749,9 +765,9 @@ fn introduce_reifyimply_ineq_from_imply(expr: &Expr, _: &SymbolTable) -> Applica
     if let Ok(y_atom) = TryInto::<&Atom>::try_into(y.as_ref()) {
         Ok(Reduction::pure(Expr::FlatIneq(
             Metadata::new(),
-            x_atom.clone(),
-            y_atom.clone(),
-            0.into(),
+            Box::new(x_atom.clone()),
+            Box::new(y_atom.clone()),
+            Box::new(0.into()),
         )))
     } else {
         Ok(Reduction::pure(Expr::MinionReifyImply(
@@ -852,8 +868,8 @@ fn introduce_element_from_index(expr: &Expr, _: &SymbolTable) -> ApplicationResu
     Ok(Reduction::pure(Expr::MinionElementOne(
         Metadata::new(),
         atom_list,
-        index,
-        equalto,
+        Box::new(index),
+        Box::new(equalto),
     )))
 }
 
@@ -1054,9 +1070,9 @@ fn geq_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::FlatIneq(
         meta.clone_dirty(),
-        y,
-        x,
-        Lit::Int(0),
+        Box::new(y),
+        Box::new(x),
+        Box::new(Lit::Int(0)),
     )))
 }
 
@@ -1081,9 +1097,9 @@ fn leq_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::FlatIneq(
         meta.clone_dirty(),
-        x,
-        y,
-        Lit::Int(0),
+        Box::new(x),
+        Box::new(y),
+        Box::new(Lit::Int(0)),
     )))
 }
 
@@ -1117,9 +1133,9 @@ fn x_leq_y_plus_k_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::FlatIneq(
         meta.clone_dirty(),
-        x,
-        y.clone(),
-        k.clone(),
+        Box::new(x),
+        Box::new(y.clone()),
+        Box::new(k.clone()),
     )))
 }
 
@@ -1152,9 +1168,9 @@ fn y_plus_k_geq_x_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     Ok(Reduction::pure(Expr::FlatIneq(
         meta.clone_dirty(),
-        x,
-        y.clone(),
-        k.clone(),
+        Box::new(x),
+        Box::new(y.clone()),
+        Box::new(k.clone()),
     )))
 }
 

--- a/perf_benchmarks/run_all.sh
+++ b/perf_benchmarks/run_all.sh
@@ -43,7 +43,7 @@ done
 
 for model in $models_slow; do
 	echo "=======[ $model ]======="
-	hyperfine --warmup 1 --runs 3 \
+	hyperfine --warmup 1 --runs 5 \
 		--command-name main "$before_bin solve --no-run-solver $model" \
 		--command-name current "$after_bin solve --no-run-solver $model"
 	echo ""


### PR DESCRIPTION
Further reduce the size of `Expression` by boxing many of the larger
flat / Minion variants. This is a followup to 6012de809 (perf: reduce
size of AST types, 2025-06-18), for a more detailed explanation and
motivation for this change, see the message for that commit.

Making `Expression` under 128 bytes should make moving our types use
inline code code instead of `memcpy`, which is cheaper [1].

## Performance 

This further improves performance in some of the standard benchmarks:

Benchmark                                 | % speedup vs main
---------                                 | -----------------
models/fast/langford.eprime               | 14%
models/fast/nqueens_8.eprime              | 10%
models/fast/xkcd.eprime                   | 13%
models/slow/nqueens_20.eprime             | 3%
models/slow/pythagorean_triples_75.eprime | 6%



[1]: https://blog.mozilla.org/nnethercote/2019/10/11/how-to-speed-up-the-rust-compiler-some-more-in-2019/
