### PR TITLE
test: intermittent build failures

### DIFF
--- a/.github/workflows/ci-treesitter.yml
+++ b/.github/workflows/ci-treesitter.yml
@@ -10,9 +10,6 @@ on:
       - crates/tree-sitter-essence/**
   
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 5
   CARGO_INCREMENTAL: "0"
   # we define the following 3 values as the defaults here, matrix jobs may overwrite their values.
   # os: ubuntu-latest # commented out here as it is always defined in matrix jobs
@@ -46,9 +43,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ matrix.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v2

--- a/.github/workflows/code-coverage-main.yml
+++ b/.github/workflows/code-coverage-main.yml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 2
   CARGO_INCREMENTAL: "0"
   # we define the following 3 values as the defaults here, matrix jobs may overwrite their values.
   os: ubuntu-latest
@@ -31,10 +28,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Install rust ${{ env.rust_release }}
         run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}
 
@@ -76,9 +69,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install rust ${{ env.rust_release }}
         run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 5
   CARGO_INCREMENTAL: "0"
   # we define the following 3 values as the defaults here, matrix jobs may overwrite their values.
   os: ubuntu-latest
@@ -34,9 +31,6 @@ jobs:
           prefix-key: conjure-oxide
           cache-on-failure: true
           shared-key: ${{ matrix.os }}--${{ matrix.rust_release }}--${{ matrix.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Install rust ${{ env.rust_release }}
         run: rustup update ${{ env.rust_release }} && rustup default ${{ env.rust_release }}

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -20,9 +20,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 5
   CARGO_INCREMENTAL: "0"
   # we define the following 3 values as the defaults here, matrix jobs may overwrite their values.
   os: ubuntu-latest
@@ -44,8 +41,5 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - run: make EXTRA_CARGO_CHECK_FLAGS=-v check

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 5
   CARGO_INCREMENTAL: "0"
   # we define these in the env if they are not defined as matrix parameters
   os: ubuntu-latest
@@ -34,9 +31,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Get Sha
         id: sha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-  SCCACHE_GHA_VERSION: 5
   CARGO_INCREMENTAL: "0"
   # we define the following 3 values as the defaults here, matrix jobs may overwrite their values.
   os: ubuntu-latest
@@ -69,9 +66,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ matrix.os }}--${{ matrix.rust_release }}--${{ matrix.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Override RUSTUP_TOOLCHAIN to nightly when we are testing with nightly
       # This value is read from the rust-toolchain.toml file otherwise
@@ -126,9 +120,6 @@ jobs:
           cache-on-failure: true
           shared-key: ${{ matrix.os }}--${{ matrix.rust_release }}--${{ env.compiler_profile }}
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       # Override RUSTUP_TOOLCHAIN to nightly when we are testing with nightly
       # This value is read from the rust-toolchain.toml file otherwise
       - name: Set RUSTUP_TOOLCHAIN
@@ -161,9 +152,6 @@ jobs:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ matrix.rust_release }}--${{ env.compiler_profile }}
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - run: rustup update ${{ matrix.rust_release }} && rustup default ${{ matrix.rust_release }}
 
       - run: cargo install cargo-audit
@@ -184,10 +172,6 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: ${{ env.os }}--${{ env.rust_release }}--${{ env.compiler_profile }}
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
       - name: Install cargo-shear
         run: cargo +nightly install cargo-shear
 


### PR DESCRIPTION
## Description
According to Oz, there has been a series of intermittent build failures and dependency bump failures across the CI Pipeline. One of the posible causes of this issue could be the `sscache` across Github Actions.

Therefore, this PR intends to test the impact of the removal of sccache across some CI workflows and to determine whether it might be the leading cause of the issues or not.

## Related Issues
Closes #1180

## Key Changes
- Removed all usages of `sccache` from all CI Workflows.

## How to Test
N/A