### PR TITLE
feat(ast): support basic destructuring of collections (`x <- <expr>` syntax)

### DIFF
--- a/crates/conjure-cp-core/src/ast/submodel.rs
+++ b/crates/conjure-cp-core/src/ast/submodel.rs
@@ -230,6 +230,9 @@ impl Display for SubModel {
                 DeclarationKind::Given(d) => {
                     writeln!(f, "given {name}: {d}")?;
                 }
+                DeclarationKind::ElementsOf(expr) => {
+                    writeln!(f, "{name} <- {expr}")?;
+                }
 
                 DeclarationKind::RecordField(_) => {
                     // Do not print a record field as it is an internal type


### PR DESCRIPTION
## Description

Adds support for basic comprehensions over the elements of a collection, e.g:

```
[x > 2 | x <- {1,2,3}]
```

Including cases where the right hand side is an `Expression` which evaluates to a collection:

```
letting S be {3, 4, 5}
[x > 2 | x <- ({1,2,3} /\ S)]
```

## Related Issues

Closes #1157 

## Key Changes

This PR:

- [x] Adds a new variant `DeclarationKind::ElementsOf(Expression)` to represent the Essence `x <- <expr>` syntax in the symbol table
- [ ] Updates `ComprehensionBuilder` to support the `[... | x <- <expr>, ...]` syntax using this new variant
- [ ] Adds rules for unrolling destructures of collections

## How to Test

Unit tests for the new code will be added before this draft PR is ready to merge