### PR TITLE
chore: update `uniplate` to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,9 +2853,9 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "uniplate"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04714c41b035090b0957e892236fd8d0354906d5cd32bb12b28964fd485b8add"
+checksum = "3d59772b7250d88992e32c38ffe75ab0207366b70c0b887f4090271db3ed3adb"
 dependencies = [
  "thiserror 2.0.12",
  "uniplate-derive",
@@ -2863,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "uniplate-derive"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3619d26fa6345ba7a9f39771537c497d49e621db84f1bb13c087b5d23ca032b3"
+checksum = "5fdcf3d19ff5ab13baff93e7acc4bbd6af8b1f661f71a88f175ac002e1fb561f"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -16,7 +16,7 @@ conjure_essence_parser = { path = "../crates/conjure_essence_parser" }
 conjure_essence_macros = { path = "../crates/conjure_essence_macros" }
 
 
-uniplate = "0.2.3"
+uniplate = "0.3.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = "3.14.0"

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -11,7 +11,7 @@ conjure_rule_macros = { path = "../conjure_rule_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }
 minion_rs = { path = "../../solvers/minion" }
 
-uniplate = "0.2.3"
+uniplate = "0.3.0"
 project-root = "0.2.2"
 linkme = "0.3.33"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -1,5 +1,6 @@
 use crate::{ast::declaration::serde::DeclarationPtrAsId, bug};
 use std::{borrow::Borrow, cell::Ref};
+use uniplate::Uniplate;
 
 use super::{
     AbstractLiteral, DeclarationPtr, Domain, Expression, Literal, Name,
@@ -10,7 +11,6 @@ use super::{
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use uniplate::derive::Uniplate;
 
 /// An `Atom` is an indivisible expression, such as a literal or a reference.
 #[serde_as]

--- a/crates/conjure_core/src/ast/comprehension.rs
+++ b/crates/conjure_core/src/ast/comprehension.rs
@@ -9,7 +9,7 @@ use std::{
 
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
-use uniplate::{Biplate, derive::Uniplate};
+use uniplate::{Biplate, Uniplate};
 
 use crate::{
     ast::{

--- a/crates/conjure_core/src/ast/declaration.rs
+++ b/crates/conjure_core/src/ast/declaration.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display};
 use std::rc::Rc;
 
 use ::serde::{Deserialize, Serialize};
-use uniplate::derive::Uniplate;
+
 use uniplate::{Biplate, Tree, Uniplate};
 
 use super::categories::{Category, CategoryOf};

--- a/crates/conjure_core/src/ast/domains.rs
+++ b/crates/conjure_core/src/ast/domains.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, fmt::Display};
 use thiserror::Error;
 
 use crate::{ast::pretty::pretty_vec, domain_int, range};
-use uniplate::{Uniplate, derive::Uniplate};
+use uniplate::Uniplate;
 
 use super::{AbstractLiteral, Literal, Name, ReturnType, records::RecordEntry, types::Typeable};
 

--- a/crates/conjure_core/src/ast/expressions.rs
+++ b/crates/conjure_core/src/ast/expressions.rs
@@ -17,8 +17,8 @@ use crate::metadata::Metadata;
 use enum_compatability_macro::document_compatibility;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use uniplate::derive::Uniplate;
-use uniplate::{Biplate, Uniplate as _};
+
+use uniplate::{Biplate, Uniplate};
 
 use super::ac_operators::ACOperatorKind;
 use super::categories::{Category, CategoryOf};

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -4,7 +4,6 @@ use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::hash::Hasher;
 
-use uniplate::derive::Uniplate;
 use uniplate::{Biplate, Tree, Uniplate};
 
 use crate::ast::pretty::pretty_vec;

--- a/crates/conjure_core/src/ast/records.rs
+++ b/crates/conjure_core/src/ast/records.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use super::literals::AbstractLiteralValue;
 use super::{Domain, Name};
 use serde::{Deserialize, Serialize};
-use uniplate::derive::Uniplate;
+
 use uniplate::{Biplate, Uniplate};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Uniplate)]

--- a/crates/conjure_essence_macros/Cargo.toml
+++ b/crates/conjure_essence_macros/Cargo.toml
@@ -11,7 +11,7 @@ conjure_core = { path = "../conjure_core" }
 conjure_essence_parser = { path = "../conjure_essence_parser" }
 
 tree-sitter = "0.24.7"
-uniplate = "0.2.3"
+uniplate = "0.3.0"
 quote = "1.0.40"
 syn = { version = "2.0.104", features = ["full"] }
 proc-macro2 = "1.0.95"

--- a/crates/conjure_essence_parser/Cargo.toml
+++ b/crates/conjure_essence_parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 conjure_core = { path = "../conjure_core" }
 tree-sitter-essence = { path = "../tree-sitter-essence" }
-uniplate = "0.2.3"
+uniplate = "0.3.0"
 tree-sitter = "0.24.7"
 thiserror = "2.0.12"
 

--- a/crates/conjure_rules/Cargo.toml
+++ b/crates/conjure_rules/Cargo.toml
@@ -11,7 +11,7 @@ conjure_core = { path = "../conjure_core" }
 conjure_rule_macros = { path = "../conjure_rule_macros" }
 conjure_essence_macros = { path = "../conjure_essence_macros" }
 
-uniplate = "0.2.2"
+uniplate = "0.3.0"
 linkme = "0.3.33"
 itertools = "0.14.0"
 tracing = "0.1"

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multipeek = "0.1.2"
 rand = "0.9.1"
-uniplate = "0.2.3"
+uniplate = "0.3.0"
 
 
 [lints]

--- a/crates/tree_morph/README.md
+++ b/crates/tree_morph/README.md
@@ -8,7 +8,8 @@ In this simple example, we use tree-morph to calculate mathematical expressions 
 
 ```rust
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/factorial.rs
+++ b/crates/tree_morph/benches/factorial.rs
@@ -6,7 +6,6 @@ use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/identity.rs
+++ b/crates/tree_morph/benches/identity.rs
@@ -2,7 +2,6 @@
 ///There is one rule, that does nothing. We create trees of a variable depth.
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/left_add.rs
+++ b/crates/tree_morph/benches/left_add.rs
@@ -3,7 +3,6 @@
 ///
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/left_add_hard.rs
+++ b/crates/tree_morph/benches/left_add_hard.rs
@@ -2,7 +2,6 @@
 ///Good optimisations will meant that this cost is vastly reduced (I am not sure by how much, but I think < +100% makes sense)
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/modify_leafs.rs
+++ b/crates/tree_morph/benches/modify_leafs.rs
@@ -3,7 +3,6 @@
 ///This benchmark will assess how efficient tree-updating (which is not done in place) is.
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/right_add.rs
+++ b/crates/tree_morph/benches/right_add.rs
@@ -3,7 +3,6 @@
 ///
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/src/commands.rs
+++ b/crates/tree_morph/src/commands.rs
@@ -27,7 +27,7 @@ enum Command<T: Uniplate, M> {
 /// # Example
 /// ```rust
 /// use tree_morph::prelude::*;
-/// use uniplate::derive::Uniplate;
+/// use uniplate::Uniplate;
 ///
 /// #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 /// #[uniplate()]

--- a/crates/tree_morph/src/engine.rs
+++ b/crates/tree_morph/src/engine.rs
@@ -40,7 +40,8 @@ use uniplate::{Uniplate, zipper::Zipper};
 /// # Example
 /// ```rust
 /// use tree_morph::{prelude::*, helpers::select_panic};
-/// use uniplate::derive::Uniplate;
+/// use uniplate::Uniplate;
+///
 ///
 /// // A simple language of multiplied and squared constant expressions
 /// #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]

--- a/crates/tree_morph/src/lib.rs
+++ b/crates/tree_morph/src/lib.rs
@@ -8,7 +8,8 @@
 //!
 //! ```rust
 //! use tree_morph::prelude::*;
-//! use uniplate::derive::Uniplate;
+//! use uniplate::Uniplate;
+//!
 //!
 //! #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! #[uniplate()]
@@ -23,7 +24,8 @@
 //!
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
+//! #
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -43,7 +45,7 @@
 //! Now we know how to create expressions, we have to also create rules that transform expressions. The following functions provide addition and multiplication rules for our tree.
 //!```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -76,7 +78,7 @@
 //!We can defining the squaring rule in a similar way.
 //!```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -100,7 +102,7 @@
 //!
 //!```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -167,7 +169,7 @@
 //!Also, until now the ``Commands`` object has held types ``<Expr, i32>``; in general, a commands object holds types ``<T, M>``, where `T` is the tree type, and `M` is the metadata type. To include our new struct ``Meta``, we need to adjust the types accordingly.
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -199,7 +201,7 @@
 //!
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -228,7 +230,7 @@
 //!
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -254,7 +256,7 @@
 //! The following test block verifies that two addition operations take place.
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -323,7 +325,7 @@
 //! It is now clear why ``assert_eq!(metaresult.num_applications_addition, 2);`` holds above. Because rule ``rule_expand_sqr`` was in the same grouping as all the other rules, tree-morph applied the rule before the addition node was ever reached. To increase the efficiency the solving algorithm, we can assign the ``rule_expand_sqr`` with a lower priority.
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]
@@ -388,7 +390,7 @@
 //! Now that ``rule_expand_sqr`` has a lower priority, the addition operation will be applied first, and hence ``metaresult.num_applications_addition`` should equal 1. If we make the following change to the test, we can verify this directly.
 //! ```rust
 //! # use tree_morph::prelude::*;
-//! # use uniplate::derive::Uniplate;
+//! # use uniplate::Uniplate;
 //! #
 //! # #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 //! # #[uniplate()]

--- a/crates/tree_morph/src/main.rs
+++ b/crates/tree_morph/src/main.rs
@@ -4,7 +4,7 @@
 // use std::cell::Cell;
 
 // use tree_morph::prelude::*;
-// use uniplate::derive::Uniplate;
+//
 
 // static mut GLOBAL_RULE_CHECKS: Cell<usize> = Cell::new(0);
 

--- a/crates/tree_morph/src/rule.rs
+++ b/crates/tree_morph/src/rule.rs
@@ -37,7 +37,8 @@ use uniplate::Uniplate;
 /// # Example
 /// ```rust
 /// use tree_morph::prelude::*;
-/// use uniplate::derive::Uniplate;
+/// use uniplate::Uniplate;
+///
 ///
 /// #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 /// #[uniplate()]
@@ -110,7 +111,8 @@ pub type RuleFn<T, M> = fn(&mut Commands<T, M>, &T, &M) -> Option<T>;
 /// # Example
 /// ```rust
 /// use tree_morph::prelude::*;
-/// use uniplate::derive::Uniplate;
+/// use uniplate::Uniplate;
+///
 ///
 /// #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 /// #[uniplate()]

--- a/crates/tree_morph/tests/dirty_clean.rs
+++ b/crates/tree_morph/tests/dirty_clean.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::Ordering;
 
 use std::sync::atomic::AtomicUsize;
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 static GLOBAL_RULE_CHECKS: AtomicUsize = AtomicUsize::new(0);
 

--- a/crates/tree_morph/tests/enum_rules.rs
+++ b/crates/tree_morph/tests/enum_rules.rs
@@ -1,7 +1,7 @@
 //! These tests use a simple constant expression tree to demonstrate the use of the `gen_reduce` crate.
 
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/tests/lambda_calc.rs
+++ b/crates/tree_morph/tests/lambda_calc.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/tests/mixed_fn_rules.rs
+++ b/crates/tree_morph/tests/mixed_fn_rules.rs
@@ -1,5 +1,5 @@
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/tests/rule_groups.rs
+++ b/crates/tree_morph/tests/rule_groups.rs
@@ -2,7 +2,7 @@
 //! Rules in a higher-index group will be applied first, even if they apply to lower nodes in the tree.
 
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 /// A simple language of two literals and a wrapper
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]

--- a/crates/tree_morph/tests/shapes.rs
+++ b/crates/tree_morph/tests/shapes.rs
@@ -1,7 +1,7 @@
 // Example case from the 05/02/2025 Conjure VIP meeting
 
 use tree_morph::prelude::*;
-use uniplate::derive::Uniplate;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]


### PR DESCRIPTION
Update uniplate to 0.3.0.

Fix breaking change: the `Uniplate` derive macro has been moved from
`uniplate::derive::Uniplate` to `uniplate::Uniplate`.
