### PR TITLE
feat(ast): cleanup `Domain`, output bounded domains from domain methods

### DIFF
--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -20,6 +20,7 @@ mod variables;
 pub use atom::Atom;
 pub use declaration::*;
 pub use domains::Domain;
+pub use domains::DomainOpError;
 pub use domains::Range;
 pub use domains::SetAttr;
 pub use expressions::Expression;

--- a/crates/conjure_core/src/ast/types.rs
+++ b/crates/conjure_core/src/ast/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub enum ReturnType {
     Int,
     Bool,

--- a/crates/conjure_rules/src/constant_eval.rs
+++ b/crates/conjure_rules/src/constant_eval.rs
@@ -184,7 +184,7 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 return None;
             };
 
-            domain.contains(lit).map(Into::into)
+            domain.contains(lit).ok().map(Into::into)
         }
         Expr::Atomic(_, Atom::Literal(c)) => Some(c.clone()),
         Expr::Atomic(_, Atom::Reference(_c)) => None,
@@ -288,7 +288,8 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 .collect::<Option<Vec<Option<Lit>>>>()?;
 
             let indices_in_slice: Vec<Vec<Lit>> = missing_domain
-                .values()?
+                .values()
+                .ok()?
                 .into_iter()
                 .map(|i| {
                     let mut indices = indices.clone();

--- a/crates/conjure_rules/src/select_representation.rs
+++ b/crates/conjure_rules/src/select_representation.rs
@@ -176,7 +176,7 @@ fn domain_needs_representation(domain: &Domain) -> bool {
         Domain::Matrix(_, _) => false, // we special case these elsewhere
         Domain::Set(_, _) | Domain::Tuple(_) | Domain::Record(_) => true,
         Domain::Reference(_) => unreachable!("domain should be resolved"),
-        // _ => false,
+        Domain::Empty(_) => false, // _ => false,
     }
 }
 


### PR DESCRIPTION
* When operating on or creating Integer domains, create domains with bounded ranges instead of just single elements: e.g. write the domain containing `{1,2,4,5,6}` as `int(1..2,4..6)` instead of `int(1,2,4,5,6)`.

  This is done through the new `from_slice_i32` and `from_set_i32` methods, which are called from all the other domain operations when they need to create a domain. These replace the removed `make_int_domain_from_values_i32` method.

* Replace `Option<Domain>` with a more descriptive error result type, `Result<Domain,DomainOpError>`. `DomainOpError` encodes the reason that a domain operation failed; e.g. the input domain type was wrong, the input domain was unbounded. This commit also adds an error section to the documentation of each function, detailing the circumstances in which it can fail.

* Add `Domain::Empty` variant to represent an empty domain. We previously represented this using an `Option<Domain>`. As returning `None` from a domain method was also used when errors occurred, this was confusing. Also, an operation outputting an empty domain should be considered a success not a failure.

  Having an empty domain variant allows us to write rules such as: `a = b ~~> false if (domainOf(a) intersection domainOf(b) = empty)`.