### PR TITLE
minor: Plug polyquine in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following projects are used by, and developed alongside, `conjure-oxide`,
 but are kept in their own repositories:
 
 - [`uniplate`](https://github.com/conjure-cp/uniplate)
-
+- [`polyquine`](https://github.com/gskorokhod/polyquine)
 
 ## Licence
 


### PR DESCRIPTION
## Description

Plug polyquine in README. It is used in the macros, so may be of interest to anyone who ends up working on the macro code!

## Related Issues

N/A

## Key Changes

- link to polyquine added to README

## How to Test

N/A