### PR TITLE
fix: unnecessary rebuilds caused by Rust Analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.targetDir": true
+}


### PR DESCRIPTION
Before this patch, on some people's development setups, rust-analyzer
and building rust in the commandline would invalidate eachothers build
caches, causing lots of unnecessary rebuilds of dependencies. For
example, often editing conjure-cp-core would cause the rebuild of all
its dependent crates.

This was especially a problem, as z3 and minion-sys would be triggered
for recompilation, and these take a long time to recompile! (see #1176)

Fix this by making Rust-analyzer use a its own target directory. This
also removes file-locking issues, allowing commandline rust tools (cargo
test, bacon, etc) to be used while VSCode is running cargo check.

This only fixes the issue for VSCode, and neovim users using
rustacean-nvim (as this plugin reads settings.json). However, the
setting added is a rust-analyzer one, so should be addable to any editor.

I'll leave adding the editor specific config to enable this setting for
other editors to anyone who uses those. However, with this patch we
cover the vast majority of editors people use.

Testing
-------

Tested working by Liz and Shikhar on VSCode.

CC: @gskorokhod, you might want to add the rust-rover configuration for
    this.
See: https://rust-analyzer.github.io/book/faq.html#rust-analyzer-and-cargo-compete-over-the-build-lock
Issue: https://github.com/conjure-cp/conjure-oxide/issues/1176
Co-authored-by: @Shikhar-Srivastava-16
Co-authored-by: @EEJDempster
