### PR TITLE
 fix(ci): fix remaining failures due to references to the `conjure_oxide` crate

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - crates/**
       - tests-integration/**
-      - conjure_oxide/tests/**
       - tools/coverage.sh
       - .github/workflows/code-coverage.yml
   workflow_dispatch:

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -14,7 +14,6 @@ on:
       - crates/**
       - tests-integration/**
       - Cargo.*
-      - conjure_oxide/tests/**
       - .github/workflows/hygiene.yml
   workflow_dispatch:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,9 +254,9 @@ jobs:
 
       - name: Build release
         run: |
-          cargo build --release -p conjure_oxide
+          cargo build --release -p conjure-cp-cli 
           mkdir -p bin # place to store all the different stuff we want to add to the release
-          cp target/release/conjure_oxide bin
+          cp target/release/conjure-oxide bin
 
       - name: Download Conjure release
         if: ${{ !(matrix.arch_name == 'aarch64' && matrix.os_name == 'linux-gnu') }}
@@ -274,8 +274,8 @@ jobs:
           mkdir dist
 
           cd bin
-          zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure_oxide
-          zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure_oxide conjure
+          zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure-oxide
+          zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure-oxide conjure
           zip "../dist/${{ env.release_prefix }}-with-solvers.zip" *
           cd ..
 
@@ -306,9 +306,9 @@ jobs:
 
       - name: Build release
         run: |
-          cargo build --release -p conjure_oxide
+          cargo build --release -p conjure-cp-cli
           mkdir -p bin # place to store all the different stuff we want to add to the release
-          cp target/release/conjure_oxide bin
+          cp target/release/conjure-oxide bin
 
       - name: Download Conjure release
         run: |
@@ -325,8 +325,8 @@ jobs:
           mkdir dist
 
           cd bin
-          zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure_oxide
-          zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure_oxide conjure
+          zip "../dist/${{ env.release_prefix }}-standalone.zip" conjure-oxide
+          zip "../dist/${{ env.release_prefix }}-with-conjure.zip" conjure-oxide conjure
           zip "../dist/${{ env.release_prefix }}-with-solvers.zip" *
           cd ..
 


### PR DESCRIPTION
Fix remaining CI failures caused by workflows referencing the
`conjure_oxide` crate that no longer exists.

Closes: https://github.com/conjure-cp/conjure-oxide/issues/1013