### PR TITLE
Tightening Rules on Included Macros

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -69,6 +69,7 @@ export LLVM_PROFILE_FILE='conjure-oxide-%p-%m.profraw'
 GRCOV_EXCLUDE_LINES=(
   'consider covered'
   'bug!'
+  '#\[derive'
   '#\[register_rule'
   'register_rule_set!'
 )


### PR DESCRIPTION
## Description
This PR aims to better define which macros we wish to include in our coverage testing.
The given example is the Derive macro, which creates new functions that do not need tested, yet get counted in the overall coverage score.

## Related Issues
This PR is related to issue #1101 and discussion #1086

## Key Changes
- Added the derive macro to GRCOV_EXCLUDE_LINES in `tools/coverage.sh`

## How to Test
Run `tools/coverage.sh` and note what is included in GRCOV_EXCLUDE_LINES