### PR TITLE
chore: update Uniplate to `0.4.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,23 +2852,21 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "uniplate"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d59772b7250d88992e32c38ffe75ab0207366b70c0b887f4090271db3ed3adb"
+checksum = "cbe190e64ecc12dc9f74d80fcdda43e1bed021da727b139fab089bf80d4aa837"
 dependencies = [
- "thiserror 2.0.12",
  "uniplate-derive",
 ]
 
 [[package]]
 name = "uniplate-derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdcf3d19ff5ab13baff93e7acc4bbd6af8b1f661f71a88f175ac002e1fb561f"
+checksum = "40dcde957b07de17f8e73be82323d356e8a58fdda860edd2832dd012a8041b1a"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",
- "log",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/conjure_oxide/Cargo.toml
+++ b/conjure_oxide/Cargo.toml
@@ -16,7 +16,7 @@ conjure_essence_parser = { path = "../crates/conjure_essence_parser" }
 conjure_essence_macros = { path = "../crates/conjure_essence_macros" }
 
 
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 serde_with = "3.14.0"

--- a/conjure_oxide/src/utils/testing.rs
+++ b/conjure_oxide/src/utils/testing.rs
@@ -265,35 +265,29 @@ pub fn normalize_solutions_for_comparison(
 
                         let mut matrix =
                             AbstractLiteral::Matrix(elems, Box::new(Domain::Int(vec![])));
-                        matrix =
-                            matrix.transform(Arc::new(
-                                move |x: AbstractLiteral<Literal>| match x {
-                                    AbstractLiteral::Matrix(items, _) => {
-                                        let items = items
-                                            .into_iter()
-                                            .map(|x| match x {
-                                                Literal::Bool(false) => Literal::Int(0),
-                                                Literal::Bool(true) => Literal::Int(1),
-                                                x => x,
-                                            })
-                                            .collect_vec();
+                        matrix = matrix.transform(&move |x: AbstractLiteral<Literal>| match x {
+                            AbstractLiteral::Matrix(items, _) => {
+                                let items = items
+                                    .into_iter()
+                                    .map(|x| match x {
+                                        Literal::Bool(false) => Literal::Int(0),
+                                        Literal::Bool(true) => Literal::Int(1),
+                                        x => x,
+                                    })
+                                    .collect_vec();
 
-                                        AbstractLiteral::Matrix(
-                                            items,
-                                            Box::new(Domain::Int(vec![])),
-                                        )
-                                    }
-                                    x => x,
-                                },
-                            ));
+                                AbstractLiteral::Matrix(items, Box::new(Domain::Int(vec![])))
+                            }
+                            x => x,
+                        });
                         updates.push((k, Literal::AbstractLiteral(matrix)));
                     }
                     Literal::AbstractLiteral(AbstractLiteral::Tuple(elems)) => {
                         // just the same as matrix but with tuples instead
                         // only conversion needed is to convert bools to ints
                         let mut tuple = AbstractLiteral::Tuple(elems);
-                        tuple =
-                            tuple.transform(Arc::new(move |x: AbstractLiteral<Literal>| match x {
+                        tuple = tuple.transform(
+                            &(move |x: AbstractLiteral<Literal>| match x {
                                 AbstractLiteral::Tuple(items) => {
                                     let items = items
                                         .into_iter()
@@ -307,37 +301,35 @@ pub fn normalize_solutions_for_comparison(
                                     AbstractLiteral::Tuple(items)
                                 }
                                 x => x,
-                            }));
+                            }),
+                        );
                         updates.push((k, Literal::AbstractLiteral(tuple)));
                     }
                     Literal::AbstractLiteral(AbstractLiteral::Record(entries)) => {
                         // just the same as matrix but with tuples instead
                         // only conversion needed is to convert bools to ints
                         let mut record = AbstractLiteral::Record(entries);
-                        record =
-                            record.transform(Arc::new(
-                                move |x: AbstractLiteral<Literal>| match x {
-                                    AbstractLiteral::Record(entries) => {
-                                        let entries = entries
-                                            .into_iter()
-                                            .map(|x| {
-                                                let RecordValue { name, value } = x;
-                                                {
-                                                    let value = match value {
-                                                        Literal::Bool(false) => Literal::Int(0),
-                                                        Literal::Bool(true) => Literal::Int(1),
-                                                        x => x,
-                                                    };
-                                                    RecordValue { name, value }
-                                                }
-                                            })
-                                            .collect_vec();
+                        record = record.transform(&move |x: AbstractLiteral<Literal>| match x {
+                            AbstractLiteral::Record(entries) => {
+                                let entries = entries
+                                    .into_iter()
+                                    .map(|x| {
+                                        let RecordValue { name, value } = x;
+                                        {
+                                            let value = match value {
+                                                Literal::Bool(false) => Literal::Int(0),
+                                                Literal::Bool(true) => Literal::Int(1),
+                                                x => x,
+                                            };
+                                            RecordValue { name, value }
+                                        }
+                                    })
+                                    .collect_vec();
 
-                                        AbstractLiteral::Record(entries)
-                                    }
-                                    x => x,
-                                },
-                            ));
+                                AbstractLiteral::Record(entries)
+                            }
+                            x => x,
+                        });
                         updates.push((k, Literal::AbstractLiteral(record)));
                     }
                     e => bug!("unexpected literal type: {e:?}"),

--- a/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/basic/lettings/03-value-expr/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 
 --
 
+!(!(!(A))), 
+   ~~> remove_double_negation ([("Base", 8400)]) 
+!(A) 
+
+--
+
 (b < 3), 
    ~~> lt_to_leq ([("Minion", 8400)]) 
 (b <= sum([3,-1;int(1..)])) 
@@ -24,12 +30,6 @@ such that
 
 NotA, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-!(!(!(A))) 
-
---
-
-!(!(!(A))), 
-   ~~> remove_double_negation ([("Base", 8400)]) 
 !(A) 
 
 --
@@ -55,7 +55,7 @@ Ineq(b, 2, 0)
 Final model:
 
 letting A be false
-letting NotA be !(!(!(A)))
+letting NotA be !(A)
 find b: int(1..20)
 
 such that

--- a/conjure_oxide/tests/integration/sets/concat/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/concat/input-expected-rule-trace-human.txt
@@ -11,6 +11,12 @@ such that
 --
 
 (c subset (b intersect a)), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(c subset (b intersect a)) 
+
+--
+
+(c subset (b intersect a)), 
    ~~> subset_to_subset_eq_neq ([("Base", 8700)]) 
 and([(c subsetEq (b intersect a)),(c != (b intersect a));int(1..)]) 
 
@@ -70,27 +76,17 @@ or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
-
---
-
-({2} subsetEq b),
-(c subsetEq a),
-or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2)]) subsetEq b),
-(c subsetEq a),
-or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]) 
+Set([Int(2)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
+Set([Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2)]) subsetEq {2,3}),
+(Set([Int(2)]) subsetEq Set([Int(2), Int(3)])),
 (c subsetEq a),
 or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
@@ -101,25 +97,17 @@ or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
-
---
-
-({2} subsetEq a),
-or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2)]) subsetEq a),
-or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]) 
+Set([Int(2)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2)]) subsetEq {1,2,3}),
+(Set([Int(2)]) subsetEq Set([Int(1), Int(2), Int(3)])),
 or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]) 
@@ -128,23 +116,17 @@ or([!(((b intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-or([!((({2,3} intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-or([!(((Set([Int(2), Int(3)]) intersect a) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]) 
+Set([Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-or([!(((Set([Int(2), Int(3)]) intersect {1,2,3}) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
+or([!(((Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2), Int(3)])) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 or([!((Set([Int(2), Int(3)]) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));int(1..)]) 
 
@@ -152,11 +134,11 @@ or([!((Set([Int(2), Int(3)]) subsetEq c)),!((c subsetEq b)),!((c subsetEq a));in
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
+Set([Int(2)]) 
 
 --
 
-or([!((Set([Int(2), Int(3)]) subsetEq {2})),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
+or([!((Set([Int(2), Int(3)]) subsetEq Set([Int(2)]))),!((c subsetEq b)),!((c subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -164,9 +146,9 @@ true
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {2,3}
-letting c be {2}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(2), Int(3)])
+letting c be Set([Int(2)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/constant_eval_set_tests/In/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/constant_eval_set_tests/In/input-expected-rule-trace-human.txt
@@ -9,13 +9,19 @@ such that
 
 --
 
-b, 
-   ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+3 in b, 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+3 in b 
 
 --
 
-3 in {1,2,3}, 
+b, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+Set([Int(1), Int(2), Int(3)]) 
+
+--
+
+3 in Set([Int(1), Int(2), Int(3)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -24,7 +30,7 @@ true
 Final model:
 
 find a: int(1..4)
-letting b be {1,2,3}
+letting b be Set([Int(1), Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/equals1/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/equals1/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 --
 
 (a = b), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(a = b) 
+
+--
+
+(a = b), 
    ~~> eq_to_subset_eq ([("Base", 8800)]) 
 and([(a subsetEq b),(b subsetEq a);int(1..)]) 
 
@@ -24,25 +30,17 @@ and([(a subsetEq b),(b subsetEq a);int(1..)]),
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
-
---
-
-({1,2,3} subsetEq b),
-(b subsetEq a), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(1), Int(2), Int(3)]) subsetEq b),
-(b subsetEq a) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq {1,2,3}),
+(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),
 (b subsetEq a), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (b subsetEq a) 
@@ -51,23 +49,17 @@ b,
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
-
---
-
-({1,2,3} subsetEq a), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(1), Int(2), Int(3)]) subsetEq a) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq {1,2,3}), 
+(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -75,8 +67,8 @@ true
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {1,2,3}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(1), Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/equals2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/equals2/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 --
 
 (b = a), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(b = a) 
+
+--
+
+(b = a), 
    ~~> eq_to_subset_eq ([("Base", 8800)]) 
 and([(b subsetEq a),(a subsetEq b);int(1..)]) 
 
@@ -24,35 +30,19 @@ and([(b subsetEq a),(a subsetEq b);int(1..)]),
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(b subsetEq {2,3}),
-(a subsetEq b), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(b subsetEq Set([Int(2), Int(3)])),
-(a subsetEq b) 
+Set([Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(b subsetEq Set([Int(2), Int(3)])),
-({2,3} subsetEq b), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(b subsetEq Set([Int(2), Int(3)])),
-(Set([Int(2), Int(3)]) subsetEq b) 
+Set([Int(2), Int(3)]) 
 
 --
 
 Final model:
 
-letting a be {2,3}
+letting a be Set([Int(2), Int(3)])
 find b: set of (int(1..3))
 
 such that

--- a/conjure_oxide/tests/integration/sets/intersect1/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/intersect1/input-expected-rule-trace-human.txt
@@ -11,6 +11,12 @@ such that
 --
 
 (c = (a intersect b)), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(c = (a intersect b)) 
+
+--
+
+(c = (a intersect b)), 
    ~~> eq_to_subset_eq ([("Base", 8800)]) 
 and([(c subsetEq (a intersect b)),((a intersect b) subsetEq c);int(1..)]) 
 
@@ -40,27 +46,17 @@ and([(c subsetEq a),(c subsetEq b);int(1..)]),
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
-
---
-
-({2} subsetEq a),
-(c subsetEq b),
-((a intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2)]) subsetEq a),
-(c subsetEq b),
-((a intersect b) subsetEq c) 
+Set([Int(2)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
+Set([Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2)]) subsetEq {2,3}),
+(Set([Int(2)]) subsetEq Set([Int(2), Int(3)])),
 (c subsetEq b),
 ((a intersect b) subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
@@ -71,25 +67,17 @@ a,
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
-
---
-
-({2} subsetEq b),
-((a intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2)]) subsetEq b),
-((a intersect b) subsetEq c) 
+Set([Int(2)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+Set([Int(1), Int(2)]) 
 
 --
 
-(Set([Int(2)]) subsetEq {1,2}),
+(Set([Int(2)]) subsetEq Set([Int(1), Int(2)])),
 ((a intersect b) subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 ((a intersect b) subsetEq c) 
@@ -98,23 +86,17 @@ b,
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(({2,3} intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-((Set([Int(2), Int(3)]) intersect b) subsetEq c) 
+Set([Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+Set([Int(1), Int(2)]) 
 
 --
 
-((Set([Int(2), Int(3)]) intersect {1,2}) subsetEq c), 
+((Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2)])) subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (Set([Int(2)]) subsetEq c) 
 
@@ -122,11 +104,11 @@ b,
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2} 
+Set([Int(2)]) 
 
 --
 
-(Set([Int(2)]) subsetEq {2}), 
+(Set([Int(2)]) subsetEq Set([Int(2)])), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -134,9 +116,9 @@ true
 
 Final model:
 
-letting a be {2,3}
-letting b be {1,2}
-letting c be {2}
+letting a be Set([Int(2), Int(3)])
+letting b be Set([Int(1), Int(2)])
+letting c be Set([Int(2)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/intersect2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/intersect2/input-expected-rule-trace-human.txt
@@ -11,6 +11,12 @@ such that
 --
 
 (c = (a intersect b)), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(c = (a intersect b)) 
+
+--
+
+(c = (a intersect b)), 
    ~~> eq_to_subset_eq ([("Base", 8800)]) 
 and([(c subsetEq (a intersect b)),((a intersect b) subsetEq c);int(1..)]) 
 
@@ -40,61 +46,31 @@ and([(c subsetEq a),(c subsetEq b);int(1..)]),
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(c subsetEq {2,3}),
-(c subsetEq b),
-((a intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(c subsetEq Set([Int(2), Int(3)])),
-(c subsetEq b),
-((a intersect b) subsetEq c) 
+Set([Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
-
---
-
-(c subsetEq Set([Int(2), Int(3)])),
-(c subsetEq {1,2}),
-((a intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(c subsetEq Set([Int(2), Int(3)])),
-(c subsetEq Set([Int(1), Int(2)])),
-((a intersect b) subsetEq c) 
+Set([Int(1), Int(2)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(c subsetEq Set([Int(2), Int(3)])),
-(c subsetEq Set([Int(1), Int(2)])),
-(({2,3} intersect b) subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(c subsetEq Set([Int(2), Int(3)])),
-(c subsetEq Set([Int(1), Int(2)])),
-((Set([Int(2), Int(3)]) intersect b) subsetEq c) 
+Set([Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+Set([Int(1), Int(2)]) 
 
 --
 
 (c subsetEq Set([Int(2), Int(3)])),
 (c subsetEq Set([Int(1), Int(2)])),
-((Set([Int(2), Int(3)]) intersect {1,2}) subsetEq c), 
+((Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2)])) subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 (c subsetEq Set([Int(2), Int(3)])),
 (c subsetEq Set([Int(1), Int(2)])),
@@ -104,8 +80,8 @@ b,
 
 Final model:
 
-letting a be {2,3}
-letting b be {1,2}
+letting a be Set([Int(2), Int(3)])
+letting b be Set([Int(1), Int(2)])
 find c: set of (int(1..3))
 
 such that

--- a/conjure_oxide/tests/integration/sets/subset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/subset/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 --
 
 (b subset a), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(b subset a) 
+
+--
+
+(b subset a), 
    ~~> subset_to_subset_eq_neq ([("Base", 8700)]) 
 and([(b subsetEq a),(b != a);int(1..)]) 
 
@@ -42,25 +48,17 @@ or([!((a subsetEq b)),!((b subsetEq a));int(1..)])
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-({2,3} subsetEq a),
-or([!((a subsetEq b)),!((b subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2), Int(3)]) subsetEq a),
-or([!((a subsetEq b)),!((b subsetEq a));int(1..)]) 
+Set([Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2), Int(3)]) subsetEq {1,2,3}),
+(Set([Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),
 or([!((a subsetEq b)),!((b subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 or([!((a subsetEq b)),!((b subsetEq a));int(1..)]) 
@@ -69,23 +67,17 @@ or([!((a subsetEq b)),!((b subsetEq a));int(1..)])
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
-
---
-
-or([!(({1,2,3} subsetEq b)),!((b subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-or([!((Set([Int(1), Int(2), Int(3)]) subsetEq b)),!((b subsetEq a));int(1..)]) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
+Set([Int(2), Int(3)]) 
 
 --
 
-or([!((Set([Int(1), Int(2), Int(3)]) subsetEq {2,3})),!((b subsetEq a));int(1..)]), 
+or([!((Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3)]))),!((b subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -93,8 +85,8 @@ true
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {2,3}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/subsetEq1/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/subsetEq1/input-expected-rule-trace-human.txt
@@ -9,25 +9,25 @@ such that
 
 --
 
-a, 
-   ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+(a subsetEq b), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(a subsetEq b) 
 
 --
 
-({1,2,3} subsetEq b), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(1), Int(2), Int(3)]) subsetEq b) 
+a, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
+Set([Int(2), Int(3)]) 
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq {2,3}), 
+(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3)])), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
 
@@ -35,8 +35,8 @@ false
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {2,3}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/subsetEq2/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/subsetEq2/input-expected-rule-trace-human.txt
@@ -10,27 +10,21 @@ and([(c subsetEq b),!((c subsetEq a));int(1..2)])
 
 --
 
-b, 
-   ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+and([(c subsetEq b),!((c subsetEq a));int(1..2)]), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+and([(c subsetEq b),!((c subsetEq a));int(1..2)]) 
 
 --
 
-and([(c subsetEq {1,2}),!((c subsetEq a));int(1..2)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-and([(c subsetEq Set([Int(1), Int(2)])),!((c subsetEq a));int(1..2)]) 
+b, 
+   ~~> substitute_value_lettings ([("Base", 5000)]) 
+Set([Int(1), Int(2)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-and([(c subsetEq Set([Int(1), Int(2)])),!((c subsetEq {2,3}));int(1..2)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-and([(c subsetEq Set([Int(1), Int(2)])),!((c subsetEq Set([Int(2), Int(3)])));int(1..2)]) 
+Set([Int(2), Int(3)]) 
 
 --
 
@@ -72,8 +66,8 @@ Reify((c subsetEq Set([Int(2), Int(3)])), __0)
 
 Final model:
 
-letting a be {2,3}
-letting b be {1,2}
+letting a be Set([Int(2), Int(3)])
+letting b be Set([Int(1), Int(2)])
 find c: set of (int(1..3))
 find __0: bool
 

--- a/conjure_oxide/tests/integration/sets/supset/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/supset/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 --
 
 (a supset b), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(a supset b) 
+
+--
+
+(a supset b), 
    ~~> supset_to_subset ([("Base", 8700)]) 
 (b subset a) 
 
@@ -48,25 +54,17 @@ or([!((a subsetEq b)),!((b subsetEq a));int(1..)])
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-({2,3} subsetEq a),
-or([!((a subsetEq b)),!((b subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2), Int(3)]) subsetEq a),
-or([!((a subsetEq b)),!((b subsetEq a));int(1..)]) 
+Set([Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2), Int(3)]) subsetEq {1,2,3}),
+(Set([Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),
 or([!((a subsetEq b)),!((b subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 or([!((a subsetEq b)),!((b subsetEq a));int(1..)]) 
@@ -75,23 +73,17 @@ or([!((a subsetEq b)),!((b subsetEq a));int(1..)])
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
-
---
-
-or([!(({1,2,3} subsetEq b)),!((b subsetEq a));int(1..)]), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-or([!((Set([Int(1), Int(2), Int(3)]) subsetEq b)),!((b subsetEq a));int(1..)]) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
+Set([Int(2), Int(3)]) 
 
 --
 
-or([!((Set([Int(1), Int(2), Int(3)]) subsetEq {2,3})),!((b subsetEq a));int(1..)]), 
+or([!((Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3)]))),!((b subsetEq a));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -99,8 +91,8 @@ true
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {2,3}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/supsetEq/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/supsetEq/input-expected-rule-trace-human.txt
@@ -10,6 +10,12 @@ such that
 --
 
 (a supsetEq b), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(a supsetEq b) 
+
+--
+
+(a supsetEq b), 
    ~~> supset_eq_to_subset_eq ([("Base", 8700)]) 
 (b subsetEq a) 
 
@@ -17,23 +23,17 @@ such that
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-({2,3} subsetEq a), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2), Int(3)]) subsetEq a) 
+Set([Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
-(Set([Int(2), Int(3)]) subsetEq {1,2,3}), 
+(Set([Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 true 
 
@@ -41,8 +41,8 @@ true
 
 Final model:
 
-letting a be {1,2,3}
-letting b be {2,3}
+letting a be Set([Int(1), Int(2), Int(3)])
+letting b be Set([Int(2), Int(3)])
 
 such that
 

--- a/conjure_oxide/tests/integration/sets/union1/input-expected-rule-trace-human.txt
+++ b/conjure_oxide/tests/integration/sets/union1/input-expected-rule-trace-human.txt
@@ -11,6 +11,12 @@ such that
 --
 
 (c = (a union b)), 
+   ~~> constant_evaluator ([("Constant", 9001)]) 
+(c = (a union b)) 
+
+--
+
+(c = (a union b)), 
    ~~> eq_to_subset_eq ([("Base", 8800)]) 
 and([(c subsetEq (a union b)),((a union b) subsetEq c);int(1..)]) 
 
@@ -40,43 +46,23 @@ and([(a subsetEq b),(a subsetEq c);int(1..)]),
 
 c, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2,3} 
-
---
-
-({1,2,3} subsetEq (a union b)),
-(a subsetEq b),
-(a subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(1), Int(2), Int(3)]) subsetEq (a union b)),
-(a subsetEq b),
-(a subsetEq c) 
+Set([Int(1), Int(2), Int(3)]) 
 
 --
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-(Set([Int(1), Int(2), Int(3)]) subsetEq ({2,3} union b)),
-(a subsetEq b),
-(a subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(1), Int(2), Int(3)]) subsetEq (Set([Int(2), Int(3)]) union b)),
-(a subsetEq b),
-(a subsetEq c) 
+Set([Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+Set([Int(1), Int(2)]) 
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq (Set([Int(2), Int(3)]) union {1,2})),
+(Set([Int(1), Int(2), Int(3)]) subsetEq (Set([Int(2), Int(3)]) union Set([Int(1), Int(2)]))),
 (a subsetEq b),
 (a subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
@@ -87,25 +73,17 @@ b,
 
 a, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{2,3} 
-
---
-
-({2,3} subsetEq b),
-(a subsetEq c), 
-   ~~> constant_evaluator ([("Constant", 9001)]) 
-(Set([Int(2), Int(3)]) subsetEq b),
-(a subsetEq c) 
+Set([Int(2), Int(3)]) 
 
 --
 
 b, 
    ~~> substitute_value_lettings ([("Base", 5000)]) 
-{1,2} 
+Set([Int(1), Int(2)]) 
 
 --
 
-(Set([Int(2), Int(3)]) subsetEq {1,2}),
+(Set([Int(2), Int(3)]) subsetEq Set([Int(1), Int(2)])),
 (a subsetEq c), 
    ~~> constant_evaluator ([("Constant", 9001)]) 
 false 
@@ -114,9 +92,9 @@ false
 
 Final model:
 
-letting a be {2,3}
-letting b be {1,2}
-letting c be {1,2,3}
+letting a be Set([Int(2), Int(3)])
+letting b be Set([Int(1), Int(2)])
+letting c be Set([Int(1), Int(2), Int(3)])
 
 such that
 

--- a/crates/conjure_core/Cargo.toml
+++ b/crates/conjure_core/Cargo.toml
@@ -11,7 +11,7 @@ conjure_rule_macros = { path = "../conjure_rule_macros" }
 enum_compatability_macro = { path = "../enum_compatability_macro" }
 minion_rs = { path = "../../solvers/minion" }
 
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 project-root = "0.2.2"
 linkme = "0.3.33"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crates/conjure_core/src/ast/atom.rs
+++ b/crates/conjure_core/src/ast/atom.rs
@@ -19,10 +19,10 @@ use serde_with::serde_as;
 #[uniplate()]
 #[biplate(to=Literal)]
 #[biplate(to=Expression)]
-#[biplate(to=AbstractLiteral<Literal>,walk_into=[Literal])]
-#[biplate(to=RecordValue<Literal>,walk_into=[Literal])]
+#[biplate(to=AbstractLiteral<Literal>)]
+#[biplate(to=RecordValue<Literal>)]
 #[biplate(to=DeclarationPtr)]
-#[biplate(to=Name,walk_into=[DeclarationPtr])]
+#[biplate(to=Name)]
 pub enum Atom {
     Literal(Literal),
     // FIXME: check if these are the hashing semantics we want.

--- a/crates/conjure_core/src/ast/declaration.rs
+++ b/crates/conjure_core/src/ast/declaration.rs
@@ -586,10 +586,9 @@ impl Display for DeclarationPtr {
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Eq, Uniplate)]
-#[biplate(to=Expression,walk_into=[DeclarationKind])]
-#[biplate(to=DeclarationPtr,walk_into=[DeclarationKind])]
+#[biplate(to=Expression)]
+#[biplate(to=DeclarationPtr)]
 #[biplate(to=Name)]
-#[uniplate(walk_into=[DeclarationKind])]
 /// The contents of a declaration
 struct Declaration {
     /// The name of the declared symbol.

--- a/crates/conjure_core/src/ast/literals.rs
+++ b/crates/conjure_core/src/ast/literals.rs
@@ -18,7 +18,7 @@ use super::{ReturnType, SetAttr, Typeable};
 #[biplate(to=Atom)]
 #[biplate(to=AbstractLiteral<Literal>)]
 #[biplate(to=AbstractLiteral<Expression>)]
-#[biplate(to=RecordValue<Literal>,walk_into=[AbstractLiteral<Literal>])]
+#[biplate(to=RecordValue<Literal>)]
 #[biplate(to=RecordValue<Expression>)]
 #[biplate(to=Expression)]
 /// A literal value, equivalent to constants in Conjure.
@@ -521,7 +521,6 @@ impl Display for Literal {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
     use crate::{into_matrix, matrix};
@@ -536,7 +535,7 @@ mod tests {
         ];
 
         let expected_index_domains = vec![Domain::Bool; 6];
-        let actual_index_domains: Vec<Domain> = my_matrix.cata(Arc::new(move |elem, children| {
+        let actual_index_domains: Vec<Domain> = my_matrix.cata(&move |elem, children| {
             let mut res = vec![];
             res.extend(children.into_iter().flatten());
             if let AbstractLiteral::Matrix(_, index_domain) = elem {
@@ -544,7 +543,7 @@ mod tests {
             }
 
             res
-        }));
+        });
 
         assert_eq!(actual_index_domains, expected_index_domains);
     }

--- a/crates/conjure_core/src/ast/matrix.rs
+++ b/crates/conjure_core/src/ast/matrix.rs
@@ -2,7 +2,7 @@
 
 // TODO: Georgiis essence macro would look really nice in these examples!
 
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use itertools::{Itertools, izip};
 use uniplate::Uniplate as _;
@@ -120,24 +120,23 @@ pub fn index_domains(matrix: AbstractLiteral<Literal>) -> Vec<Domain> {
         panic!("matrix should be a matrix");
     };
 
-    matrix.cata(Arc::new(
-        move |element: AbstractLiteral<Literal>, child_index_domains: VecDeque<Vec<Domain>>| {
-            assert!(
-                child_index_domains.iter().all_equal(),
-                "each child of a matrix should have the same index domain"
-            );
+    matrix.cata(&move |element: AbstractLiteral<Literal>,
+                       child_index_domains: VecDeque<Vec<Domain>>| {
+        assert!(
+            child_index_domains.iter().all_equal(),
+            "each child of a matrix should have the same index domain"
+        );
 
-            let child_index_domains = child_index_domains.front().cloned().unwrap_or(vec![]);
-            match element {
-                AbstractLiteral::Set(_) => vec![],
-                AbstractLiteral::Matrix(_, domain) => {
-                    let mut index_domains = vec![*domain];
-                    index_domains.extend(child_index_domains);
-                    index_domains
-                }
-                AbstractLiteral::Tuple(_) => vec![],
-                AbstractLiteral::Record(_) => vec![],
+        let child_index_domains = child_index_domains.front().cloned().unwrap_or(vec![]);
+        match element {
+            AbstractLiteral::Set(_) => vec![],
+            AbstractLiteral::Matrix(_, domain) => {
+                let mut index_domains = vec![*domain];
+                index_domains.extend(child_index_domains);
+                index_domains
             }
-        },
-    ))
+            AbstractLiteral::Tuple(_) => vec![],
+            AbstractLiteral::Record(_) => vec![],
+        }
+    })
 }

--- a/crates/conjure_core/src/ast/model.rs
+++ b/crates/conjure_core/src/ast/model.rs
@@ -230,13 +230,13 @@ impl SerdeModel {
         }
 
         // Swizzle declaration pointers in expressions (references, auxdecls) using their ids and `all_declarations`.
-        *self.submodel.constraints_mut() = self.submodel.constraints().transform_bi(Arc::new(move |decl: DeclarationPtr| {
+        *self.submodel.constraints_mut() = self.submodel.constraints().transform_bi(&move |decl: DeclarationPtr| {
                 let id = decl.id();
                         all_declarations
                             .get(&id)
                             .unwrap_or_else(|| panic!("A declaration used in the expression tree should exist in the symbol table. The missing declaration has id {id}."))
                             .clone()
-        }));
+        });
 
         Some(Model {
             submodel: self.submodel,

--- a/crates/conjure_essence_macros/Cargo.toml
+++ b/crates/conjure_essence_macros/Cargo.toml
@@ -11,7 +11,7 @@ conjure_core = { path = "../conjure_core" }
 conjure_essence_parser = { path = "../conjure_essence_parser" }
 
 tree-sitter = "0.24.7"
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 quote = "1.0.40"
 syn = { version = "2.0.104", features = ["full"] }
 proc-macro2 = "1.0.95"

--- a/crates/conjure_essence_parser/Cargo.toml
+++ b/crates/conjure_essence_parser/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 conjure_core = { path = "../conjure_core" }
 tree-sitter-essence = { path = "../tree-sitter-essence" }
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 tree-sitter = "0.24.7"
 thiserror = "2.0.12"
 

--- a/crates/conjure_rules/Cargo.toml
+++ b/crates/conjure_rules/Cargo.toml
@@ -11,7 +11,7 @@ conjure_core = { path = "../conjure_core" }
 conjure_rule_macros = { path = "../conjure_rule_macros" }
 conjure_essence_macros = { path = "../conjure_essence_macros" }
 
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 linkme = "0.3.33"
 itertools = "0.14.0"
 tracing = "0.1"

--- a/crates/conjure_rules/src/constant_eval.rs
+++ b/crates/conjure_rules/src/constant_eval.rs
@@ -37,7 +37,7 @@ fn constant_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     let has_changed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
     let has_changed_2 = Arc::clone(&has_changed);
 
-    let new_expr = expr.transform_bi(Arc::new(move |x| {
+    let new_expr = expr.transform_bi(&move |x| {
         if let Expr::Atomic(_, Atom::Literal(_)) = x {
             return x;
         }
@@ -53,7 +53,7 @@ fn constant_evaluator(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
             None => x,
         }
-    }));
+    });
 
     if has_changed_2.load(Ordering::Relaxed) {
         Ok(Reduction::pure(new_expr))

--- a/crates/conjure_rules/src/select_representation.rs
+++ b/crates/conjure_rules/src/select_representation.rs
@@ -80,19 +80,19 @@ fn select_representation_matrix(expr: &Expr, symbols: &SymbolTable) -> Applicati
         let old_name_2 = old_name.clone();
         let new_name_2 = new_name.clone();
         let has_changed_ptr = Arc::clone(&has_changed);
-        expr = expr.transform_bi(Arc::new(move |n: Name| {
+        expr = expr.transform_bi(&move |n: Name| {
             if n == old_name_2 {
                 has_changed_ptr.store(true, Ordering::SeqCst);
                 new_name_2.clone()
             } else {
                 n
             }
-        }));
+        });
 
         let has_changed_ptr = Arc::clone(&has_changed);
         let old_name = old_name.clone();
         let new_name = new_name.clone();
-        expr = expr.transform_bi(Arc::new(move |mut x: SubModel| {
+        expr = expr.transform_bi(&move |mut x: SubModel| {
             let old_name = old_name.clone();
             let new_name = new_name.clone();
             let has_changed_ptr = Arc::clone(&has_changed_ptr);
@@ -100,17 +100,17 @@ fn select_representation_matrix(expr: &Expr, symbols: &SymbolTable) -> Applicati
             // only do things if this inscope and not shadowed..
             if x.symbols().lookup(&old_name).is_none_or(|x| x.id() == id) {
                 let root = x.root_mut_unchecked();
-                *root = root.transform_bi(Arc::new(move |n: Name| {
+                *root = root.transform_bi(&move |n: Name| {
                     if n == old_name {
                         has_changed_ptr.store(true, Ordering::SeqCst);
                         new_name.clone()
                     } else {
                         n
                     }
-                }));
+                });
             }
             x
-        }));
+        });
     }
 
     if has_changed.load(Ordering::Relaxed) {

--- a/crates/tree_morph/Cargo.toml
+++ b/crates/tree_morph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multipeek = "0.1.2"
 rand = "0.9.2"
-uniplate = "0.3.0"
+uniplate = "0.4.0"
 
 
 [lints]

--- a/crates/tree_morph/benches/factorial.rs
+++ b/crates/tree_morph/benches/factorial.rs
@@ -6,9 +6,9 @@ use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
-#[uniplate()]
 enum Expr {
     Add(Box<Expr>, Box<Expr>),
     Mul(Box<Expr>, Box<Expr>),

--- a/crates/tree_morph/benches/identity.rs
+++ b/crates/tree_morph/benches/identity.rs
@@ -2,6 +2,7 @@
 ///There is one rule, that does nothing. We create trees of a variable depth.
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/left_add.rs
+++ b/crates/tree_morph/benches/left_add.rs
@@ -3,6 +3,7 @@
 ///
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/left_add_hard.rs
+++ b/crates/tree_morph/benches/left_add_hard.rs
@@ -2,6 +2,7 @@
 ///Good optimisations will meant that this cost is vastly reduced (I am not sure by how much, but I think < +100% makes sense)
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
 #[uniplate()]

--- a/crates/tree_morph/benches/modify_leafs.rs
+++ b/crates/tree_morph/benches/modify_leafs.rs
@@ -3,9 +3,9 @@
 ///This benchmark will assess how efficient tree-updating (which is not done in place) is.
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
-#[uniplate()]
 enum Expr {
     Branch(Box<Expr>, Box<Expr>),
     Val(i32),

--- a/crates/tree_morph/benches/right_add.rs
+++ b/crates/tree_morph/benches/right_add.rs
@@ -3,9 +3,9 @@
 ///
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tree_morph::prelude::*;
+use uniplate::Uniplate;
 
 #[derive(Debug, Clone, PartialEq, Eq, Uniplate)]
-#[uniplate()]
 enum Expr {
     Add(Box<Expr>, Box<Expr>),
     Val(i32),

--- a/crates/tree_morph/src/helpers.rs
+++ b/crates/tree_morph/src/helpers.rs
@@ -7,7 +7,7 @@
 //! which rule to apply. That is, when more than one rule from the same group returns [`Some(...)`]
 //! for a given sub-tree.
 
-use std::{collections::VecDeque, fmt::Display, io::Write, sync::Arc};
+use std::{collections::VecDeque, fmt::Display, io::Write};
 
 use crate::{Rule, Update};
 use multipeek::multipeek;
@@ -173,10 +173,10 @@ where
     R: Rule<T, M>,
 {
     rs.min_by_key(|(_, u)| {
-        u.new_subtree.cata(Arc::new(|_, cs: VecDeque<i32>| {
+        u.new_subtree.cata(&|_, cs: VecDeque<i32>| {
             // Max subtree height + 1
             cs.iter().max().unwrap_or(&0) + 1
-        }))
+        })
     })
     .map(|(_, u)| u)
 }


### PR DESCRIPTION
Update uniplate from 0.3.0 to 0.4.0.

The most important change is that Uniplate automatically determines which types to walk into when deriving a biplate instance, instead of having to specify this using the `walk_into` property. The `walk_into` property has also been removed. I believe that this change is why some test outputs have changed - we probably were missing some types in our `walk_into` lists!

Also, methods that used to take `Arc<dyn Fn()>` as input not take `&impl Fn()` instead.

For more details, see the Uniplate changelogs.
