### PR TITLE
fix: possibly fix nightly ci failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Save builds
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.release_prefix }}
+          name: artifact-${{ env.release_prefix }}
           path: dist/*.zip
 
   build_nightly_linux:
@@ -333,7 +333,7 @@ jobs:
       - name: Save builds
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.release_prefix }}
+          name: artifact-${{ env.release_prefix }}
           path: dist/*.zip
 
   create_release:
@@ -347,11 +347,13 @@ jobs:
       - run: mkdir dist
 
       # download all artifacts made in this workflow (i.e. all the different builds)
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           merge-multiple: true # put all releases in the same folder
           path: dist/
-
+          pattern: artifact-*
+  
+          
       - name: Publish nightly release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Possibly fix nightly CI failure

This seems to be this bug: https://github.com/actions/download-artifact/issues/367

Trying to fix this by filtering out any artifact junk docker makes, as per this commit https://github.com/scylladb/scylla-cqlsh/commit/2d388cd2db3c8f9fce52125a44824865e557e0a1