### PR TITLE
feat(ci): Add rust-toolchain support to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,20 @@ updates:
       - "dependencies"
       - "dependencies::rust"
 
+  - package-ecosystem: rust-toolchain
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - ozgurakgun
+    groups:
+      all:
+        patterns:
+          - '*'
+    labels:
+      - "dependencies"
+      - "dependencies::rust"
+
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:


### PR DESCRIPTION
## Description

Get dependabot to also check rust-toolchain updates

## Related Issues

This doesn't address why #1137 slipped through, but keeping the toolchain file up to date is probably a good idea regardless. 

