### PR TITLE
Add single-commit option to code coverage action

### DIFF
--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -103,4 +103,5 @@ jobs:
           folder: ./deploy
           target-folder: "coverage/main"
           branch: gh-pages
+          single-commit: true
           commit-message: "Actions: Update code coverage for main "


### PR DESCRIPTION
## Description

Currently there is a disk space error for the gh-pages branch during code-coverage-deployment. The single-commit option apparently will squash the history. Let's see if it helps. We might have to manually edit git history on the gh-pages branch even if this helps in the future...

