### PR TITLE
Begin refactoring types to use `HasDomain` trait

### DIFF
--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use super::{
-    Expression, Literal, Name, ReturnType, Typeable, literals::AbstractLiteral,
+    Domain, Expression, Literal, Name, domains::HasDomain, literals::AbstractLiteral,
     records::RecordValue,
 };
 use serde::{Deserialize, Serialize};
@@ -37,12 +37,11 @@ impl Atom {
     }
 }
 
-impl Typeable for Atom {
-    fn return_type(&self) -> Option<ReturnType> {
+impl HasDomain for Atom {
+    fn domain_of(&self) -> super::Domain {
         match self {
-            Atom::Literal(lit) => lit.return_type(),
-            //TODO: access symbol table to get return type of references
-            Atom::Reference(_) => None,
+            Atom::Literal(literal) => literal.domain_of(),
+            Atom::Reference(name) => Domain::Reference(name.clone()),
         }
     }
 }

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -671,8 +671,20 @@ impl Typeable for Domain {
             Domain::Matrix(_, _) => {
                 todo!("fix ReturnType::Matrix type to support multi-dimensional matrices")
             }
-            Domain::Tuple(_) => todo!("add ReturnType for Domain::Tuple"),
-            Domain::Record(_) => todo!("add ReturnType for Domain::Record"),
+            Domain::Tuple(items) => {
+                let mut item_types = vec![];
+                for item in items {
+                    item_types.push(item.return_type()?);
+                }
+                Some(ReturnType::Tuple(item_types))
+            }
+            Domain::Record(items) => {
+                let mut item_types = vec![];
+                for item in items {
+                    item_types.push(item.domain.return_type()?);
+                }
+                Some(ReturnType::Record(item_types))
+            }
         }
     }
 }

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -668,8 +668,18 @@ impl Typeable for Domain {
             Domain::Empty(return_type) => Some(return_type.clone()),
             Domain::Set(_, domain) => Some(ReturnType::Set(Box::new(domain.return_type()?))),
             Domain::Reference(_) => None, // todo!("add ReturnType for Domain::Reference"),
-            Domain::Matrix(_, _) => {
-                todo!("fix ReturnType::Matrix type to support multi-dimensional matrices")
+            Domain::Matrix(item_domain, index_domains) => {
+                assert!(
+                    !index_domains.is_empty(),
+                    "a matrix should have atleast one dimension"
+                );
+                let mut return_type = ReturnType::Matrix(Box::new(item_domain.return_type()?));
+
+                for _ in 0..(index_domains.len() - 1) {
+                    return_type = ReturnType::Matrix(Box::new(return_type));
+                }
+
+                Some(return_type)
             }
             Domain::Tuple(items) => {
                 let mut item_types = vec![];

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -21,6 +21,7 @@ use uniplate::{Biplate, Uniplate as _};
 
 use super::ac_operators::ACOperatorKind;
 use super::comprehension::Comprehension;
+use super::domains::HasDomain as _;
 use super::records::RecordValue;
 use super::{Domain, Range, SubModel, Typeable};
 
@@ -606,12 +607,8 @@ impl Expression {
                 }
             }
             Expression::InDomain(_, _, _) => Some(Domain::Bool),
-            Expression::Atomic(_, Atom::Reference(name)) => Some(syms.resolve_domain(name)?),
-            Expression::Atomic(_, Atom::Literal(Literal::Int(n))) => {
-                Some(Domain::Int(vec![Range::Single(*n)]))
-            }
-            Expression::Atomic(_, Atom::Literal(Literal::Bool(_))) => Some(Domain::Bool),
-            Expression::Atomic(_, Atom::Literal(Literal::AbstractLiteral(_))) => None,
+            Expression::Atomic(_, Atom::Reference(name)) => syms.resolve_domain(name),
+            Expression::Atomic(_, atom) => Some(atom.domain_of().resolve(syms)),
             Expression::Scope(_, _) => Some(Domain::Bool),
             Expression::Sum(_, e) => {
                 bounded_i32_domain_for_matrix_literal_monotonic(e, |x, y| Some(x + y), syms)

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -40,8 +40,13 @@ use super::{Domain, Range, SubModel, Typeable};
 //
 // https://github.com/conjure-cp/conjure-oxide/commit/6012de8096ca491ded91ecec61352fdf4e994f2e
 
-// expect size of Expression to be 96 bytes
-static_assertions::assert_eq_size!([u8; 96], Expression);
+// TODO: box all usages of Metadata to bring this down a bit more - I have added variants to
+// ReturnType, and Metadata contains ReturnType, so Metadata has got bigger. Metadata will get a
+// lot bigger still when we start using it for memoisation, so it should really be
+// boxed ~niklasdewally
+
+// expect size of Expression to be 112 bytes
+static_assertions::assert_eq_size!([u8; 112], Expression);
 
 /// Represents different types of expressions used to define rules and constraints in the model.
 ///

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -58,7 +58,6 @@ impl Typeable for Literal {
     }
 }
 
-// TODO: handle tuples and records
 impl<T: AbstractLiteralValue + Typeable> Typeable for AbstractLiteral<T> {
     fn return_type(&self) -> Option<ReturnType> {
         match self {
@@ -77,7 +76,6 @@ impl<T: AbstractLiteralValue + Typeable> Typeable for AbstractLiteral<T> {
 
                 Some(ReturnType::Set(Box::new(item_type)))
             }
-
             AbstractLiteral::Matrix(items, _) if items.is_empty() => {
                 Some(ReturnType::Matrix(Box::new(ReturnType::Unknown)))
             }
@@ -93,7 +91,20 @@ impl<T: AbstractLiteralValue + Typeable> Typeable for AbstractLiteral<T> {
 
                 Some(ReturnType::Matrix(Box::new(item_type)))
             }
-            _ => None,
+            AbstractLiteral::Tuple(items) => {
+                let mut item_types = vec![];
+                for item in items {
+                    item_types.push(item.return_type()?);
+                }
+                Some(ReturnType::Tuple(item_types))
+            }
+            AbstractLiteral::Record(items) => {
+                let mut item_types = vec![];
+                for item in items {
+                    item_types.push(item.value.return_type()?);
+                }
+                Some(ReturnType::Record(item_types))
+            }
         }
     }
 }

--- a/crates/conjure_core/src/ast/types.rs
+++ b/crates/conjure_core/src/ast/types.rs
@@ -6,6 +6,15 @@ pub enum ReturnType {
     Bool,
     Matrix(Box<ReturnType>),
     Set(Box<ReturnType>),
+
+    /// An unknown type
+    ///
+    /// This can be found inside the types of empty abstract literals.
+    ///
+    /// To understand why, consider the typing of a set literal.  We construct the type of a set
+    /// literal by looking at the type of its items (e.g. {1,2,3} is type `set(int)`, as 1 is an
+    /// int). However, if it has no items, we can't do this, so we give it the type `set(unknown)`.
+    Unknown,
 }
 
 /// Something with a return type

--- a/crates/conjure_core/src/ast/types.rs
+++ b/crates/conjure_core/src/ast/types.rs
@@ -6,6 +6,8 @@ pub enum ReturnType {
     Bool,
     Matrix(Box<ReturnType>),
     Set(Box<ReturnType>),
+    Tuple(Vec<ReturnType>),
+    Record(Vec<ReturnType>),
 
     /// An unknown type
     ///


### PR DESCRIPTION
**Based on #906**

---

This PR is the start of work to make `domain_of()` return a `Domain`, not a `Option<Domain>` , as discussed in issue #876.  It introduces the `HasDomain` trait central to this effort. Then, it begins filling in some missing return types, which is needed before we start implementing `HasDomain` everywhere.


For more details, see the commit log.
