### PR TITLE
fix(minion-sys): fix submodule initialisation in build scripts

### DIFF
--- a/crates/minion-sys/build.sh
+++ b/crates/minion-sys/build.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 
+set -e
 set -x
 
 SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
 cd "$SCRIPT_DIR"
 
-
-cd "$SCRIPT_DIR"
-
-git submodule init -- vendor 
-git submodule sync -- vendor 
-git submodule update --init --recursive -- vendor 
+git submodule update --init --recursive --remote -- vendor
 
 if [[ -z "$OUT_DIR" ]]; then
   echo "OUT_DIR env variable does not exist - did you run this script through cargo build?"


### PR DESCRIPTION
Fix submodule not initializing properly when first building minion-sys, and remove unnecessary submodule commands.

Submodule initialisation was failing because `--remote` was not given to `git submodule update` in the build script, so the contents of the minion submodule were never fetched.

Add `set -e` to the build script so that the bash script exits on errors, making diagnosing issues such as this easier in the future.

Test: clone a fresh copy of the repo and run `cargo build -p minion-sys`
