### PR TITLE
refactor: move representation rules to their own rule set

### DIFF
--- a/crates/conjure-cp-rules/src/select_representation.rs
+++ b/crates/conjure-cp-rules/src/select_representation.rs
@@ -1,21 +1,29 @@
 use conjure_cp::{
-    ast::Metadata,
-    ast::{Atom, Domain, Expression as Expr, Name, SubModel, SymbolTable, serde::HasId},
+    ast::{Atom, Domain, Expression as Expr, Metadata, Name, SubModel, SymbolTable, serde::HasId},
     bug,
     representation::Representation,
     rule_engine::{
         ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
+        register_rule_set,
     },
+    solver::SolverFamily,
 };
 use itertools::Itertools;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use uniplate::Biplate;
+
+register_rule_set!(
+    "Representations",
+    ("Base"),
+    (SolverFamily::Sat, SolverFamily::Minion)
+);
+
 // special case rule to select representations for matrices in one go.
 //
 // we know that they only have one possible representation, so this rule adds a representation for all matrices in the model.
-#[register_rule(("Base", 8001))]
+#[register_rule(("Representations", 8001))]
 fn select_representation_matrix(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
     let Expr::Root(_, _) = expr else {
         return Err(RuleNotApplicable);
@@ -118,7 +126,7 @@ fn select_representation_matrix(expr: &Expr, symbols: &SymbolTable) -> Applicati
     }
 }
 
-#[register_rule(("Base", 8000))]
+#[register_rule(("Representations", 8000))]
 fn select_representation(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
     // thing we are representing must be a reference
     let Expr::Atomic(_, Atom::Reference(decl)) = expr else {

--- a/tests-integration/tests/integration/basic/comprehension/01/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/comprehension/01/input-expected-rule-trace-human.txt
@@ -19,7 +19,7 @@ such that
 
 (m#matrix_to_atom[i] = i)
  | i: int(1..5),]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..5)
 
 such that

--- a/tests-integration/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/comprehension/02/input-expected-rule-trace-human.txt
@@ -32,7 +32,7 @@ such that
 
 ((n#matrix_to_atom[i] < 5)) -> ((m#matrix_to_atom[i] = i))
  | i: int(1..5),(i < 4)]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..5)
 
 such that

--- a/tests-integration/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/comprehension/03/input-expected-rule-trace-human.txt
@@ -23,7 +23,7 @@ such that
 
 ((y < 5)) -> ((m#matrix_to_atom[x] = x))
  | x: int(1..5),(x < 4)]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (x = 1),
 and([given x: int(1..5)
 

--- a/tests-integration/tests/integration/basic/comprehension/04-sum/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/comprehension/04-sum/input-expected-rule-trace-human.txt
@@ -19,7 +19,7 @@ such that
 
 a#matrix_to_atom[i]
  | i: int(1..2),]) = 3), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (sum([given i: int(1..2)
 
 such that

--- a/tests-integration/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/01-indexing/input-expected-rule-trace-human.txt
@@ -17,7 +17,7 @@ such that
 (a#matrix_to_atom[3] = true),
 (a#matrix_to_atom[4] = true),
 (a#matrix_to_atom[5] = !(a#matrix_to_atom[4])), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (a#matrix_to_atom[1] = true),
 (a#matrix_to_atom[2] = true),
 (a#matrix_to_atom[3] = true),

--- a/tests-integration/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/02-2d-slicing/input-expected-rule-trace-human.txt
@@ -21,7 +21,7 @@ allDiff(a#matrix_to_atom[2,..]),
 allDiff(a#matrix_to_atom[3,..]),
 (a#matrix_to_atom[1, 1] = 1),
 (a#matrix_to_atom[2, 2] = 1), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 allDiff(a#matrix_to_atom[..,1]),
 allDiff(a#matrix_to_atom[..,2]),
 allDiff(a#matrix_to_atom[1,..]),

--- a/tests-integration/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/03-domain-letting/input-expected-rule-trace-human.txt
@@ -208,7 +208,7 @@ allDiff(a#matrix_to_atom[2,..]),
 allDiff(a#matrix_to_atom[3,..]),
 (a#matrix_to_atom[1, 1] = 1),
 (a#matrix_to_atom[2, 2] = 1), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 allDiff(a#matrix_to_atom[..,1]),
 allDiff(a#matrix_to_atom[..,2]),
 allDiff(a#matrix_to_atom[1,..]),

--- a/tests-integration/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/06-invalid-index/input-expected-rule-trace-human.txt
@@ -214,7 +214,7 @@ false
 --
 
 false, 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 false 
 new variables:
   find a#matrix_to_atom_1_1: int(1..3)

--- a/tests-integration/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/07-invalid-slice/input-expected-rule-trace-human.txt
@@ -94,7 +94,7 @@ false
 --
 
 false, 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 false 
 new variables:
   find a#matrix_to_atom_1_1: int(1..3)

--- a/tests-integration/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/08-index-is-expr/input-expected-rule-trace-human.txt
@@ -18,7 +18,7 @@ such that
 (a#matrix_to_atom[2, 1] = 1),
 (a#matrix_to_atom[3, 1] = 1),
 (a#matrix_to_atom[3, 2] = 1), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (a#matrix_to_atom[i, i] = i),
 (a#matrix_to_atom[1, 2] = 1),
 (a#matrix_to_atom[2, 1] = 1),

--- a/tests-integration/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/09-index-is-expr-offset/input-expected-rule-trace-human.txt
@@ -24,7 +24,7 @@ such that
 (a#matrix_to_atom[3, 2] = 1),
 (a#matrix_to_atom[3, 4] = 1),
 (a#matrix_to_atom[i, i] = i), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (a#matrix_to_atom[1, 2] = 1),
 (a#matrix_to_atom[1, 3] = 1),
 (a#matrix_to_atom[1, 4] = 1),

--- a/tests-integration/tests/integration/basic/matrix/14-matrix-index-matrix/matrix-index-matrix-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/14-matrix-index-matrix/matrix-index-matrix-expected-rule-trace-human.txt
@@ -13,7 +13,7 @@ such that
 (m#matrix_to_atom[m#matrix_to_atom[1]] = 1),
 (m#matrix_to_atom[m#matrix_to_atom[2]] = 2),
 (m#matrix_to_atom[m#matrix_to_atom[3]] = 3), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (m#matrix_to_atom[m#matrix_to_atom[1]] = 1),
 (m#matrix_to_atom[m#matrix_to_atom[2]] = 2),
 (m#matrix_to_atom[m#matrix_to_atom[3]] = 3) 

--- a/tests-integration/tests/integration/basic/matrix/15-matrix-index-matrix-with-offset/matrix-index-matrix-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/15-matrix-index-matrix-with-offset/matrix-index-matrix-expected-rule-trace-human.txt
@@ -13,7 +13,7 @@ such that
 (m#matrix_to_atom[m#matrix_to_atom[2]] = 2),
 (m#matrix_to_atom[m#matrix_to_atom[3]] = 3),
 (m#matrix_to_atom[m#matrix_to_atom[4]] = 4), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (m#matrix_to_atom[m#matrix_to_atom[2]] = 2),
 (m#matrix_to_atom[m#matrix_to_atom[3]] = 3),
 (m#matrix_to_atom[m#matrix_to_atom[4]] = 4) 

--- a/tests-integration/tests/integration/basic/matrix/16-matrix-out-bounds/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/16-matrix-out-bounds/input-expected-rule-trace-human.txt
@@ -12,7 +12,7 @@ such that
 --
 
 (m#matrix_to_atom[sum([a,b;int(1..2)])] = c), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (m#matrix_to_atom[sum([a,b;int(1..2)])] = c) 
 new variables:
   find m#matrix_to_atom_1: int(1..2)

--- a/tests-integration/tests/integration/basic/matrix/17-matrix-out-bounds-reify/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/17-matrix-out-bounds-reify/input-expected-rule-trace-human.txt
@@ -13,7 +13,7 @@ such that
 --
 
 (z) <-> ((m#matrix_to_atom[sum([a,b;int(1..2)])] = c)), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (z) <-> ((m#matrix_to_atom[sum([a,b;int(1..2)])] = c)) 
 new variables:
   find m#matrix_to_atom_1: int(1..2)

--- a/tests-integration/tests/integration/basic/matrix/18-matrix-out-bounds-possibly-undef/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/matrix/18-matrix-out-bounds-possibly-undef/input-expected-rule-trace-human.txt
@@ -17,7 +17,7 @@ such that
 (z) <-> ((m#matrix_to_atom[sum([a,b;int(1..2)])] = c)),
 (m#matrix_to_atom[0] = 1),
 (m#matrix_to_atom[1] = 1), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (z) <-> ((m#matrix_to_atom[sum([a,b;int(1..2)])] = c)),
 (m#matrix_to_atom[0] = 1),
 (m#matrix_to_atom[1] = 1) 

--- a/tests-integration/tests/integration/basic/record/01-records/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/input-expected-rule-trace-human.txt
@@ -17,7 +17,7 @@ such that
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#record_to_atom 
 new variables:
   find x#record_to_atom_1: bool
@@ -43,7 +43,7 @@ x#record_to_atom[a],
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#record_to_atom 
 
 --
@@ -67,7 +67,7 @@ x#record_to_atom[b],
 --
 
 y, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 y#record_to_atom 
 new variables:
   find y#record_to_atom_1: bool
@@ -75,13 +75,13 @@ new variables:
 --
 
 y, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 y#record_to_atom 
 
 --
 
 z, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 z#record_to_atom 
 new variables:
   find z#record_to_atom_1: bool

--- a/tests-integration/tests/integration/basic/tuples/01-bool-int/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/tuples/01-bool-int/input-expected-rule-trace-human.txt
@@ -10,7 +10,7 @@ such that
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#tuple_to_atom 
 new variables:
   find x#tuple_to_atom_1: bool
@@ -32,7 +32,7 @@ x#tuple_to_atom[1],
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#tuple_to_atom 
 
 --

--- a/tests-integration/tests/integration/basic/tuples/03-equality/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/tuples/03-equality/input-expected-rule-trace-human.txt
@@ -10,7 +10,7 @@ such that
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#tuple_to_atom 
 new variables:
   find x#tuple_to_atom_1: int(1..2)
@@ -18,7 +18,7 @@ new variables:
 --
 
 y, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 y#tuple_to_atom 
 new variables:
   find y#tuple_to_atom_1: int(2..5)

--- a/tests-integration/tests/integration/basic/tuples/04-inequality/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/tuples/04-inequality/input-expected-rule-trace-human.txt
@@ -10,7 +10,7 @@ such that
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#tuple_to_atom 
 new variables:
   find x#tuple_to_atom_1: int(1..2)
@@ -18,7 +18,7 @@ new variables:
 --
 
 y, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 y#tuple_to_atom 
 new variables:
   find y#tuple_to_atom_1: int(2..5)

--- a/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/input-expected-rule-trace-human.txt
@@ -9,7 +9,7 @@ such that
 --
 
 x, 
-   ~~> select_representation ([("Base", 8000)]) 
+   ~~> select_representation ([("Representations", 8000)]) 
 x#tuple_to_atom 
 new variables:
   find x#tuple_to_atom_1: int(1..2)

--- a/tests-integration/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/input-expected-rule-trace-human.txt
@@ -36,7 +36,7 @@ such that
 
 (a#matrix_to_atom[i] = i)
  | i: DOM,]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: DOM
 
 such that

--- a/tests-integration/tests/integration/bugs/parse-indices-in-wrong-order/tictactoe-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/bugs/parse-indices-in-wrong-order/tictactoe-expected-rule-trace-human.txt
@@ -667,7 +667,7 @@ such that
 tickTackToe#matrix_to_atom[step, row, col]
  | col: LENGTH,row: LENGTH,]))
  | step: STEPS1,]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: LENGTH
 given j: LENGTH
 

--- a/tests-integration/tests/integration/eprime-minion/nqueens-4/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/eprime-minion/nqueens-4/input-expected-rule-trace-human.txt
@@ -27,7 +27,7 @@ and([(majorDiagonal#matrix_to_atom[queen] = sum([queen,row#matrix_to_atom[queen]
 allDiff(row#matrix_to_atom),
 allDiff(majorDiagonal#matrix_to_atom),
 allDiff(minorDiagonal#matrix_to_atom), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given queen: int(0..3)
 
 such that

--- a/tests-integration/tests/integration/hakank_eprime/quasigroup_completion/01/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/hakank_eprime/quasigroup_completion/01/input-expected-rule-trace-human.txt
@@ -35,7 +35,7 @@ such that
 
 and([allDiff(x#matrix_to_atom[i,..]),allDiff(x#matrix_to_atom[..,i]);int(1..2)])
  | i: int(1..4),]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..4)
 given j: int(1..4)
 

--- a/tests-integration/tests/integration/hakank_eprime/quasigroup_completion/02/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/hakank_eprime/quasigroup_completion/02/input-expected-rule-trace-human.txt
@@ -35,7 +35,7 @@ such that
 
 and([allDiff(x#matrix_to_atom[i,..]),allDiff(x#matrix_to_atom[..,i]);int(1..2)])
  | i: int(1..4),]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..4)
 given j: int(1..4)
 

--- a/tests-integration/tests/integration/hakank_eprime/schur_small/schur_small-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/hakank_eprime/schur_small/schur_small-expected-rule-trace-human.txt
@@ -25,7 +25,7 @@ such that
 
 ((sum([i,j;int(1..2)]) = k)) -> (!(and([(schur#matrix_to_atom[i] = schur#matrix_to_atom[j]),(schur#matrix_to_atom[j] = schur#matrix_to_atom[k]);int(1..2)])))
  | i: int(1..2),j: int(1..2),k: int(1..2),]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..2)
 given j: int(1..2)
 given k: int(1..2)

--- a/tests-integration/tests/integration/hakank_eprime/xkcd/xkcd-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/hakank_eprime/xkcd/xkcd-expected-rule-trace-human.txt
@@ -22,7 +22,7 @@ such that
 
 product([price[i],x#matrix_to_atom[i];int(1..2)])
  | i: int(1..6),])), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 (total_ = sum([given i: int(1..6)
 
 such that

--- a/tests-integration/tests/integration/pythagorean-triples/input-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/pythagorean-triples/input-expected-rule-trace-human.txt
@@ -24,7 +24,7 @@ such that
 
 (and([and([(sum([UnsafePow(a, 2),UnsafePow(b, 2);int(1..2)]) = UnsafePow(c, 2)),(a <= b);int(1..2)]),(b <= c);int(1..2)])) -> (or([(class#matrix_to_atom[a] != class#matrix_to_atom[b]),(class#matrix_to_atom[b] != class#matrix_to_atom[c]),(class#matrix_to_atom[c] != class#matrix_to_atom[a]);int(1..3)]))
  | a: int(1..10),b: int(1..10),c: int(1..10),]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given a: int(1..10)
 given b: int(1..10)
 given c: int(1..10)

--- a/tests-integration/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/savilerow/langford/langford-expected-rule-trace-human.txt
@@ -42,7 +42,7 @@ such that
 (position#matrix_to_atom[sum([i,k;int(1..2)])] = sum([sum([position#matrix_to_atom[i],i;int(1..2)]),1;int(1..2)]))
  | i: int(1..3),]),
 allDiff(position#matrix_to_atom), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 and([given i: int(1..3)
 
 such that

--- a/tests-integration/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
+++ b/tests-integration/tests/integration/savilerow/nqueens-8/nqueens-expected-rule-trace-human.txt
@@ -50,7 +50,7 @@ such that
 
 and([(q2#matrix_to_atom[i] = (q1#matrix_to_atom[i] - i)),(q3#matrix_to_atom[i] = sum([q1#matrix_to_atom[i],i;int(1..2)]));int(1..2)])
  | i: AMOUNT_QUEENS,]), 
-   ~~> select_representation_matrix ([("Base", 8001)]) 
+   ~~> select_representation_matrix ([("Representations", 8001)]) 
 allDiff(q1#matrix_to_atom),
 allDiff(q2#matrix_to_atom),
 allDiff(q3#matrix_to_atom),


### PR DESCRIPTION
## Description

This creates a new rule set "Representations" which targets the SAT and Minion solver families. I added this since matrix representations create extra variables the SMT backend doesn't care about, since it just encodes the matrices directly. These extra variables then caused issues with returning a solution since we expect them to be set.

## Key changes

- Added "Representations" rule set which depends on Base and targets Minion and SAT
- Ran tests with `ACCEPT=true`

## How to test/review

<!-- instructions to make the reviewer's life easier-->
