### PR TITLE
Use rayon to parallelise converting solutions back from conjure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "pretty_assertions",
  "project-root",
  "rand 0.9.1",
+ "rayon",
  "regex",
  "schemars 1.0.4",
  "serde",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -53,6 +53,7 @@ project-root = "0.2.2"
 tempfile = "3.20.0"
 itertools = "0.14.0"
 clap_complete = "4.5.55"
+rayon = "1.8.0"
 
 [features]
 


### PR DESCRIPTION
This is a fairly tiny PR -- and even tinier if I'd pre-converted the loop to an iter/map, then it's just turning iter -> par_iter, but probably should be considered as it's a fairly huge change (introducing parallelisation!)

I noticed some larger `test-solve` took a long time, and noticed almost all of the time is being spent converting conjure solutions back one by one.

There may be a better way to do this, but we can also just chuck parallelisation at it.

I found this sped up test-solve on instances by quite a lot, for example on my machine the following instance goes from 120s to 6s

```
language ESSENCE' 1.0

find a : int(-5..5)
find b : int(-5..5)
find c : int(-5..5)


find z : bool
such that

z <-> (a/b=c)

```

Let's let the tests run, and see if it works, and if it breaks anything!