### PR TITLE
chore(.gitignore): add target symlink to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tests-integration/tests/*.png
 ## Rust
 debug/
 target/
+target
 
 ## C++
 solvers/**/vendor/build


### PR DESCRIPTION
This links to the post I made on Teams:

```
Hey! A couple of people were running into the problem of quota exceeded with conjure-oxide. One of the reasons could be that the target in the root of conjure-oxide folder is getting into snapshot. Shikhar Srivastava solution to that was to create a symlink to some folder that is not getting saved (e.g Downloads). 
 
That's what I've done
 
~Documents/VIP/conjure-oxide $ ln -sf /cs/home/yb33/Downloads/ ./target
```

