### PR TITLE
feat(ci): add action to enforce semantic PR title

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,26 @@
+name: 'Lint PR'
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore


### PR DESCRIPTION
## Description
This PR introduces CI action that would disallow PR titles that don't comply with conventional format described by [this gist](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) (+ we allow commits starting with "Merge").
<!-- what does this PR do? a quick summary of changes. -->

## Key Changes
- `pr-semantic-title.yml` An action that disallow non-semantic title

## How to Test
Check [this action run](https://github.com/conjure-cp/conjure-oxide/actions/runs/18870019067/job/53845981391?pr=1099). It failed on non-semantic PR title.

You can also change the title of this PR and check whether it works (I promise it does)