### PR TITLE
Minor: Update Contributing.md to reflect fork-procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ For information on how to set up your environment, go to the [Contributor's Guid
 ## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), so All Code Changes Happen Through Pull Requests
 Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
 
-1. Make a fork.
-2. Create a branch on your fork, do not develop on main.
+1. Do **not** make a fork, create a branch for your feature on the `conjure-cp/conjure-oxide` repository (can be done directly through GH issues)
+2. Create a branch, do not develop on main.
 3. Create a pull request as soon as you want others to be able to see your progress, comment, and/or help. Err on the side of creating the pull request too early instead of too late. Having an active PR makes your work visible, allows others to help you and give feedback. Request reviews from people who have worked on similar parts of the project.
 4. Keep the PR in draft status until you think it's ready to be merged.
 5. Assign PR to reviewer(s) when it's ready to be merged.


### PR DESCRIPTION
## Description
Minor update to the contributing instructions. This is regarding @ozgurakgun 's comment:

> Hi! I don't think this is communicated properly with everyone, so definitely not your fault, but if you create a branch inside this repo instead of in a fork CI does a bit more for you. Specifically, it posts coverage stats as a comment to the PR.

## Related Issues
- Oz mentioned this in #1119  (his [comment](https://github.com/conjure-cp/conjure-oxide/pull/1119#issuecomment-3424650842))

## Key Changes
- Don't create a fork, develop on the conjure-cp/conjure-oxide repo