### PR TITLE
[`DeclarationPtr` 01] Add `DeclarationPtr`

### DIFF
--- a/crates/conjure_core/src/ast/declaration.rs
+++ b/crates/conjure_core/src/ast/declaration.rs
@@ -430,6 +430,12 @@ impl DefaultWithId for DeclarationPtr {
     }
 }
 
+impl Typeable for DeclarationPtr {
+    fn return_type(&self) -> Option<ReturnType> {
+        self.borrow().return_type()
+    }
+}
+
 impl Uniplate for DeclarationPtr {
     fn uniplate(&self) -> (Tree<Self>, Box<dyn Fn(Tree<Self>) -> Self>) {
         let decl = self.borrow();

--- a/crates/conjure_core/src/ast/mod.rs
+++ b/crates/conjure_core/src/ast/mod.rs
@@ -18,7 +18,7 @@ mod types;
 mod variables;
 
 pub use atom::Atom;
-pub use declaration::*;
+pub use declaration::{Declaration, DeclarationKind, DeclarationPtr};
 pub use domains::Domain;
 pub use domains::DomainOpError;
 pub use domains::Range;


### PR DESCRIPTION
Add `DeclarationPtr` type, and implement the `ReturnType` and `Biplate` traits
on it, as discussed in issue #911.


Note that this PR is expected to fail hygene checks, as it deprecates the `Declaration` type, resulting in `deprecated type used` warnings. Follow up PRs will replace all usages `Rc<RefCell<Declaration>>` with `DeclarationPtr`, allowing me to remove all usages of `Declaration`. I am putting that refactor in a seperate PR, as it will be a large change.

Tracking-Issue: #910

For more information, see the commit log:

 * * * * * 

## Commits

- **feat(ast): add `DeclarationPtr`**
  Add `DeclarationPtr` type, representing a shared pointer to a
  `Declaration`.
  
  In future commits, I intend to replace all usages of
  `Rc<RefCell<Declaration>>`, which we currently use as the shared pointer
  type, with `DeclarationPtr`.
  
  The eventual goal is to only interact with declarations through this
  pointer type. This is because the equality, hashing, and ordering
  semantics of `DeclarationPtr` are clearer, as explained below.
  
  For this reason, this commit also adds methods similar to those already
  on `Declaration` to `DeclarationPtr`, and deprecates the `Declaration`
  type and its methods. `Declaration`'s methods will be removed soon as
  possible. Once this is done, the `Declaration` type will be made
  private.
  
  EQUALITY
  
  The equality semantics of `DeclarationPtr` are simpler than
  `Declaration`, and our current `Rc<RefCell<Declaration>>` type.
  
  These both do equality by value - that is, two declarations are identical if
  they have the same name, kind, domain, etc. This is not ideal. Consider
  this model:
  
  ```
  find a: int(1..5)
  
  such that
  a <= sum([a + 1 | a:int(1..5)]) / 5
  ~         ~
  ````
  
  Currently, the references underlined would be equal, as their
  declarations are identical. However, they are in different scopes!
  
  What we want instead is to say that two symbols are equal if they point
  to the same declaration in memory. This is what `DeclarationPtr` does.
  
  We also often use names to check whether two references are equal. As a
  name can mean different things in different scopes, this is not ideal.
  Once the refactor is finished, we will remove names from
  `Atom::Reference` entirely, and check whether two variables are
  identical by checking the equality of `DeclarationPtr`.
  
  IDS
  
  Underlying the `Eq` implementation are the ids of the `DeclarationPtr`.
  These follow the following rules:
  
  1. Declaration pointers have the same id if they point to the same
     underlying declaration.
  
  2. The id is immutable. This is required for `HashMap` and `BTreeMap`
     to work properly with DeclarationPtrs as keys. See
     https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type.
  
  3. Changing the declaration pointed to by the declaration pointer does
     not change the id. This allows declarations to be updated by
     replacing them with a newer version of themsevles, which is a
     frequent operation in our rule engine.
  
  It may seem strange that `Declaration` and `DeclarationPtr` both have id
  fields. I plan to remove ids from the former when possible. Using the id
  stored inside the Declaration itself was not ideal here for the
  following reasons: it is inside a RefCell, so is mutable (potentially
  breaking invariant 2); replacing the underlying declaration would
  violate invariant 3.
  
  HASH, ORD
  
  I also use ids to implement `Hash` and `Ord`.
  
  MOTIVATION
  
  By implementing methods such as `domain` on `DeclarationPtr` instead of
  `Declaration`, I hope to reduce the boilerplate needed to work with
  declarations behind pointers. For example, currently to get the domain
  of a declaration, we must do:
  
  ```rs
  let decl = (*declaration_ptr).borrow();
  let domain = decl.domain();
  ```
  
  Instead, we can now do:
  
  ```rs
  declaration_ptr.domain();
  ```
  
  Also, having this wrapper type lets us implement custom trait
  implementations for the pointer type, including:
  serialisation, deserialisation, uniplate.
  
  Tracking-issue: #911
  

- **feat(ast): implement Biplate, Uniplate for DeclarationPtr**
  

- **feat(ast): implement ReturnType for DeclarationPtr**
  