### PR TITLE
fix(ci): remove macos-intel support (closes #837)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -224,16 +224,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13         # x86_64 mac
           - macos-latest     # aarch64 mac
 
         # platform and arch info for naming the binary
         include:
-          - os: macos-13
-            os_name: darwin
-            arch_name: x86_64
-            conjure_prefix: macos-intel
-
           - os: macos-latest
             os_name: darwin
             arch_name: aarch64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           - os: ubuntu-latest
             release_suffix: linux
           - os: macos-latest
-            release_suffix: macos-intel
+            release_suffix: macos-arm
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Description

See #837

We could also remove the matrix in the `build_nightly_mac` job since it now has a single configuration in the matrix, though that's not necessarily bad...