### PR TITLE
refactor(parser, macros): improve parser errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ name = "conjure-cp-essence-parser"
 version = "0.1.0"
 dependencies = [
  "conjure-cp-core",
+ "serde_json",
  "thiserror",
  "tree-sitter",
  "tree-sitter-essence",

--- a/crates/conjure-cp-cli/src/solve.rs
+++ b/crates/conjure-cp-cli/src/solve.rs
@@ -179,7 +179,7 @@ pub(crate) fn parse(
 
     tracing::info!(target: "file", "Input file: {}", input_file);
     if global_args.use_native_parser {
-        parse_essence_file_native(input_file.as_str(), context.clone()).map_err(|e| anyhow!(e))
+        parse_essence_file_native(input_file.as_str(), context.clone()).map_err(|e| e.into())
     } else {
         conjure_executable()
             .map_err(|e| anyhow!("Could not find correct conjure executable: {}", e))?;

--- a/crates/conjure-cp-essence-macros/src/expand.rs
+++ b/crates/conjure-cp-essence-macros/src/expand.rs
@@ -1,5 +1,8 @@
 use super::expression::parse_expr_to_ts;
-use conjure_cp_essence_parser::util::{get_tree, query_toplevel};
+use conjure_cp_essence_parser::{
+    EssenceParseError,
+    util::{get_tree, query_toplevel},
+};
 use proc_macro2::{TokenStream, TokenTree};
 use quote::{ToTokens, quote};
 use syn::{Error, LitStr, Result};
@@ -53,8 +56,37 @@ fn mk_expr(node: Node, src: &str, root: &Node, tt: &TokenTree) -> Result<TokenSt
     match parse_expr_to_ts(node, src, root) {
         Ok(expr) => Ok(expr),
         Err(err) => {
-            let msg = format!("Error parsing Essence expression: {err}");
-            Err(Error::new(tt.span(), msg))
+            let error_message = match err {
+                EssenceParseError::SyntaxError {
+                    msg,
+                    range: Some(rng),
+                } => {
+                    let lines: Vec<&str> = src.lines().collect();
+                    let start_line = rng.start_point.row;
+                    let mut start_col = rng.start_point.column;
+
+                    let mut line_content = lines
+                        .get(start_line)
+                        .unwrap_or(&"<line not found>")
+                        .trim()
+                        .to_string();
+                    if line_content.starts_with("such that") {
+                        let len = "such that".len();
+                        line_content = line_content[len..].trim_start().to_string();
+                        start_col -= len;
+                    }
+
+                    format!(
+                        "Syntax error: {}\n{}\n{}^-- Error here",
+                        msg,
+                        line_content,
+                        " ".repeat(start_col)
+                    )
+                }
+                _ => err.to_string(),
+            };
+
+            Err(Error::new(tt.span(), error_message))
         }
     }
 }

--- a/crates/conjure-cp-essence-parser/Cargo.toml
+++ b/crates/conjure-cp-essence-parser/Cargo.toml
@@ -10,7 +10,7 @@ tree-sitter-essence = { path = "../tree-sitter-essence" }
 uniplate = {workspace = true}
 tree-sitter = {workspace = true}
 thiserror = {workspace = true}
-
+serde_json = {workspace = true}
 
 [lints]
 workspace = true

--- a/crates/conjure-cp-essence-parser/src/errors.rs
+++ b/crates/conjure-cp-essence-parser/src/errors.rs
@@ -1,36 +1,45 @@
 pub use conjure_cp_core::error::Error as ConjureParseError;
+use conjure_cp_core::error::Error;
+use serde_json::Error as JsonError;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]
 pub enum EssenceParseError {
     #[error("Could not parse Essence AST: {0}")]
     TreeSitterError(String),
-    #[error("Error running conjure pretty: {0}")]
+    #[error("Error running `conjure pretty`: {0}")]
     ConjurePrettyError(String),
-    #[error("Error running conjure solve: {0}")]
-    ConjureSolveError(String),
-    #[error("Error parsing essence file: {0}")]
-    ParseError(ConjureParseError),
-    #[error("Error parsing Conjure solutions file: {0}")]
-    ConjureSolutionsError(String),
-    #[error("No solutions file for {0}")]
-    ConjureNoSolutionsFile(String),
+    #[error("Essence syntax error: {msg}{}",
+        match range {
+            Some(range) => format!(" at {}-{}", range.start_point, range.end_point),
+            None => "".to_string(),
+        }
+    )]
+    SyntaxError {
+        msg: String,
+        range: Option<tree_sitter::Range>,
+    },
+    #[error("JSON Error: {0}")]
+    JsonError(#[from] JsonError),
+    #[error("Error: {0} is not yet implemented.")]
+    NotImplemented(String),
+    #[error("Error: {0}")]
+    Other(Error),
+}
+
+impl EssenceParseError {
+    pub fn syntax_error(msg: String, range: Option<tree_sitter::Range>) -> Self {
+        EssenceParseError::SyntaxError { msg, range }
+    }
 }
 
 impl From<ConjureParseError> for EssenceParseError {
-    fn from(e: ConjureParseError) -> Self {
-        EssenceParseError::ParseError(e)
-    }
-}
-
-impl From<&str> for EssenceParseError {
-    fn from(e: &str) -> Self {
-        EssenceParseError::ParseError(ConjureParseError::Parse(e.to_string()))
-    }
-}
-
-impl From<String> for EssenceParseError {
-    fn from(e: String) -> Self {
-        EssenceParseError::ParseError(ConjureParseError::Parse(e))
+    fn from(value: ConjureParseError) -> Self {
+        match value {
+            Error::Parse(msg) => EssenceParseError::syntax_error(msg, None),
+            Error::NotImplemented(msg) => EssenceParseError::NotImplemented(msg),
+            Error::Json(err) => EssenceParseError::JsonError(err),
+            Error::Other(err) => EssenceParseError::Other(err.into()),
+        }
     }
 }

--- a/crates/conjure-cp-essence-parser/src/parser/parse_exprs.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/parse_exprs.rs
@@ -1,6 +1,5 @@
 use crate::errors::EssenceParseError;
 use conjure_cp_core::ast::{Expression, SymbolTable};
-use conjure_cp_core::error::Error;
 #[allow(unused)]
 use uniplate::Uniplate;
 
@@ -10,9 +9,10 @@ use super::util::{get_tree, query_toplevel};
 pub fn parse_expr(src: &str, symbol_table: &SymbolTable) -> Result<Expression, EssenceParseError> {
     let exprs = parse_exprs(src, symbol_table)?;
     if exprs.len() != 1 {
-        return Err(EssenceParseError::ParseError(Error::Parse(
-            "Expected exactly one expression".into(),
-        )));
+        return Err(EssenceParseError::syntax_error(
+            "Expected a single expression".to_string(),
+            None,
+        ));
     }
     Ok(exprs[0].clone())
 }

--- a/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
@@ -6,7 +6,6 @@ use conjure_cp_core::ast::Expression;
 use conjure_cp_core::ast::Metadata;
 use conjure_cp_core::ast::{DeclarationPtr, Moo};
 use conjure_cp_core::context::Context;
-use conjure_cp_core::error::Error;
 #[allow(unused)]
 use uniplate::Uniplate;
 
@@ -84,17 +83,19 @@ pub fn parse_essence_with_context(
                 let expr = parse_expression(inner, &source_code, &statement, &current_symbols)?;
                 let dominance = Expression::DominanceRelation(Metadata::new(), Moo::new(expr));
                 if model.dominance.is_some() {
-                    return Err(EssenceParseError::ParseError(Error::Parse(
-                        "Duplicate dominance relation".to_owned(),
-                    )));
+                    return Err(EssenceParseError::syntax_error(
+                        "Duplicate dominance relation".to_string(),
+                        None,
+                    ));
                 }
                 model.dominance = Some(dominance);
             }
             _ => {
                 let kind = statement.kind();
-                return Err(EssenceParseError::ParseError(Error::Parse(format!(
-                    "Unrecognized top level statement kind: {kind}"
-                ))));
+                return Err(EssenceParseError::syntax_error(
+                    format!("Unrecognized top level statement kind: {kind}"),
+                    None,
+                ));
             }
         }
     }

--- a/crates/conjure-cp/tests/essence_macro_tests.rs
+++ b/crates/conjure-cp/tests/essence_macro_tests.rs
@@ -1,5 +1,5 @@
 use conjure_cp::ast::Metadata;
-use conjure_cp::ast::{Atom, Expression, Moo};
+use conjure_cp::ast::{Expression, Moo};
 use conjure_cp::essence_expr;
 use conjure_cp::matrix_expr;
 
@@ -33,27 +33,3 @@ fn test_metavar_const() {
         )
     );
 }
-
-// TODO (gs248): We need to be able to generate Atom::Reference via the essence_expr! macro.
-// These used to just be a string (variable name). Now, they are a pointer to Declaration.
-// Thus we need to be able to pass the symbol table into the macro when working with references.
-// Needs design + implementation.
-//
-// #[test]
-// fn test_such_that() {
-//     let expr = essence_expr!(x + 2 > y);
-//     assert_eq!(
-//         expr,
-//         Expression::Gt(
-//             Metadata::new(),
-//             Box::new(Expression::Sum(
-//                 Metadata::new(),
-//                 Box::new(matrix_expr![
-//                     Expression::Atomic(Metadata::new(), Atom::new_uref("x")),
-//                     Expression::Atomic(Metadata::new(), 2.into())
-//                 ])
-//             )),
-//             Box::new(Expression::Atomic(Metadata::new(), Atom::new_uref("y")))
-//         )
-//     );
-// }

--- a/tests-integration/tests/integration_tests.rs
+++ b/tests-integration/tests/integration_tests.rs
@@ -41,7 +41,7 @@ use conjure_cp_cli::utils::testing::save_stats_json;
 use conjure_cp_cli::utils::testing::{
     read_model_json, read_solutions_json, save_model_json, save_solutions_json,
 };
-#[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports, unused_imports)]
 use conjure_cp_rules;
 use pretty_assertions::assert_eq;
 use serde::Deserialize;


### PR DESCRIPTION
Previously, the error messages produced by the parser (and, consequently, the essence macros) were not very helpful.

For example:
<img width="1157" height="195" alt="image" src="https://github.com/user-attachments/assets/f19f8c7c-6d46-4c49-aa1e-742a738acee0" />

There was also an `.unwrap()` in one of the match arms that caused the macro to panic with no proper error message at all
<img width="1006" height="205" alt="Screenshot From 2025-09-20 01-35-43" src="https://github.com/user-attachments/assets/2aabf9f9-a102-4122-9512-b730ee19414e" />

This patch refactors the `EssenceParseError` enum:
-  Instead of wrapping `conjure-cp-core::Error` in one of its variants, it implements `From<conjure-cp-core::Error>`.
   This avoids the "nested" error messages seen above
- The `SyntaxError` variant (previously `ParseError`) contains an optional range pinpointing the problematic expression

Error handling in the essence macro has also been improved slightly

With these changes, we can now produce semi-useful compiler errors like:
<img width="1149" height="244" alt="Screenshot From 2025-09-20 01-28-08" src="https://github.com/user-attachments/assets/af2ac924-28bc-41f6-919d-a693217aa750" />

