### PR TITLE
build/style: update rust to 1.88.0 and edition to 2024

### DIFF
--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_oxide"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 default-run = "conjure_oxide"
 
 # these are available inside build.rs

--- a/conjure_oxide/build.rs
+++ b/conjure_oxide/build.rs
@@ -1,5 +1,5 @@
 use std::env::var;
-use std::fs::{read_dir, File};
+use std::fs::{File, read_dir};
 use std::io::{self, Write};
 use std::path::Path;
 

--- a/conjure_oxide/examples/solver-hello-minion.rs
+++ b/conjure_oxide/examples/solver-hello-minion.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 #[allow(clippy::unwrap_used)]
 pub fn main() {
     use conjure_core::solver::SolverFamily;
-    use conjure_core::solver::{adaptors, Solver};
+    use conjure_core::solver::{Solver, adaptors};
     use conjure_core::{parse::get_example_model, rule_engine::resolve_rule_sets};
     use std::sync::{Arc, Mutex};
 
@@ -105,13 +105,13 @@ pub fn main() {
     let solver: Solver<Minion, ExecutionSuccess> = match result {
         Ok(s) => s,
         Err(e) => {
-            panic!("Error! {:?}", e);
+            panic!("Error! {e:?}");
         }
     };
 
     // Read our counter.
     let counter = (*counter_ptr).lock().unwrap();
-    println!("Num solutions: {}\n", counter);
+    println!("Num solutions: {counter}\n");
 
     // Read solutions, print 3
     let all_sols = (*all_solutions_ptr).lock().unwrap();
@@ -122,7 +122,7 @@ pub fn main() {
         }
         println!("Solution {}:", i + 1);
         for (k, v) in sols.iter().sorted_by_key(|x| x.0) {
-            println!("  {} = {}", k, v);
+            println!("  {k} = {v}");
         }
         println!()
     }
@@ -134,5 +134,5 @@ pub fn main() {
     //
     // TRY: what happens if we call solver.stats() when we haven't run the solver yet?
     let stats_json = serde_json::to_string_pretty(&solver.stats()).unwrap();
-    println!("Solver stats: \n{}", stats_json);
+    println!("Solver stats: \n{stats_json}");
 }

--- a/conjure_oxide/examples/tree-sitter-haskell-expr.rs
+++ b/conjure_oxide/examples/tree-sitter-haskell-expr.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                     // Parse expr_node to our Expr type
                     let expr = parse_expr(expr_node, source_code);
-                    println!("{} is parsed as {:?}", name_text, expr);
+                    println!("{name_text} is parsed as {expr:?}");
                 }
             }
         }

--- a/conjure_oxide/src/cli.rs
+++ b/conjure_oxide/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{arg, command, Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, arg, command};
 
 use clap_complete::Shell;
 use conjure_oxide::SolverFamily;

--- a/conjure_oxide/src/find_conjure.rs
+++ b/conjure_oxide/src/find_conjure.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use versions::Versioning;
 
 const CONJURE_MIN_VERSION: &str = "2.5.1";

--- a/conjure_oxide/src/lib.rs
+++ b/conjure_oxide/src/lib.rs
@@ -1,21 +1,21 @@
 // #![feature(doc_auto_cfg)]
 
+pub use conjure_core::Model;
 pub use conjure_core::ast;
 pub use conjure_core::error::Error;
 pub use conjure_core::metadata::Metadata;
 pub use conjure_core::parse::{get_example_model, get_example_model_by_path, model_from_json};
 pub use conjure_core::rule_engine;
 pub use conjure_core::rule_engine::{
-    get_all_rule_sets, get_rule_by_name, get_rule_set_by_name, get_rule_sets_for_solver_family,
-    get_rules, register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
-    Rule, RuleSet,
+    ApplicationError, ApplicationResult, Reduction, Rule, RuleSet, get_all_rule_sets,
+    get_rule_by_name, get_rule_set_by_name, get_rule_sets_for_solver_family, get_rules,
+    register_rule, register_rule_set,
 };
 pub use conjure_core::solver;
 pub use conjure_core::solver::SolverFamily;
-pub use conjure_core::Model;
 pub use conjure_essence_macros::essence_expr;
 pub use conjure_essence_parser::{
-    parse_essence_file, parse_essence_file_native, EssenceParseError,
+    EssenceParseError, parse_essence_file, parse_essence_file_native,
 };
 pub use conjure_rules;
 pub mod find_conjure;

--- a/conjure_oxide/src/main.rs
+++ b/conjure_oxide/src/main.rs
@@ -18,7 +18,7 @@ use git_version::git_version;
 use tracing_subscriber::filter::{FilterFn, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
-use tracing_subscriber::{fmt, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, fmt};
 
 pub fn main() {
     // exit with 2 instead of 1 on failure,like grep
@@ -27,7 +27,7 @@ pub fn main() {
             exit(0);
         }
         Err(e) => {
-            eprintln!("{:?}", e);
+            eprintln!("{e:?}");
             exit(2);
         }
     }
@@ -132,7 +132,7 @@ fn run_completion_command(completion_args: cli::CompletionArgs) -> anyhow::Resul
     let shell = completion_args.shell;
     let name = cmd.get_name().to_string();
 
-    eprintln!("Generating completion for {}...", shell);
+    eprintln!("Generating completion for {shell}...");
 
     generate(shell, &mut cmd, name, &mut io::stdout());
     Ok(())

--- a/conjure_oxide/src/solve.rs
+++ b/conjure_oxide/src/solve.rs
@@ -11,17 +11,17 @@ use std::{
 use anyhow::{anyhow, ensure};
 use clap::ValueHint;
 use conjure_core::{
+    Model,
     context::Context,
     rule_engine::{resolve_rule_sets, rewrite_naive},
-    solver::{adaptors, Solver},
-    Model,
+    solver::{Solver, adaptors},
 };
 use conjure_oxide::{
+    SolverFamily,
     defaults::DEFAULT_RULE_SETS,
     find_conjure::conjure_executable,
     get_rules, model_from_json, parse_essence_file_native,
     utils::conjure::{get_minion_solutions, get_sat_solutions, solutions_to_json},
-    SolverFamily,
 };
 use serde_json::to_string_pretty;
 
@@ -147,7 +147,7 @@ pub(crate) fn init_context(
     tracing::info!(
         target: "file",
         "Rules: {}",
-        rules.iter().map(|rd| format!("{}", rd)).collect::<Vec<_>>().join("\n")
+        rules.iter().map(|rd| format!("{rd}")).collect::<Vec<_>>().join("\n")
     );
     let context = Context::new_ptr(
         target_family,
@@ -247,7 +247,7 @@ fn run_minion(global_args: &GlobalArgs, cmd_args: &Args, model: Model) -> anyhow
     match out_file {
         None => {
             println!("Solutions:");
-            println!("{}", solutions_str);
+            println!("{solutions_str}");
         }
         Some(mut outf) => {
             outf.write_all(solutions_str.as_bytes())?;
@@ -284,7 +284,7 @@ fn run_sat_solver(global_args: &GlobalArgs, cmd_args: &Args, model: Model) -> an
     match out_file {
         None => {
             println!("Solutions:");
-            println!("{}", solutions_str);
+            println!("{solutions_str}");
         }
         Some(mut outf) => {
             outf.write_all(solutions_str.as_bytes())?;

--- a/conjure_oxide/src/test_solve.rs
+++ b/conjure_oxide/src/test_solve.rs
@@ -53,9 +53,9 @@ pub fn run_test_solve_command(global_args: GlobalArgs, local_args: Args) -> anyh
         exit(0);
     } else {
         eprintln!("=== our solutions:");
-        eprintln!("{}", our_solutions_json);
+        eprintln!("{our_solutions_json}");
         eprintln!("=== conjure's solutions:");
-        eprintln!("{}", conjure_solutions_json);
+        eprintln!("{conjure_solutions_json}");
         eprintln!("Failure: solutions do not match!");
         exit(1);
     }

--- a/conjure_oxide/src/utils/conjure.rs
+++ b/conjure_oxide/src/utils/conjure.rs
@@ -14,12 +14,12 @@ use serde_json::{Map, Value as JsonValue};
 use itertools::Itertools as _;
 use tempfile::tempdir;
 
-use crate::parse_essence_file;
-use crate::solver::adaptors::Minion;
-use crate::solver::Solver;
-use crate::utils::json::sort_json_object;
 use crate::EssenceParseError;
 use crate::Model;
+use crate::parse_essence_file;
+use crate::solver::Solver;
+use crate::solver::adaptors::Minion;
+use crate::utils::json::sort_json_object;
 
 use glob::glob;
 

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -6,7 +6,7 @@ use conjure_core::ast::records::RecordValue;
 use conjure_core::bug;
 use itertools::Itertools as _;
 use std::fs::File;
-use std::fs::{read_to_string, OpenOptions};
+use std::fs::{OpenOptions, read_to_string};
 use std::hash::Hash;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
@@ -14,17 +14,17 @@ use uniplate::Uniplate;
 
 use conjure_core::ast::{AbstractLiteral, Domain, SerdeModel};
 use conjure_core::context::Context;
-use serde_json::{json, Error as JsonError, Value as JsonValue};
+use serde_json::{Error as JsonError, Value as JsonValue, json};
 
 use conjure_core::error::Error;
 
+use crate::Model as ConjureModel;
+use crate::SolverFamily;
 use crate::ast::Name::User;
 use crate::ast::{Literal, Name};
 use crate::utils::conjure::solutions_to_json;
 use crate::utils::json::sort_json_object;
 use crate::utils::misc::to_set;
-use crate::Model as ConjureModel;
-use crate::SolverFamily;
 
 pub fn assert_eq_any_order<T: Eq + Hash + Debug + Clone>(a: &Vec<Vec<T>>, b: &Vec<Vec<T>>) {
     assert_eq!(a.len(), b.len());
@@ -41,7 +41,7 @@ pub fn assert_eq_any_order<T: Eq + Hash + Debug + Clone>(a: &Vec<Vec<T>>, b: &Ve
         b_rows.push(hash_row);
     }
 
-    println!("{:?},{:?}", a_rows, b_rows);
+    println!("{a_rows:?},{b_rows:?}");
     for row in a_rows {
         assert!(b_rows.contains(&row));
     }

--- a/conjure_oxide/tests/custom_tests.rs
+++ b/conjure_oxide/tests/custom_tests.rs
@@ -13,16 +13,14 @@ pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
     let test_path = PathBuf::from(test_dir);
     assert!(
         test_path.exists(),
-        "Test directory not found: {:?}",
-        test_path
+        "Test directory not found: {test_path:?}"
     );
 
     // Get paths
     let script_path = test_path.join("run.sh");
     assert!(
         script_path.exists(),
-        "Test script not found: {:?}",
-        script_path
+        "Test script not found: {script_path:?}"
     );
     let expected_output_path = test_path.join("stdout.expected");
     let expected_error_path = test_path.join("stderr.expected");
@@ -38,7 +36,7 @@ pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
     // Modify PATH so run.sh can find conjure_oxide
     let mut path_var = env::var("PATH").unwrap_or_else(|_| "".to_string());
     let conjure_dir = conjure_oxide_path.parent().unwrap().to_str().unwrap();
-    path_var = format!("{}:{}", conjure_dir, path_var);
+    path_var = format!("{conjure_dir}:{path_var}");
 
     // Execute the test script in the correct directory
     let output: Output = Command::new("sh")

--- a/conjure_oxide/tests/essence_macro_tests/mod.rs
+++ b/conjure_oxide/tests/essence_macro_tests/mod.rs
@@ -1,7 +1,7 @@
 use conjure_core::ast::{Atom, Expression};
 use conjure_core::matrix_expr;
 use conjure_essence_macros::essence_vec;
-use conjure_oxide::{essence_expr, Metadata};
+use conjure_oxide::{Metadata, essence_expr};
 
 #[test]
 fn test_2plus2() {

--- a/conjure_oxide/tests/parser_tests/mod.rs
+++ b/conjure_oxide/tests/parser_tests/mod.rs
@@ -3,7 +3,7 @@ use conjure_core::{
     context::Context,
     matrix_expr,
 };
-use conjure_oxide::{parse_essence_file_native, Metadata};
+use conjure_oxide::{Metadata, parse_essence_file_native};
 use pretty_assertions::assert_eq;
 use project_root::get_project_root;
 use std::sync::{Arc, RwLock};

--- a/conjure_oxide/tests/rewrite_tests.rs
+++ b/conjure_oxide/tests/rewrite_tests.rs
@@ -7,11 +7,11 @@ use conjure_core::rule_engine::rewrite_naive;
 use conjure_core::{into_matrix_expr, matrix_expr};
 use conjure_oxide::SolverFamily;
 use conjure_oxide::{
+    Metadata, Model, Rule,
     ast::*,
     get_rule_by_name,
     rule_engine::resolve_rule_sets,
-    solver::{adaptors, Solver},
-    Metadata, Model, Rule,
+    solver::{Solver, adaptors},
 };
 use conjure_rules::eval_constant;
 use uniplate::{Biplate, Uniplate};
@@ -135,10 +135,9 @@ fn simplify_expression(expr: Expression) -> Expression {
             } else {
                 Expression::Sum(
                     Metadata::new(),
-                    Box::new(into_matrix_expr![expressions
-                        .into_iter()
-                        .map(simplify_expression)
-                        .collect()]),
+                    Box::new(into_matrix_expr![
+                        expressions.into_iter().map(simplify_expression).collect()
+                    ]),
                 )
             }
         }
@@ -627,11 +626,11 @@ fn rewrite_solve_xyz() {
     let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
-            eprintln!("Error resolving rule sets: {}", e);
+            eprintln!("Error resolving rule sets: {e}");
             exit(1);
         }
     };
-    println!("Rule sets: {:?}", rule_sets);
+    println!("Rule sets: {rule_sets:?}");
 
     // Create variables and domains
     let variable_a = Atom::Reference(Name::User(String::from("a")));
@@ -669,7 +668,7 @@ fn rewrite_solve_xyz() {
     let rule_sets = match resolve_rule_sets(SolverFamily::Minion, &["Constant"]) {
         Ok(rs) => rs,
         Err(e) => {
-            eprintln!("Error resolving rule sets: {}", e);
+            eprintln!("Error resolving rule sets: {e}");
             exit(1);
         }
     };

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_core"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 
 [features]
 extra-rule-checks = []

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 
 use super::{
-    literals::AbstractLiteral, records::RecordValue, Expression, Literal, Name, ReturnType,
-    Typeable,
+    Expression, Literal, Name, ReturnType, Typeable, literals::AbstractLiteral,
+    records::RecordValue,
 };
 use serde::{Deserialize, Serialize};
 use uniplate::derive::Uniplate;

--- a/crates/conjure_core/src/ast/comprehension.rs
+++ b/crates/conjure_core/src/ast/comprehension.rs
@@ -8,7 +8,7 @@ use std::{
 
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
-use uniplate::{derive::Uniplate, Biplate};
+use uniplate::{Biplate, derive::Uniplate};
 
 use crate::{
     ast::{Atom, DeclarationKind},
@@ -126,7 +126,9 @@ impl Comprehension {
                 }
 
                 let Name::Machine(_) = &name else {
-                    bug!("the symbol table of the return expression of a comprehension should only contain machine names");
+                    bug!(
+                        "the symbol table of the return expression of a comprehension should only contain machine names"
+                    );
                 };
 
                 let new_machine_name = symtab.gensym();

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::ast::pretty::pretty_vec;
-use uniplate::{derive::Uniplate, Uniplate};
+use uniplate::{Uniplate, derive::Uniplate};
 
-use super::{records::RecordEntry, types::Typeable, AbstractLiteral, Literal, Name, ReturnType};
+use super::{AbstractLiteral, Literal, Name, ReturnType, records::RecordEntry, types::Typeable};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Range<A>
@@ -625,9 +625,9 @@ impl Display for Domain {
                     write!(f, "int({domain_ranges})")
                 }
             }
-            Domain::Reference(name) => write!(f, "{}", name),
+            Domain::Reference(name) => write!(f, "{name}"),
             Domain::Set(_, domain) => {
-                write!(f, "set of ({})", domain)
+                write!(f, "set of ({domain})")
             }
             Domain::Matrix(value_domain, index_domains) => {
                 write!(
@@ -672,7 +672,9 @@ impl Typeable for Domain {
 #[allow(clippy::enum_variant_names)] // all variant names start with Input at the moment, but that is ok.
 pub enum DomainOpError {
     /// The operation only supports bounded / finite domains, but was given an unbounded input domain.
-    #[error("The operation only supports bounded / finite domains, but was given an unbounded input domain.")]
+    #[error(
+        "The operation only supports bounded / finite domains, but was given an unbounded input domain."
+    )]
     InputUnbounded,
 
     /// The operation only supports integer input domains, but was given an input domain of a

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::ast::literals::AbstractLiteral;
-use crate::ast::literals::Literal;
-use crate::ast::pretty::{pretty_expressions_as_top_level, pretty_vec};
-use crate::ast::symbol_table::SymbolTable;
 use crate::ast::Atom;
 use crate::ast::Name;
 use crate::ast::ReturnType;
 use crate::ast::SetAttr;
+use crate::ast::literals::AbstractLiteral;
+use crate::ast::literals::Literal;
+use crate::ast::pretty::{pretty_expressions_as_top_level, pretty_vec};
+use crate::ast::symbol_table::SymbolTable;
 use crate::bug;
 use crate::metadata::Metadata;
 use enum_compatability_macro::document_compatibility;
@@ -976,7 +976,7 @@ impl Display for Expression {
                 write!(f, "({} union {})", box1.clone(), box2.clone())
             }
             Expression::In(_, e1, e2) => {
-                write!(f, "{} in {}", e1, e2)
+                write!(f, "{e1} in {e2}")
             }
             Expression::Intersect(_, box1, box2) => {
                 write!(f, "({} intersect {})", box1.clone(), box2.clone())
@@ -1003,7 +1003,7 @@ impl Display for Expression {
                 let args = es
                     .iter()
                     .map(|x| match x {
-                        Some(x) => format!("{}", x),
+                        Some(x) => format!("{x}"),
                         None => "..".into(),
                     })
                     .join(",");
@@ -1016,11 +1016,11 @@ impl Display for Expression {
             Expression::Root(_, exprs) => {
                 write!(f, "{}", pretty_expressions_as_top_level(exprs))
             }
-            Expression::DominanceRelation(_, expr) => write!(f, "DominanceRelation({})", expr),
-            Expression::FromSolution(_, expr) => write!(f, "FromSolution({})", expr),
+            Expression::DominanceRelation(_, expr) => write!(f, "DominanceRelation({expr})"),
+            Expression::FromSolution(_, expr) => write!(f, "FromSolution({expr})"),
             Expression::Atomic(_, atom) => atom.fmt(f),
             Expression::Scope(_, submodel) => write!(f, "{{\n{submodel}\n}}"),
-            Expression::Abs(_, a) => write!(f, "|{}|", a),
+            Expression::Abs(_, a) => write!(f, "|{a}|"),
             Expression::Sum(_, e) => {
                 write!(f, "sum({e})")
             }
@@ -1043,10 +1043,10 @@ impl Display for Expression {
                 write!(f, "and({e})")
             }
             Expression::Imply(_, box1, box2) => {
-                write!(f, "({}) -> ({})", box1, box2)
+                write!(f, "({box1}) -> ({box2})")
             }
             Expression::Iff(_, box1, box2) => {
-                write!(f, "({}) <-> ({})", box1, box2)
+                write!(f, "({box1}) <-> ({box2})")
             }
             Expression::Eq(_, box1, box2) => {
                 write!(f, "({} = {})", box1.clone(), box2.clone())
@@ -1116,7 +1116,7 @@ impl Display for Expression {
                 )
             }
             Expression::FlatWatchedLiteral(_, x, l) => {
-                write!(f, "WatchedLiteral({},{})", x, l)
+                write!(f, "WatchedLiteral({x},{l})")
             }
             Expression::MinionReify(_, box1, box2) => {
                 write!(f, "Reify({}, {})", box1.clone(), box2.clone())
@@ -1184,7 +1184,7 @@ impl Display for Expression {
                 )
             }
             Expression::MinionPow(_, atom, atom1, atom2) => {
-                write!(f, "MinionPow({},{},{})", atom, atom1, atom2)
+                write!(f, "MinionPow({atom},{atom1},{atom2})")
             }
             Expression::MinionElementOne(_, atoms, atom, atom1) => {
                 let atoms = atoms.iter().join(",");

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -7,7 +7,7 @@ use std::hash::Hasher;
 use uniplate::derive::Uniplate;
 use uniplate::{Biplate, Tree, Uniplate};
 
-use super::{records::RecordValue, Atom, Domain, Expression, Range};
+use super::{Atom, Domain, Expression, Range, records::RecordValue};
 use super::{ReturnType, Typeable};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Uniplate, Hash)]
@@ -392,9 +392,9 @@ impl AbstractLiteral<Expression> {
 impl Display for Literal {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
-            Literal::Int(i) => write!(f, "{}", i),
-            Literal::Bool(b) => write!(f, "{}", b),
-            Literal::AbstractLiteral(l) => write!(f, "{:?}", l),
+            Literal::Int(i) => write!(f, "{i}"),
+            Literal::Bool(b) => write!(f, "{b}"),
+            Literal::AbstractLiteral(l) => write!(f, "{l:?}"),
         }
     }
 }

--- a/crates/conjure_core/src/ast/matrix.rs
+++ b/crates/conjure_core/src/ast/matrix.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use itertools::{izip, Itertools};
+use itertools::{Itertools, izip};
 use uniplate::Uniplate as _;
 
 use crate::ast::{Domain, Range};

--- a/crates/conjure_core/src/ast/name.rs
+++ b/crates/conjure_core/src/ast/name.rs
@@ -36,8 +36,8 @@ uniplate::derive_unplateable!(Name);
 impl Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Name::User(s) => write!(f, "{}", s),
-            Name::Machine(i) => write!(f, "__{}", i),
+            Name::User(s) => write!(f, "{s}"),
+            Name::Machine(i) => write!(f, "__{i}"),
             Name::Represented(fields) => {
                 let (name, rule_string, suffix) = fields.as_ref();
                 write!(f, "{name}#{rule_string}_{suffix}")

--- a/crates/conjure_core/src/ast/pretty.rs
+++ b/crates/conjure_core/src/ast/pretty.rs
@@ -22,7 +22,7 @@ use super::{Expression, Name, SymbolTable};
 ///
 /// Each `Expression` is printed using its underlying `Display` implementation.
 pub fn pretty_expressions_as_top_level(expressions: &[Expression]) -> String {
-    expressions.iter().map(|x| format!("{}", x)).join(",\n")
+    expressions.iter().map(|x| format!("{x}")).join(",\n")
 }
 
 /// Pretty prints a `Vec<Expression>` as if it were a conjunction.
@@ -35,7 +35,7 @@ pub fn pretty_expressions_as_top_level(expressions: &[Expression]) -> String {
 ///
 /// Each `Expression` is printed using its underlying `Display` implementation.
 pub fn pretty_expressions_as_conjunction(expressions: &[Expression]) -> String {
-    let mut str = expressions.iter().map(|x| format!("{}", x)).join(" /\\ ");
+    let mut str = expressions.iter().map(|x| format!("{x}")).join(" /\\ ");
 
     str.insert(0, '(');
     str.push(')');
@@ -53,7 +53,7 @@ pub fn pretty_expressions_as_conjunction(expressions: &[Expression]) -> String {
 ///
 /// Each element is printed using its underlying `Display` implementation.
 pub fn pretty_vec<T: Display>(elems: &[T]) -> String {
-    let mut str = elems.iter().map(|x| format!("{}", x)).join(", ");
+    let mut str = elems.iter().map(|x| format!("{x}")).join(", ");
     str.insert(0, '[');
     str.push(']');
 

--- a/crates/conjure_core/src/ast/serde.rs
+++ b/crates/conjure_core/src/ast/serde.rs
@@ -6,9 +6,9 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use serde::Serialize;
 use serde::de::Deserialize;
 use serde::de::Error;
-use serde::Serialize;
 use serde_with::{DeserializeAs, SerializeAs};
 
 /// A unique id, used to distinguish between objects of the same type.

--- a/crates/conjure_core/src/ast/submodel.rs
+++ b/crates/conjure_core/src/ast/submodel.rs
@@ -1,4 +1,5 @@
 use super::{
+    Atom, Declaration, Literal,
     comprehension::Comprehension,
     declaration::DeclarationKind,
     pretty::{
@@ -6,7 +7,6 @@ use super::{
         pretty_value_letting_declaration, pretty_variable_declaration,
     },
     serde::RcRefCellAsInner,
-    Atom, Declaration, Literal,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -20,7 +20,7 @@ use std::{
     rc::Rc,
 };
 
-use super::{types::Typeable, Expression, ReturnType, SymbolTable};
+use super::{Expression, ReturnType, SymbolTable, types::Typeable};
 
 /// A sub-model, representing a lexical scope in the model.
 ///

--- a/crates/conjure_core/src/ast/symbol_table.rs
+++ b/crates/conjure_core/src/ast/symbol_table.rs
@@ -3,13 +3,13 @@
 //! See the item documentation for [`SymbolTable`] for more details.
 
 use crate::bug;
-use crate::representation::{get_repr_rule, Representation};
+use crate::representation::{Representation, get_repr_rule};
 
 use super::comprehension::Comprehension;
 use super::serde::{RcRefCellAsId, RcRefCellAsInner};
 use std::cell::RefCell;
-use std::collections::btree_map::Entry;
 use std::collections::BTreeSet;
+use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, VecDeque};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use super::declaration::Declaration;
 use super::serde::{DefaultWithId, HasId, ObjId};
 use super::types::Typeable;
-use itertools::{izip, Itertools as _};
+use itertools::{Itertools as _, izip};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use uniplate::Tree;

--- a/crates/conjure_core/src/ast/variables.rs
+++ b/crates/conjure_core/src/ast/variables.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ast::domains::Domain, representation::Representation};
 
-use super::{types::Typeable, ReturnType};
+use super::{ReturnType, types::Typeable};
 
 /// Represents a decision variable within a computational model.
 ///

--- a/crates/conjure_core/src/context.rs
+++ b/crates/conjure_core/src/context.rs
@@ -85,12 +85,11 @@ impl Debug for Context<'_> {
         write!(
             f,
             "Context {{\n\
-            \ttarget_solver_family: {:?}\n\
-            \textra_rule_set_names: {:?}\n\
-            \trules: {:?}\n\
-            \trule_sets: {:?}\n\
-        }}",
-            target_solver_family, extra_rule_set_names, rules, rule_sets
+            \ttarget_solver_family: {target_solver_family:?}\n\
+            \textra_rule_set_names: {extra_rule_set_names:?}\n\
+            \trules: {rules:?}\n\
+            \trule_sets: {rule_sets:?}\n\
+        }}"
         )
     }
 }

--- a/crates/conjure_core/src/parse/example_models.rs
+++ b/crates/conjure_core/src/parse/example_models.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use project_root::get_project_root;
 use walkdir::WalkDir;
 
-use crate::parse::model_from_json;
 use crate::Model;
+use crate::parse::model_from_json;
 
 /// Searches recursively in `../tests/integration` folder for an `.essence` file matching the given
 /// filename, then uses conjure to process it into astjson, and returns the parsed model.

--- a/crates/conjure_core/src/parse/parse_model.rs
+++ b/crates/conjure_core/src/parse/parse_model.rs
@@ -18,7 +18,7 @@ use crate::ast::{Declaration, DeclarationKind};
 use crate::context::Context;
 use crate::error::{Error, Result};
 use crate::metadata::Metadata;
-use crate::{bug, error, into_matrix_expr, throw_error, Model};
+use crate::{Model, bug, error, into_matrix_expr, throw_error};
 
 #[allow(unused_macros)]
 macro_rules! parser_trace {
@@ -372,10 +372,7 @@ fn parse_domain_value_int(obj: &JsonValue, symbols: &SymbolTable) -> Option<i32>
                 Some(x)
             }
             Err(_) => {
-                println!(
-                    "Could not convert integer constant to i32: {:#?}",
-                    leaf_node
-                );
+                println!("Could not convert integer constant to i32: {leaf_node:#?}");
                 None
             }
         }

--- a/crates/conjure_core/src/rule_engine/mod.rs
+++ b/crates/conjure_core/src/rule_engine/mod.rs
@@ -80,7 +80,7 @@ pub use conjure_rule_macros::register_rule;
 /// ```
 #[doc(inline)]
 pub use conjure_rule_macros::register_rule_set;
-pub use resolve_rules::{get_rules, get_rules_grouped, resolve_rule_sets, RuleData};
+pub use resolve_rules::{RuleData, get_rules, get_rules_grouped, resolve_rule_sets};
 pub use rewrite_naive::rewrite_naive;
 pub use rewriter_common::RewriteError;
 pub use rule::{ApplicationError, ApplicationResult, Reduction, Rule, RuleFn};
@@ -236,7 +236,7 @@ pub fn get_rule_set_by_name(name: &str) -> Option<&'static RuleSet<'static>> {
 /// register_rule_set!("CNF", (), SolverFamily::Sat);
 ///
 /// let rule_sets = get_rule_sets_for_solver_family(SolverFamily::Sat);
-/// assert_eq!(rule_sets.len(), 1);
+/// assert_eq!(rule_sets.len(), 2);
 /// assert_eq!(rule_sets[0].name, "CNF");
 /// ```
 pub fn get_rule_sets_for_solver_family(

--- a/crates/conjure_core/src/rule_engine/resolve_rules.rs
+++ b/crates/conjure_core/src/rule_engine/resolve_rules.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt::Display;
 use thiserror::Error;
 
-use crate::rule_engine::{get_rule_set_by_name, get_rule_sets_for_solver_family, Rule, RuleSet};
+use crate::rule_engine::{Rule, RuleSet, get_rule_set_by_name, get_rule_sets_for_solver_family};
 use crate::solver::SolverFamily;
 
 /// Holds a rule and its priority, along with the rule set it came from.

--- a/crates/conjure_core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure_core/src/rule_engine/rewrite_naive.rs
@@ -1,19 +1,19 @@
-use super::{resolve_rules::RuleData, RewriteError, RuleSet};
+use super::{RewriteError, RuleSet, resolve_rules::RuleData};
 use crate::{
+    Model,
     ast::{Expression as Expr, SubModel},
     bug,
     rule_engine::{
         get_rules_grouped,
-        rewriter_common::{log_rule_application, RuleResult},
+        rewriter_common::{RuleResult, log_rule_application},
         submodel_zipper::submodel_ctx,
     },
     stats::RewriterStats,
-    Model,
 };
 
 use itertools::Itertools;
 use std::{sync::Arc, time::Instant};
-use tracing::{span, trace, Level};
+use tracing::{Level, span, trace};
 use uniplate::Biplate;
 
 /// A naive, exhaustive rewriter for development purposes. Applies rules in priority order,
@@ -200,7 +200,7 @@ fn assert_no_multiple_equally_applicable_rules<CtxFnType>(
     let mut rules_by_priority_string = String::new();
     rules_by_priority_string.push_str("Rules grouped by priority:\n");
     for (priority, rules) in rules_grouped.iter() {
-        rules_by_priority_string.push_str(&format!("Priority {}:\n", priority));
+        rules_by_priority_string.push_str(&format!("Priority {priority}:\n"));
         for rd in rules {
             rules_by_priority_string.push_str(&format!(
                 "  - {} (from {})\n",

--- a/crates/conjure_core/src/rule_engine/rewriter_common.rs
+++ b/crates/conjure_core/src/rule_engine/rewriter_common.rs
@@ -1,11 +1,11 @@
 //! Common utilities and types for rewriters.
 use super::{
-    resolve_rules::{ResolveRulesError, RuleData},
     Reduction,
+    resolve_rules::{ResolveRulesError, RuleData},
 };
 use crate::ast::{
-    pretty::{pretty_variable_declaration, pretty_vec},
     Expression, SubModel,
+    pretty::{pretty_variable_declaration, pretty_vec},
 };
 
 use itertools::Itertools;
@@ -47,12 +47,12 @@ pub fn log_rule_application(
         let mut exprs: Vec<String> = vec![];
 
         for expr in &red.new_top {
-            exprs.push(format!("  {}", expr));
+            exprs.push(format!("  {expr}"));
         }
 
         let exprs = exprs.iter().join("\n");
 
-        format!("new constraints:\n{}\n", exprs)
+        format!("new constraints:\n{exprs}\n")
     };
 
     // empty if no new variables

--- a/crates/conjure_core/src/rule_engine/rule_set.rs
+++ b/crates/conjure_core/src/rule_engine/rule_set.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 
 use log::warn;
 
-use crate::rule_engine::{get_all_rules, get_rule_set_by_name, Rule};
+use crate::rule_engine::{Rule, get_all_rules, get_rule_set_by_name};
 use crate::solver::SolverFamily;
 
 /// A structure representing a set of rules with a name, priority, and dependencies.

--- a/crates/conjure_core/src/solver/adaptors/minion/adaptor.rs
+++ b/crates/conjure_core/src/solver/adaptors/minion/adaptor.rs
@@ -7,15 +7,13 @@ use minion_rs::ast as minion_ast;
 use minion_rs::error::MinionError;
 use minion_rs::{get_from_table, run_minion};
 
+use crate::Model as ConjureModel;
 use crate::ast::{self as conjure_ast, Name};
 use crate::solver::SolverCallback;
 use crate::solver::SolverFamily;
 use crate::solver::SolverMutCallback;
 use crate::stats::SolverStats;
-use crate::Model as ConjureModel;
 
-use crate::solver::model_modifier::NotModifiable;
-use crate::solver::private;
 use crate::solver::SearchComplete::{HasSolutions, NoSolutions};
 use crate::solver::SearchIncomplete::UserTerminated;
 use crate::solver::SearchStatus::{Complete, Incomplete};
@@ -23,6 +21,8 @@ use crate::solver::SolveSuccess;
 use crate::solver::SolverAdaptor;
 use crate::solver::SolverError;
 use crate::solver::SolverError::{OpNotImplemented, Runtime, RuntimeNotImplemented};
+use crate::solver::model_modifier::NotModifiable;
+use crate::solver::private;
 
 use super::parse_model::model_to_minion;
 
@@ -122,17 +122,17 @@ impl SolverAdaptor for Minion {
             .unwrap();
         *user_callback = callback;
         drop(user_callback); // release mutex. REQUIRED so that run_minion can use the
-                             // user callback and not deadlock.
+        // user callback and not deadlock.
 
         run_minion(
             self.model.clone().expect("STATE MACHINE ERR"),
             minion_rs_callback,
         )
         .map_err(|err| match err {
-            MinionError::RuntimeError(x) => Runtime(format!("{:#?}", x)),
-            MinionError::Other(x) => Runtime(format!("{:#?}", x)),
+            MinionError::RuntimeError(x) => Runtime(format!("{x:#?}")),
+            MinionError::Other(x) => Runtime(format!("{x:#?}")),
             MinionError::NotImplemented(x) => RuntimeNotImplemented(x),
-            x => Runtime(format!("unknown minion_rs error: {:#?}", x)),
+            x => Runtime(format!("unknown minion_rs error: {x:#?}")),
         })?;
 
         let mut status = Complete(HasSolutions);

--- a/crates/conjure_core/src/solver/adaptors/rustsat/adaptor.rs
+++ b/crates/conjure_core/src/solver/adaptors/rustsat/adaptor.rs
@@ -21,14 +21,14 @@ use rustsat_minisat::core::Minisat;
 
 use crate::ast::{Atom, Expression, Literal, Name};
 use crate::metadata::Metadata;
-use crate::solver::adaptors::rustsat::convs::handle_cnf;
 use crate::solver::SearchComplete::NoSolutions;
+use crate::solver::adaptors::rustsat::convs::handle_cnf;
 use crate::solver::{
-    self, private, SearchStatus, SolveSuccess, SolverAdaptor, SolverCallback, SolverError,
-    SolverFamily, SolverMutCallback,
+    self, SearchStatus, SolveSuccess, SolverAdaptor, SolverCallback, SolverError, SolverFamily,
+    SolverMutCallback, private,
 };
 use crate::stats::SolverStats;
-use crate::{ast as conjure_ast, bug, Model as ConjureModel};
+use crate::{Model as ConjureModel, ast as conjure_ast, bug};
 use crate::{into_matrix_expr, matrix_expr};
 
 use rustsat::instances::{BasicVarManager, Cnf, ManageVars, SatInstance};
@@ -124,7 +124,7 @@ impl SolverAdaptor for Sat {
                     });
                 }
                 SolverResult::Interrupted => {
-                    return Err(SolverError::Runtime("!!Interrupted Solution!!".to_string()))
+                    return Err(SolverError::Runtime("!!Interrupted Solution!!".to_string()));
                 }
             };
 

--- a/crates/conjure_core/src/solver/adaptors/rustsat/convs.rs
+++ b/crates/conjure_core/src/solver/adaptors/rustsat/convs.rs
@@ -9,7 +9,7 @@ use rustsat::{
 
 use rustsat_minisat::core::Minisat;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::{ast::Expression, solver::Error};
 
@@ -62,11 +62,7 @@ pub fn handle_atom(
                     // TODO: Temp Clone
                     // let m = n.clone();
                     let lit_temp: Lit = fetch_lit(n, vars_added, inst);
-                    if polarity {
-                        lit_temp
-                    } else {
-                        !lit_temp
-                    }
+                    if polarity { lit_temp } else { !lit_temp }
                 }
                 _ => {
                     todo!("Change Here for other types of vars")

--- a/crates/conjure_core/src/solver/mod.rs
+++ b/crates/conjure_core/src/solver/mod.rs
@@ -116,10 +116,10 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString};
 use thiserror::Error;
 
+use crate::Model;
 use crate::ast::{Literal, Name};
 use crate::context::Context;
 use crate::stats::SolverStats;
-use crate::Model;
 
 use self::model_modifier::ModelModifier;
 use self::states::{ExecutionSuccess, Init, ModelLoaded, SolverState};

--- a/crates/conjure_core/src/solver/model_modifier.rs
+++ b/crates/conjure_core/src/solver/model_modifier.rs
@@ -7,8 +7,8 @@
 
 use crate::ast::{Domain, Expression, Name};
 
-use super::private;
 use super::Solver;
+use super::private;
 
 /// A ModelModifier provides an interface to modify a model during solving.
 ///

--- a/crates/conjure_core/src/solver/states.rs
+++ b/crates/conjure_core/src/solver/states.rs
@@ -3,11 +3,11 @@ use std::fmt::Display;
 
 use crate::stats::SolverStats;
 
-use super::private::Internal;
-use super::private::Sealed;
 use super::SearchStatus;
 use super::Solver;
 use super::SolverError;
+use super::private::Internal;
+use super::private::Sealed;
 
 pub trait SolverState: Sealed {}
 

--- a/crates/conjure_essence_macros/Cargo.toml
+++ b/crates/conjure_essence_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_essence_macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/conjure_essence_macros/src/expand.rs
+++ b/crates/conjure_essence_macros/src/expand.rs
@@ -1,7 +1,7 @@
 use super::expression::parse_expr_to_ts;
 use conjure_essence_parser::util::{get_tree, query_toplevel};
 use proc_macro2::{TokenStream, TokenTree};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::{Error, LitStr, Result};
 use tree_sitter::Node;
 
@@ -20,7 +20,12 @@ pub fn expand_expr(essence: &TokenTree) -> Result<TokenStream> {
     // We only expect one expression, error if that's not the case
     if let Some(expr) = query.next() {
         let tokens = &source_code[expr.start_byte()..expr.end_byte()];
-        return Err(Error::new(essence.span(), format!("Unexpected tokens: `{}`. Expected a single Essence expression. Perhaps you meant `essence_vec!`?", tokens)));
+        return Err(Error::new(
+            essence.span(),
+            format!(
+                "Unexpected tokens: `{tokens}`. Expected a single Essence expression. Perhaps you meant `essence_vec!`?"
+            ),
+        ));
     }
 
     // Parse expression and build the token stream
@@ -48,7 +53,7 @@ fn mk_expr(node: Node, src: &str, root: &Node, tt: &TokenTree) -> Result<TokenSt
     match parse_expr_to_ts(node, src, root) {
         Ok(expr) => Ok(expr),
         Err(err) => {
-            let msg = format!("Error parsing Essence expression: {}", err);
+            let msg = format!("Error parsing Essence expression: {err}");
             Err(Error::new(tt.span(), msg))
         }
     }

--- a/crates/conjure_essence_macros/src/expression.rs
+++ b/crates/conjure_essence_macros/src/expression.rs
@@ -132,7 +132,7 @@ pub fn parse_expr_to_ts(
                     Box::new(#expr1),
                     Box::new(#expr2),
                 )}),
-                _ => Err(format!("Unsupported operator '{}'", op_type).into()),
+                _ => Err(format!("Unsupported operator '{op_type}'").into()),
             }
         }
         "quantifier_expr" => {

--- a/crates/conjure_essence_parser/Cargo.toml
+++ b/crates/conjure_essence_parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_essence_parser"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 conjure_core = { path = "../conjure_core" }

--- a/crates/conjure_essence_parser/src/parser/expression.rs
+++ b/crates/conjure_essence_parser/src/parser/expression.rs
@@ -123,7 +123,7 @@ pub fn parse_expression(
                     Box::new(expr1),
                     Box::new(expr2),
                 )),
-                _ => Err(format!("Unsupported operator '{}'", op_type).into()),
+                _ => Err(format!("Unsupported operator '{op_type}'").into()),
             }
         }
         "quantifier_expr" => {

--- a/crates/conjure_essence_parser/src/parser/parse_model.rs
+++ b/crates/conjure_essence_parser/src/parser/parse_model.rs
@@ -2,12 +2,12 @@ use std::fs;
 use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 
+use conjure_core::Model;
 use conjure_core::ast::Declaration;
 use conjure_core::ast::Expression;
 use conjure_core::context::Context;
 use conjure_core::error::Error;
 use conjure_core::metadata::Metadata;
-use conjure_core::Model;
 #[allow(unused)]
 use uniplate::Uniplate;
 
@@ -24,7 +24,7 @@ pub fn parse_essence_file_native(
     context: Arc<RwLock<Context<'static>>>,
 ) -> Result<Model, EssenceParseError> {
     let source_code = fs::read_to_string(path)
-        .unwrap_or_else(|_| panic!("Failed to read the source code file {}", path));
+        .unwrap_or_else(|_| panic!("Failed to read the source code file {path}"));
     parse_essence_with_context(&source_code, context)
 }
 
@@ -37,7 +37,7 @@ pub fn parse_essence_with_context(
         None => {
             return Err(EssenceParseError::TreeSitterError(
                 "Failed to parse source code".to_string(),
-            ))
+            ));
         }
     };
 

--- a/crates/conjure_essence_parser/src/parser/util.rs
+++ b/crates/conjure_essence_parser/src/parser/util.rs
@@ -31,7 +31,7 @@ pub fn get_tree(src: &str) -> Option<(Tree, String)> {
             if src.starts_with("such that") {
                 None
             } else {
-                get_tree(&format!("such that {}", src))
+                get_tree(&format!("such that {src}"))
             }
         } else {
             Some((tree, src.to_string()))

--- a/crates/conjure_essence_parser/src/parser_legacy.rs
+++ b/crates/conjure_essence_parser/src/parser_legacy.rs
@@ -1,6 +1,6 @@
 use crate::errors::EssenceParseError;
 use conjure_core::parse::model_from_json;
-use conjure_core::{context::Context, Model};
+use conjure_core::{Model, context::Context};
 use std::sync::{Arc, RwLock};
 
 pub fn parse_essence_file(
@@ -28,9 +28,8 @@ pub fn parse_essence_file(
         Ok(astjson) => astjson,
         Err(e) => {
             return Err(EssenceParseError::ConjurePrettyError(format!(
-                "Error parsing output from conjure: {:#?}",
-                e
-            )))
+                "Error parsing output from conjure: {e:#?}"
+            )));
         }
     };
 

--- a/crates/conjure_rule_macros/Cargo.toml
+++ b/crates/conjure_rule_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_rule_macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/conjure_rule_macros/src/lib.rs
+++ b/crates/conjure_rule_macros/src/lib.rs
@@ -5,8 +5,8 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{
-    parenthesized, parse::Parse, parse::ParseStream, parse_macro_input, Ident, ItemFn, LitInt,
-    LitStr, Path, Result,
+    Ident, ItemFn, LitInt, LitStr, Path, Result, parenthesized, parse::Parse, parse::ParseStream,
+    parse_macro_input,
 };
 
 #[derive(Debug)]
@@ -47,7 +47,7 @@ impl Parse for RegisterRuleArgs {
 pub fn register_rule(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);
     let rule_ident = &func.sig.ident;
-    let static_name = format!("CONJURE_GEN_RULE_{}", rule_ident).to_uppercase();
+    let static_name = format!("CONJURE_GEN_RULE_{rule_ident}").to_uppercase();
     let static_ident = Ident::new(&static_name, rule_ident.span());
 
     let args = parse_macro_input!(arg_tokens as RegisterRuleArgs);

--- a/crates/conjure_rules/Cargo.toml
+++ b/crates/conjure_rules/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conjure_rules"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 extra-rule-checks = []

--- a/crates/conjure_rules/src/base.rs
+++ b/crates/conjure_rules/src/base.rs
@@ -5,7 +5,7 @@ use conjure_core::{
     into_matrix_expr,
     metadata::Metadata,
     rule_engine::{
-        register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
+        ApplicationError, ApplicationResult, Reduction, register_rule, register_rule_set,
     },
 };
 use conjure_essence_macros::essence_expr;

--- a/crates/conjure_rules/src/bubble.rs
+++ b/crates/conjure_rules/src/bubble.rs
@@ -3,9 +3,8 @@ use conjure_core::{
     into_matrix_expr, matrix_expr,
     metadata::Metadata,
     rule_engine::{
-        register_rule, register_rule_set,
         ApplicationError::{self, RuleNotApplicable},
-        ApplicationResult, Reduction,
+        ApplicationResult, Reduction, register_rule, register_rule_set,
     },
 };
 use uniplate::{Biplate, Uniplate};

--- a/crates/conjure_rules/src/cnf.rs
+++ b/crates/conjure_rules/src/cnf.rs
@@ -8,7 +8,7 @@ use conjure_core::solver::SolverFamily;
 use conjure_core::ast::Expression as Expr;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 
 use conjure_core::ast::SymbolTable;

--- a/crates/conjure_rules/src/constant_eval.rs
+++ b/crates/conjure_rules/src/constant_eval.rs
@@ -1,17 +1,17 @@
 #![allow(dead_code)]
 use conjure_core::ast::{
-    matrix, AbstractLiteral, Atom, Expression as Expr, Literal as Lit, SymbolTable,
+    AbstractLiteral, Atom, Expression as Expr, Literal as Lit, SymbolTable, matrix,
 };
 use conjure_core::into_matrix;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, register_rule_set, ApplicationError::RuleNotApplicable, ApplicationResult,
-    Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
+    register_rule_set,
 };
-use itertools::{izip, Itertools as _};
+use itertools::{Itertools as _, izip};
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use uniplate::Biplate;
 
 use super::partial_eval::run_partial_evaluator;
@@ -76,12 +76,11 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 let a_set: HashSet<Lit> = a.iter().cloned().collect();
                 let b_set: HashSet<Lit> = b.iter().cloned().collect();
 
-                let result = if a_set.difference(&b_set).count() > 0 {
+                if a_set.difference(&b_set).count() > 0 {
                     Some(Lit::Bool(a_set.is_superset(&b_set)))
                 } else {
                     Some(Lit::Bool(false))
-                };
-                result
+                }
             }
             _ => None,
         },
@@ -105,12 +104,11 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
                 let a_set: HashSet<Lit> = a.iter().cloned().collect();
                 let b_set: HashSet<Lit> = b.iter().cloned().collect();
 
-                let result = if b_set.difference(&a_set).count() > 0 {
+                if b_set.difference(&a_set).count() > 0 {
                     Some(Lit::Bool(a_set.is_subset(&b_set)))
                 } else {
                     Some(Lit::Bool(false))
-                };
-                result
+                }
             }
             _ => None,
         },

--- a/crates/conjure_rules/src/expand_comprehension.rs
+++ b/crates/conjure_rules/src/expand_comprehension.rs
@@ -3,7 +3,7 @@ use conjure_core::{
     into_matrix_expr,
     metadata::Metadata,
     rule_engine::{
-        register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+        ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
     },
 };
 

--- a/crates/conjure_rules/src/matrix/bubble.rs
+++ b/crates/conjure_rules/src/matrix/bubble.rs
@@ -1,11 +1,11 @@
 use conjure_core::ast::{Domain, Expression, SymbolTable};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult,
-    Reduction,
+    ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    register_rule,
 };
 use conjure_core::{bug, into_matrix_expr};
-use itertools::{izip, Itertools as _};
+use itertools::{Itertools as _, izip};
 
 /// Converts an unsafe index to a safe index using a bubble expression.
 #[register_rule(("Bubble", 6000))]
@@ -25,16 +25,26 @@ fn index_to_bubble(expr: &Expression, symbols: &SymbolTable) -> ApplicationResul
     }
 
     let Domain::Matrix(_, index_domains) = domain else {
-        bug!("subject of an index expression should have a matrix domain. subject: {:?}, with domain: {:?}", subject, domain);
+        bug!(
+            "subject of an index expression should have a matrix domain. subject: {:?}, with domain: {:?}",
+            subject,
+            domain
+        );
     };
 
-    assert_eq!(index_domains.len(),indices.len(),"in an index expression, there should be the same number of indices as the subject has index domains");
+    assert_eq!(
+        index_domains.len(),
+        indices.len(),
+        "in an index expression, there should be the same number of indices as the subject has index domains"
+    );
 
-    let bubble_constraints = Box::new(into_matrix_expr![izip!(index_domains, indices)
-        .map(|(domain, index)| {
-            Expression::InDomain(Metadata::new(), Box::new(index.clone()), domain)
-        })
-        .collect_vec()]);
+    let bubble_constraints = Box::new(into_matrix_expr![
+        izip!(index_domains, indices)
+            .map(|(domain, index)| {
+                Expression::InDomain(Metadata::new(), Box::new(index.clone()), domain)
+            })
+            .collect_vec()
+    ]);
 
     let new_expr = Box::new(Expression::SafeIndex(
         Metadata::new(),
@@ -61,19 +71,29 @@ fn slice_to_bubble(expr: &Expression, symbols: &SymbolTable) -> ApplicationResul
         .ok_or(ApplicationError::DomainError)?;
 
     let Domain::Matrix(_, index_domains) = domain else {
-        bug!("subject of a slice expression should have a matrix domain. subject: {:?}, with domain: {:?}", subject, domain);
+        bug!(
+            "subject of a slice expression should have a matrix domain. subject: {:?}, with domain: {:?}",
+            subject,
+            domain
+        );
     };
 
-    assert_eq!(index_domains.len(),indices.len(),"in a slice expression, there should be the same number of indices as the subject has index domains");
+    assert_eq!(
+        index_domains.len(),
+        indices.len(),
+        "in a slice expression, there should be the same number of indices as the subject has index domains"
+    );
 
     // the wildcard dimension doesn't need a constraint.
-    let bubble_constraints = Box::new(into_matrix_expr![izip!(index_domains, indices)
-        .filter_map(|(domain, index)| {
-            index
-                .clone()
-                .map(|index| Expression::InDomain(Metadata::new(), Box::new(index.clone()), domain))
-        })
-        .collect_vec()]);
+    let bubble_constraints = Box::new(into_matrix_expr![
+        izip!(index_domains, indices)
+            .filter_map(|(domain, index)| {
+                index.clone().map(|index| {
+                    Expression::InDomain(Metadata::new(), Box::new(index.clone()), domain)
+                })
+            })
+            .collect_vec()
+    ]);
 
     let new_expr = Box::new(Expression::SafeSlice(
         Metadata::new(),

--- a/crates/conjure_rules/src/matrix/matrix_to_list.rs
+++ b/crates/conjure_rules/src/matrix/matrix_to_list.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use conjure_core::ast::{Domain, Expression as Expr, Range, SymbolTable};
 use conjure_core::into_matrix_expr;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 use uniplate::Uniplate;
 

--- a/crates/conjure_rules/src/matrix/repr_matrix.rs
+++ b/crates/conjure_rules/src/matrix/repr_matrix.rs
@@ -1,13 +1,13 @@
 use conjure_core::ast::{
-    matrix, Atom, Domain, Expression as Expr, Literal, Name, Range, SymbolTable,
+    Atom, Domain, Expression as Expr, Literal, Name, Range, SymbolTable, matrix,
 };
 use conjure_core::into_matrix_expr;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 use conjure_essence_macros::essence_expr;
-use itertools::{chain, izip, Itertools};
+use itertools::{Itertools, chain, izip};
 use uniplate::Uniplate;
 
 use crate::bottom_up_adaptor::as_bottom_up;

--- a/crates/conjure_rules/src/minion.rs
+++ b/crates/conjure_rules/src/minion.rs
@@ -18,7 +18,7 @@ use conjure_core::{
     into_matrix_expr, matrix_expr,
     metadata::Metadata,
     rule_engine::{
-        register_rule, register_rule_set, ApplicationError, ApplicationResult, Reduction,
+        ApplicationError, ApplicationResult, Reduction, register_rule, register_rule_set,
     },
     solver::SolverFamily,
 };
@@ -417,7 +417,11 @@ fn flatten_weighted_sum_term(
                 // assume the coefficients have been placed at the front by normalisation rules
 
                 // product[1,x,y,...] ~> return (coeff,product([x,y,...]))
-                [Expr::Atomic(_, Atom::Literal(Lit::Int(coeff))), e, rest @ ..] => {
+                [
+                    Expr::Atomic(_, Atom::Literal(Lit::Int(coeff))),
+                    e,
+                    rest @ ..,
+                ] => {
                     let mut product_terms = Vec::from(rest);
                     product_terms.push(e.clone());
                     let product =

--- a/crates/conjure_rules/src/normalisers/associative_commutative.rs
+++ b/crates/conjure_rules/src/normalisers/associative_commutative.rs
@@ -5,7 +5,7 @@ use std::mem::Discriminant;
 
 use conjure_core::ast::{Expression as Expr, SymbolTable};
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 use uniplate::Biplate;
 

--- a/crates/conjure_rules/src/normalisers/bool.rs
+++ b/crates/conjure_rules/src/normalisers/bool.rs
@@ -3,8 +3,8 @@
 use conjure_core::ast::{Atom, Expression as Expr, SymbolTable};
 use conjure_core::into_matrix_expr;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult,
-    Reduction,
+    ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    register_rule,
 };
 use conjure_essence_macros::essence_expr;
 use uniplate::Uniplate;

--- a/crates/conjure_rules/src/normalisers/eq_neq.rs
+++ b/crates/conjure_rules/src/normalisers/eq_neq.rs
@@ -2,7 +2,7 @@
 
 use conjure_core::ast::{Expression as Expr, SymbolTable, Typeable};
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 
 use conjure_core::ast::ReturnType::Set;

--- a/crates/conjure_rules/src/normalisers/neg_minus.rs
+++ b/crates/conjure_rules/src/normalisers/neg_minus.rs
@@ -31,7 +31,7 @@ use conjure_core::{
     into_matrix_expr,
     metadata::Metadata,
     rule_engine::{
-        register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+        ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
     },
 };
 use conjure_essence_macros::essence_expr;

--- a/crates/conjure_rules/src/normalisers/sum.rs
+++ b/crates/conjure_rules/src/normalisers/sum.rs
@@ -1,10 +1,10 @@
 //! Normalising rules for `Sum`
 
+use ApplicationError::RuleNotApplicable;
 use conjure_core::{
     ast::{Expression as Expr, SymbolTable},
-    rule_engine::{register_rule, ApplicationError, ApplicationResult, Reduction},
+    rule_engine::{ApplicationError, ApplicationResult, Reduction, register_rule},
 };
-use ApplicationError::RuleNotApplicable;
 
 /// Removes sums with a single argument.
 ///

--- a/crates/conjure_rules/src/normalisers/weighted_sums.rs
+++ b/crates/conjure_rules/src/normalisers/weighted_sums.rs
@@ -54,8 +54,10 @@ fn collect_like_terms(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
                     }
 
                     // c*v
-                    [Expr::Atomic(_, Atom::Reference(name)), Expr::Atomic(_, Atom::Literal(Lit::Int(l)))] =>
-                    {
+                    [
+                        Expr::Atomic(_, Atom::Reference(name)),
+                        Expr::Atomic(_, Atom::Literal(Lit::Int(l))),
+                    ] => {
                         weighted_terms
                             .insert(name.clone(), weighted_terms.get(name).unwrap_or(&0) + l);
                     }

--- a/crates/conjure_rules/src/records.rs
+++ b/crates/conjure_rules/src/records.rs
@@ -4,7 +4,7 @@ use conjure_core::ast::SymbolTable;
 use conjure_core::into_matrix_expr;
 use conjure_core::matrix_expr;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 
 use conjure_core::ast::Atom;

--- a/crates/conjure_rules/src/representation/matrix_to_atom.rs
+++ b/crates/conjure_rules/src/representation/matrix_to_atom.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use itertools::{izip, Itertools};
+use itertools::{Itertools, izip};
 
 use super::prelude::*;
 
@@ -146,16 +146,18 @@ impl Representation for MatrixToAtom {
             n_dims: usize,
         ) -> Literal {
             if current_dim < n_dims {
-                Literal::AbstractLiteral(into_matrix![self1.index_domains[current_dim]
-                    .values()
-                    .unwrap()
-                    .into_iter()
-                    .map(|i| {
-                        let mut current_index_1 = current_index.clone();
-                        current_index_1.push(i);
-                        inner(current_index_1, current_dim + 1, self1, values, n_dims)
-                    })
-                    .collect_vec()])
+                Literal::AbstractLiteral(into_matrix![
+                    self1.index_domains[current_dim]
+                        .values()
+                        .unwrap()
+                        .into_iter()
+                        .map(|i| {
+                            let mut current_index_1 = current_index.clone();
+                            current_index_1.push(i);
+                            inner(current_index_1, current_dim + 1, self1, values, n_dims)
+                        })
+                        .collect_vec()
+                ])
             } else {
                 values
                     .get(&self1.indices_to_name(&current_index))

--- a/crates/conjure_rules/src/representation/mod.rs
+++ b/crates/conjure_rules/src/representation/mod.rs
@@ -5,13 +5,13 @@ mod prelude {
     #![allow(unused_imports)]
     pub use conjure_core::{
         ast::{
-            matrix, AbstractLiteral, Atom, Declaration, Domain, Expression, Literal, Name,
-            RecordEntry, SymbolTable,
+            AbstractLiteral, Atom, Declaration, Domain, Expression, Literal, Name, RecordEntry,
+            SymbolTable, matrix,
         },
         bug, into_matrix,
         metadata::Metadata,
         register_representation,
-        representation::{get_repr_rule, Representation},
+        representation::{Representation, get_repr_rule},
         rule_engine::{ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult},
     };
 }

--- a/crates/conjure_rules/src/select_representation.rs
+++ b/crates/conjure_rules/src/select_representation.rs
@@ -1,16 +1,16 @@
 use conjure_core::{
-    ast::{serde::HasId, Atom, Domain, Expression as Expr, Name, SubModel, SymbolTable},
+    ast::{Atom, Domain, Expression as Expr, Name, SubModel, SymbolTable, serde::HasId},
     bug,
     metadata::Metadata,
     representation::Representation,
     rule_engine::{
-        register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+        ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
     },
 };
 use itertools::Itertools;
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use uniplate::Biplate;
 // special case rule to select representations for matrices in one go.
 //

--- a/crates/conjure_rules/src/sets/horizontal/concat.rs
+++ b/crates/conjure_rules/src/sets/horizontal/concat.rs
@@ -5,7 +5,7 @@ use conjure_core::matrix_expr;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 // A subsetEq (B intersect C) -> A subsetEq B /\ A subsetEq C

--- a/crates/conjure_rules/src/sets/horizontal/equals.rs
+++ b/crates/conjure_rules/src/sets/horizontal/equals.rs
@@ -4,7 +4,7 @@ use conjure_core::matrix_expr;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 use Expression::{And, Eq, SubsetEq};

--- a/crates/conjure_rules/src/sets/horizontal/neq.rs
+++ b/crates/conjure_rules/src/sets/horizontal/neq.rs
@@ -3,7 +3,7 @@ use conjure_core::ast::{Expression as Expr, ReturnType, SymbolTable, Typeable};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 #[register_rule(("Base", 8700))]

--- a/crates/conjure_rules/src/sets/horizontal/subset.rs
+++ b/crates/conjure_rules/src/sets/horizontal/subset.rs
@@ -4,7 +4,7 @@ use conjure_core::matrix_expr;
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 #[register_rule(("Base", 8700))]

--- a/crates/conjure_rules/src/sets/horizontal/supset.rs
+++ b/crates/conjure_rules/src/sets/horizontal/supset.rs
@@ -3,7 +3,7 @@ use conjure_core::ast::{Expression as Expr, ReturnType, SymbolTable, Typeable};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 #[register_rule(("Base", 8700))]

--- a/crates/conjure_rules/src/sets/horizontal/supseteq.rs
+++ b/crates/conjure_rules/src/sets/horizontal/supseteq.rs
@@ -3,7 +3,7 @@ use conjure_core::ast::{Expression as Expr, ReturnType, SymbolTable, Typeable};
 use conjure_core::metadata::Metadata;
 use conjure_core::rule_engine::Reduction;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 #[register_rule(("Base", 8700))]

--- a/crates/conjure_rules/src/sets/vertical/literal/in_rule.rs
+++ b/crates/conjure_rules/src/sets/vertical/literal/in_rule.rs
@@ -8,7 +8,7 @@ use conjure_core::ast::Literal;
 
 use conjure_core::ast::SymbolTable;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult,
+    ApplicationError::RuleNotApplicable, ApplicationResult, register_rule,
 };
 
 // turns an in expression into a w-inset expression where x is an integer decision variable

--- a/crates/conjure_rules/src/tuple.rs
+++ b/crates/conjure_rules/src/tuple.rs
@@ -4,7 +4,7 @@ use conjure_core::ast::SymbolTable;
 use conjure_core::into_matrix_expr;
 use conjure_core::matrix_expr;
 use conjure_core::rule_engine::{
-    register_rule, ApplicationError::RuleNotApplicable, ApplicationResult, Reduction,
+    ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
 
 use conjure_core::ast::Atom;

--- a/crates/enum_compatability_macro/Cargo.toml
+++ b/crates/enum_compatability_macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "enum_compatability_macro"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/enum_compatability_macro/src/lib.rs
+++ b/crates/enum_compatability_macro/src/lib.rs
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use quote::quote;
 use syn::{
-    parse_macro_input, parse_quote, punctuated::Punctuated, visit_mut::VisitMut, Attribute,
-    ItemEnum, Meta, Token, Variant,
+    Attribute, ItemEnum, Meta, Token, Variant, parse_macro_input, parse_quote,
+    punctuated::Punctuated, visit_mut::VisitMut,
 };
 
 // A nice S.O answer that helped write the syn code :)
@@ -58,7 +58,7 @@ impl VisitMut for RemoveCompatibleAttrs {
 
         if !solvers.is_empty() {
             let solver_list: String = solvers.into_iter().intersperse(", ".into()).collect();
-            let doc_string: String = format!("**Supported by:** {}.\n", solver_list);
+            let doc_string: String = format!("**Supported by:** {solver_list}.\n");
             let doc_attr: Attribute = parse_quote!(#[doc = #doc_string]);
             i.attrs.push(doc_attr);
         }
@@ -171,7 +171,7 @@ pub fn document_compatibility(_attr: TokenStream, input: TokenStream) -> TokenSt
     let mut doc_msg: String = "# Compatability\n".into();
     for solver in nodes_supported_by_solver.keys() {
         // a nice title
-        doc_msg.push_str(&format!("## {}\n", solver));
+        doc_msg.push_str(&format!("## {solver}\n"));
 
         // list all the ast nodes for this solver
         for node in nodes_supported_by_solver
@@ -181,7 +181,7 @@ pub fn document_compatibility(_attr: TokenStream, input: TokenStream) -> TokenSt
             .map(|x| x.to_string())
             .sorted()
         {
-            doc_msg.push_str(&format!("* [`{}`]({}::{})\n", node, input.ident, node));
+            doc_msg.push_str(&format!("* [`{node}`]({}::{node})\n", input.ident));
         }
 
         // end list

--- a/crates/randicheck/Cargo.toml
+++ b/crates/randicheck/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "randicheck"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 streaming-iterator = "0.1.9"

--- a/crates/tree-sitter-essence/Cargo.toml
+++ b/crates/tree-sitter-essence/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-essence"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 build = "bindings/rust/build.rs"
 include = ["bindings/rust/*", "grammar.js", "src/*"]

--- a/crates/tree-sitter-essence/bindings/rust/lib.rs
+++ b/crates/tree-sitter-essence/bindings/rust/lib.rs
@@ -20,7 +20,7 @@
 
 use tree_sitter_language::LanguageFn;
 
-extern "C" {
+unsafe extern "C" {
     fn tree_sitter_essence() -> *const ();
 }
 

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-morph"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 multipeek = "0.1.2"

--- a/crates/tree_morph/benches/factorial.rs
+++ b/crates/tree_morph/benches/factorial.rs
@@ -2,7 +2,7 @@
 ///Note that addition and multiplication are performed modulo 10, to avoid having large numbers
 /// in the factorial. I also add in a dummy "do_nothing" rule. This gives another area where
 /// an optimiser can shine.
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tree_morph::prelude::*;

--- a/crates/tree_morph/benches/identity.rs
+++ b/crates/tree_morph/benches/identity.rs
@@ -1,6 +1,6 @@
 ///The following test is designed to test how long tree traversal takes.
 ///There is one rule, that does nothing. We create trees of a variable depth.
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 

--- a/crates/tree_morph/benches/left_add.rs
+++ b/crates/tree_morph/benches/left_add.rs
@@ -1,7 +1,7 @@
 ///This is a simple benchmark that tests how long it takes tree-morph to evaluate (1+(1+...)).
 ///This benchmark is designed to be compared with right_add.
 ///
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 

--- a/crates/tree_morph/benches/left_add_hard.rs
+++ b/crates/tree_morph/benches/left_add_hard.rs
@@ -1,6 +1,6 @@
 ///Added 4 extra rules (that never apply) to left_add, showing a performance cost of > +400%
 ///Good optimisations will meant that this cost is vastly reduced (I am not sure by how much, but I think < +100% makes sense)
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 

--- a/crates/tree_morph/benches/modify_leafs.rs
+++ b/crates/tree_morph/benches/modify_leafs.rs
@@ -1,7 +1,7 @@
 ///This benchmark aims to assess how compute-heavy modifying all the nodes is.
 ///A tree of depth n with n children will be created, with the only rule being a modification 0->1.
 ///This benchmark will assess how efficient tree-updating (which is not done in place) is.
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 

--- a/crates/tree_morph/benches/right_add.rs
+++ b/crates/tree_morph/benches/right_add.rs
@@ -1,7 +1,7 @@
 ///This is a simple benchmark that tests how long it takes tree-morph to evaluate (()...+1)+1).
 ///This benchmark is designed to be compared with left_add.
 ///
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
 use uniplate::derive::Uniplate;
 

--- a/crates/tree_morph/src/engine.rs
+++ b/crates/tree_morph/src/engine.rs
@@ -2,8 +2,8 @@
 #![allow(missing_docs)]
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{helpers::one_or_select, Commands, Rule, Update};
-use uniplate::{zipper::Zipper, Uniplate};
+use crate::{Commands, Rule, Update, helpers::one_or_select};
+use uniplate::{Uniplate, zipper::Zipper};
 /// Exhaustively rewrites a tree using a set of transformation rules.
 ///
 /// Rewriting is complete when all rules have been attempted with no change. Rules may be organised

--- a/crates/tree_morph/src/helpers.rs
+++ b/crates/tree_morph/src/helpers.rs
@@ -67,10 +67,7 @@ where
     let rules = rs.map(|(r, _)| r).collect::<Vec<_>>();
     // Since `one_or_select` only calls the selector if there is more than one rule,
     // at this point there is guaranteed to be more than one rule.
-    panic!(
-        "Multiple rules applicable to expression {:?}\n{:?}",
-        t, rules
-    );
+    panic!("Multiple rules applicable to expression {t:?}\n{rules:?}",);
 }
 
 /// Selects an [`Update`] based on user input through stdin.
@@ -115,17 +112,16 @@ where
     loop {
         print!(
             "--- Current Expression ---
-{}
+{t}
 
 --- Rules ---
-{}
+{rules}
 
 ---
 q   No change
 <n> Apply rule n
 
 :",
-            t, rules
         );
         std::io::stdout().flush().unwrap(); // Print the : on same line
 

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -480,10 +480,10 @@ pub mod prelude {
 }
 
 pub use commands::Commands;
-pub use engine::morph;
-pub use engine::morph_impl;
 pub use engine::DirtyZipper;
 pub use engine::NodeState;
 pub use engine::State;
+pub use engine::morph;
+pub use engine::morph_impl;
 pub use rule::{Rule, RuleFn};
 pub use update::Update;

--- a/crates/tree_morph/tests/lambda_calc.rs
+++ b/crates/tree_morph/tests/lambda_calc.rs
@@ -93,7 +93,7 @@ fn subst(expr: &Expr, x: u32, f: &Expr) -> Expr {
 fn beta_reduce(expr: &Expr) -> Option<Expr> {
     if let Expr::App(m, n) = expr {
         if let Expr::Abs(x, g) = m.as_ref() {
-            return Some(subst(&g, *x, n));
+            return Some(subst(g, *x, n));
         }
     }
     None

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["cargo", "rustfmt", "clippy"]

--- a/solvers/minion/Cargo.toml
+++ b/solvers/minion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minion_rs"
 version = "0.0.1"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/solvers/minion/build.rs
+++ b/solvers/minion/build.rs
@@ -13,7 +13,7 @@ use std::process::Command;
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    println!("cargo:rustc-link-search=all={}/build", out_dir);
+    println!("cargo:rustc-link-search=all={out_dir}/build");
     println!("cargo:rustc-link-lib=static=minion");
     println!("cargo:rerun-if-changed=vendor");
     println!("cargo:rerun-if-changed=build.rs");
@@ -111,7 +111,7 @@ fn bind() {
         .allowlist_function("vec_vec_int_push_back")
         .allowlist_function("vec_vec_int_free")
         .allowlist_function("TableOut_get")
-        .clang_arg(format!("-I{}/build/src/", out_dir)) // generated from configure.py
+        .clang_arg(format!("-I{out_dir}/build/src/")) // generated from configure.py
         .clang_arg("-Ivendor/minion/")
         .clang_arg("-DLIBMINION")
         .clang_arg(r"--std=gnu++11")

--- a/solvers/minion/src/ffi.rs
+++ b/solvers/minion/src/ffi.rs
@@ -1,4 +1,7 @@
 #![allow(warnings)]
+
+use std::ffi::CString;
+use std::sync::atomic::{AtomicI32, Ordering};
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
@@ -8,16 +11,16 @@ mod tests {
     use super::*;
 
     // solutions
-    static mut X_VAL: i32 = 0;
-    static mut Y_VAL: i32 = 0;
-    static mut Z_VAL: i32 = 0;
+    static X_VAL: AtomicI32 = AtomicI32::new(0);
+    static Y_VAL: AtomicI32 = AtomicI32::new(0);
+    static Z_VAL: AtomicI32 = AtomicI32::new(0);
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub extern "C" fn hello_from_rust() -> bool {
         unsafe {
-            X_VAL = printMatrix_getValue(0) as _;
-            Y_VAL = printMatrix_getValue(1) as _;
-            Z_VAL = printMatrix_getValue(2) as _;
+            X_VAL.store(printMatrix_getValue(0) as _, Ordering::Relaxed);
+            Y_VAL.store(printMatrix_getValue(1) as _, Ordering::Relaxed);
+            Z_VAL.store(printMatrix_getValue(2) as _, Ordering::Relaxed);
             return true;
         }
     }
@@ -97,9 +100,9 @@ mod tests {
             assert_eq!(res, 0);
 
             // test if solutions are correct
-            assert_eq!(X_VAL, 1);
-            assert_eq!(Y_VAL, 2);
-            assert_eq!(Z_VAL, 1);
+            assert_eq!(X_VAL.load(Ordering::Relaxed), 1);
+            assert_eq!(Y_VAL.load(Ordering::Relaxed), 2);
+            assert_eq!(Z_VAL.load(Ordering::Relaxed), 1);
         }
     }
 }

--- a/solvers/minion/src/run.rs
+++ b/solvers/minion/src/run.rs
@@ -1,4 +1,5 @@
 #![allow(unreachable_patterns)]
+#![allow(unsafe_op_in_unsafe_fn)]
 
 use std::{
     collections::HashMap,
@@ -119,7 +120,7 @@ static PRINT_VARS: Mutex<Option<Vec<VarName>>> = Mutex::new(None);
 
 static LOCK: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn run_callback() -> bool {
     // get printvars from static PRINT_VARS if they exist.
     // if not, return true and continue search.
@@ -245,7 +246,7 @@ unsafe fn convert_model_to_raw(
         let (vartype_raw, domain_low, domain_high) = match vartype {
             VarDomain::Bound(a, b) => Ok((ffi::VariableType_VAR_BOUND, a, b)),
             VarDomain::Bool => Ok((ffi::VariableType_VAR_BOOL, 0, 1)), // TODO: will this work?
-            x => Err(MinionError::NotImplemented(format!("{:?}", x))),
+            x => Err(MinionError::NotImplemented(format!("{x:?}"))),
         }?;
 
         ffi::newVar_ffi(
@@ -391,8 +392,7 @@ unsafe fn get_constraint_type(constraint: &Constraint) -> Result<u32, MinionErro
 
         #[allow(unreachable_patterns)]
         x => Err(MinionError::NotImplemented(format!(
-            "Constraint not implemented {:?}",
-            x,
+            "Constraint not implemented {x:?}",
         ))),
     }
 }
@@ -629,7 +629,7 @@ unsafe fn constraint_add_args(
         Constraint::True => Ok(()),
         Constraint::False => Ok(()),
         #[allow(unreachable_patterns)]
-        x => Err(MinionError::NotImplemented(format!("{:?}", x))),
+        x => Err(MinionError::NotImplemented(format!("{x:?}"))),
     }
 }
 
@@ -733,7 +733,7 @@ unsafe fn read_constant(
         Constant::Integer(n) => Ok(*n),
         Constant::Bool(true) => Ok(1),
         Constant::Bool(false) => Ok(0),
-        x => Err(MinionError::NotImplemented(format!("{:?}", x))),
+        x => Err(MinionError::NotImplemented(format!("{x:?}"))),
     }?;
 
     ffi::constraint_addConstant(raw_constraint, val);
@@ -753,7 +753,7 @@ unsafe fn read_constant_list(
             Constant::Bool(true) => Ok(1),
             Constant::Bool(false) => Ok(0),
             #[allow(unreachable_patterns)] // TODO: can there be other types?
-            x => Err(MinionError::NotImplemented(format!("{:?}", x))),
+            x => Err(MinionError::NotImplemented(format!("{x:?}"))),
         }?;
 
         ffi::vec_int_push_back(raw_consts.ptr, val);

--- a/solvers/minion/src/wrappers.rs
+++ b/solvers/minion/src/wrappers.rs
@@ -1,6 +1,6 @@
 //! Small wrapper functions over FFI things.
 
-use std::ffi::{c_char, CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 
 use crate::ffi;
 use libc::free;


### PR DESCRIPTION
Update rust version from 1.87.0 to 1.88.0, and edition from 2021 to
2024. Also apply clippy lints / `cargo fmt` for the new edition.

Combined, these changes give us let-chaining within ifs and whiles [1]

1: https://doc.rust-lang.org/edition-guide/rust-2024/let-chains.html
