### PR TITLE
hotfix: trim whitespace in metavars

### DIFF
--- a/crates/conjure-cp-essence-parser/src/parser/expression.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/expression.rs
@@ -287,7 +287,10 @@ pub fn parse_expression(
                     "Meta-variable must start with '&'".to_string(),
                     Some(constraint.range()),
                 ))?;
-            Ok(Expression::Metavar(Metadata::new(), Ustr::from(text)))
+            Ok(Expression::Metavar(
+                Metadata::new(),
+                Ustr::from(text.trim()),
+            ))
         }
         "ERROR" => Err(EssenceParseError::syntax_error(
             format!(


### PR DESCRIPTION
For some names, `essence_expr!(&my_metavar)` seemed to get parsed as `" my_metavar"` when expanding macros, leading to invalid code.
For some reason, this only affected the "expand macro" action in the IDE, but did not seem to stop the entire project from compiling. (Possibly something specific to `rust-analyzer` or an environment issue).
This just adds an extra `.trim()` to ensure the metavar name never has any leading/trailing whitespace