### PR TITLE
refactor(ast): remove Atom::new_ilit()

### DIFF
--- a/conjure_oxide/tests/essence_macro_tests/mod.rs
+++ b/conjure_oxide/tests/essence_macro_tests/mod.rs
@@ -1,4 +1,4 @@
-use conjure_cp_core::ast::{Atom, Expression, Moo};
+use conjure_cp_core::ast::{Expression, Moo};
 use conjure_cp_core::matrix_expr;
 use conjure_oxide::{Metadata, essence_expr};
 
@@ -10,29 +10,34 @@ fn test_2plus2() {
         Expression::Sum(
             Metadata::new(),
             Moo::new(matrix_expr![
-                Expression::Atomic(Metadata::new(), Atom::new_ilit(2)),
-                Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+                Expression::Atomic(Metadata::new(), 2.into()),
+                Expression::Atomic(Metadata::new(), 2.into())
             ])
         )
     );
 }
 
-// #[test]
-// fn test_metavar_const() {
-//     let x = 4;
-//     let expr = essence_expr!(&x + 2);
-//     assert_eq!(
-//         expr,
-//         Expression::Sum(
-//             Metadata::new(),
-//             Box::new(matrix_expr![
-//                 Expression::Atomic(Metadata::new(), Atom::new_ilit(4)),
-//                 Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
-//             ])
-//         )
-//     );
-// }
+#[test]
+fn test_metavar_const() {
+    let x = 4;
+    let expr = essence_expr!(&x + 2);
+    assert_eq!(
+        expr,
+        Expression::Sum(
+            Metadata::new(),
+            Moo::new(matrix_expr![
+                Expression::Atomic(Metadata::new(), 4.into()),
+                Expression::Atomic(Metadata::new(), 2.into())
+            ])
+        )
+    );
+}
 
+// TODO (gs248): We need to be able to generate Atom::Reference via the essence_expr! macro.
+// These used to just be a string (variable name). Now, they are a pointer to Declaration.
+// Thus we need to be able to pass the symbol table into the macro when working with references.
+// Needs design + implementation.
+//
 // #[test]
 // fn test_such_that() {
 //     let expr = essence_expr!(x + 2 > y);
@@ -44,126 +49,10 @@ fn test_2plus2() {
 //                 Metadata::new(),
 //                 Box::new(matrix_expr![
 //                     Expression::Atomic(Metadata::new(), Atom::new_uref("x")),
-//                     Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+//                     Expression::Atomic(Metadata::new(), 2.into())
 //                 ])
 //             )),
 //             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("y")))
 //         )
 //     );
-// }
-
-// #[test]
-// fn test_alldiff() {
-//     let expr = essence_expr!(
-//         // Comments work!
-//         allDiff([a, b, c])
-//     );
-//     assert_eq!(
-//         expr,
-//         Expression::AllDiff(
-//             Metadata::new(),
-//             Box::new(matrix_expr![
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("b")),
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("c")),
-//             ])
-//         )
-//     )
-// }
-
-// #[test]
-// fn test_and() {
-//     let expr = essence_expr!("a /\\ b");
-//     assert_eq!(
-//         expr,
-//         Expression::And(
-//             Metadata::new(),
-//             Box::new(matrix_expr![
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("b")),
-//             ])
-//         )
-//     )
-// }
-
-// #[test]
-// fn text_leq_meta() {
-//     let meta = essence_expr!(a + 2);
-//     let expr = essence_expr!(x <= &meta);
-//     assert_eq!(
-//         expr,
-//         Expression::Leq(
-//             Metadata::new(),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("x"))),
-//             Box::new(Expression::Sum(
-//                 Metadata::new(),
-//                 Box::new(matrix_expr![
-//                     Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
-//                     Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
-//                 ])
-//             )),
-//         )
-//     );
-// }
-
-// #[test]
-// fn test_essence_vec_basic() {
-//     let exprs = essence_vec!(a + 2, b = true);
-//     assert_eq!(exprs.len(), 2);
-//     assert_eq!(
-//         exprs[0],
-//         Expression::Sum(
-//             Metadata::new(),
-//             Box::new(matrix_expr![
-//                 Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
-//                 Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
-//             ])
-//         )
-//     );
-//     assert_eq!(
-//         exprs[1],
-//         Expression::Eq(
-//             Metadata::new(),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b"))),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
-//         )
-//     );
-// }
-
-// #[test]
-// fn test_essence_vec() {
-//     let exprs = essence_vec!(r"(x /\ y) -> true, |a / |b|| = 42");
-//     assert_eq!(exprs.len(), 2);
-//     assert_eq!(
-//         exprs[0],
-//         Expression::Imply(
-//             Metadata::new(),
-//             Box::new(Expression::And(
-//                 Metadata::new(),
-//                 Box::new(matrix_expr![
-//                     Expression::Atomic(Metadata::new(), Atom::new_uref("x")),
-//                     Expression::Atomic(Metadata::new(), Atom::new_uref("y")),
-//                 ])
-//             )),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
-//         )
-//     );
-//     assert_eq!(
-//         exprs[1],
-//         Expression::Eq(
-//             Metadata::new(),
-//             Box::new(Expression::Abs(
-//                 Metadata::new(),
-//                 Box::new(Expression::UnsafeDiv(
-//                     Metadata::new(),
-//                     Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("a"))),
-//                     Box::new(Expression::Abs(
-//                         Metadata::new(),
-//                         Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b")))
-//                     ))
-//                 ))
-//             )),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_ilit(42)))
-//         )
-//     )
 // }

--- a/crates/conjure-cp-core/src/ast/atom.rs
+++ b/crates/conjure-cp-core/src/ast/atom.rs
@@ -40,16 +40,6 @@ impl Atom {
             _ => panic!("Called into_declaration on a non-reference Atom"),
         }
     }
-
-    /// Shorthand to create an integer literal.
-    pub fn new_ilit(value: i32) -> Atom {
-        Atom::Literal(Literal::Int(value))
-    }
-
-    /// Shorthand to create a boolean literal.
-    pub fn new_blit(value: bool) -> Atom {
-        Atom::Literal(Literal::Bool(value))
-    }
 }
 
 impl CategoryOf for Atom {

--- a/crates/conjure-cp-essence-macros/src/lib.rs
+++ b/crates/conjure-cp-essence-macros/src/lib.rs
@@ -50,21 +50,21 @@ pub fn essence_expr(args: TokenStream) -> TokenStream {
 /// use conjure_cp_core::metadata::Metadata;
 /// use conjure_cp_essence_macros::essence_vec;
 ///
-/// let exprs = essence_vec!(a + 2, b = true);
+/// let exprs = essence_vec!(2 + 2, false = true);
 /// println!("{:?}", exprs);
 /// assert_eq!(exprs.len(), 2);
 /// assert_eq!(
 ///     exprs[0],
 ///     Expression::Sum(Metadata::new(), Moo::new(matrix_expr![
-///         Expression::Atomic(Metadata::new(), Atom::new_uref("a")),
-///         Expression::Atomic(Metadata::new(), Atom::new_ilit(2))
+///         Expression::Atomic(Metadata::new(), 2.into()),
+///         Expression::Atomic(Metadata::new(), 2.into())
 ///     ]))
 /// );
 /// assert_eq!(
 ///    exprs[1],
 ///     Expression::Eq(Metadata::new(),
-///         Moo::new(Expression::Atomic(Metadata::new(), Atom::new_uref("b"))),
-///         Moo::new(Expression::Atomic(Metadata::new(), Atom::new_blit(true)))
+///         Moo::new(Expression::Atomic(Metadata::new(), false.into())),
+///         Moo::new(Expression::Atomic(Metadata::new(), true.into()))
 ///     )
 /// );
 /// ```


### PR DESCRIPTION
Remove `Atom::new_ilit()` / `Atom::new_blit()` as they are not necessary now that we have a proper `From` implementation. Also remove some commented out macro tests.