### PR TITLE
refactor: use callback for rule set filtering; solver family holds SMT config

### DIFF
--- a/crates/conjure-cp-cli/src/cli.rs
+++ b/crates/conjure-cp-cli/src/cli.rs
@@ -4,7 +4,6 @@ use clap::{Args, Parser, Subcommand, arg, command};
 
 use clap_complete::Shell;
 use conjure_cp::solver::SolverFamily;
-use conjure_cp::solver::adaptors::smt::{IntTheory, MatrixTheory};
 
 use crate::{solve, test_solve};
 
@@ -59,7 +58,6 @@ pub struct GlobalArgs {
     /// Solver family to use
     #[arg(
         long,
-        value_enum,
         value_name = "SOLVER",
         default_value_t = SolverFamily::Minion,
         short = 's',
@@ -116,24 +114,6 @@ pub struct GlobalArgs {
     /// Use the experimental optimized / dirty-clean rewriter, instead of the default rewriter
     #[arg(long, default_value_t = false, global = true, help_heading = EXPERIMENTAL_HELP_HEADING)]
     pub use_optimised_rewriter: bool,
-
-    /// SMT integer theory to use when `--solver smt` is selected
-    #[arg(long,
-        value_enum,
-        default_value_t = IntTheory::Lia,
-        global = true,
-        help = "SMT integer theory to use (lia | bv), default = lia"
-    )]
-    pub smt_int_theory: IntTheory,
-
-    /// SMT theory to use for matrices when `--solver smt` is selected
-    #[arg(long,
-        value_enum,
-        default_value_t = MatrixTheory::Arrays,
-        global = true,
-        help = "SMT matrix theory to use (arrays | atomic), default = arrays"
-    )]
-    pub smt_matrix_theory: MatrixTheory,
 
     /// Exit after all comprehensions have been unrolled, printing the number of expressions at that point.
     ///

--- a/crates/conjure-cp-cli/src/test_solve.rs
+++ b/crates/conjure-cp-cli/src/test_solve.rs
@@ -26,7 +26,7 @@ pub fn run_test_solve_command(global_args: GlobalArgs, local_args: Args) -> anyh
     let model = solve::parse(&global_args, Arc::clone(&context))?;
     let rewritten_model = solve::rewrite(model, &global_args, Arc::clone(&context))?;
 
-    let solver = init_solver(&global_args);
+    let solver = init_solver(global_args.solver);
 
     // now we are stealing from the integration tester
 

--- a/crates/conjure-cp-cli/src/utils/testing.rs
+++ b/crates/conjure-cp-cli/src/utils/testing.rs
@@ -219,7 +219,7 @@ pub fn save_solutions_json(
 
     let solver_name = match solver {
         SolverFamily::Sat => "sat",
-        SolverFamily::Smt => "smt",
+        SolverFamily::Smt(..) => "smt",
         SolverFamily::Minion => "minion",
     };
 
@@ -237,7 +237,7 @@ pub fn read_solutions_json(
 ) -> Result<JsonValue, anyhow::Error> {
     let solver_name = match solver {
         SolverFamily::Sat => "sat",
-        SolverFamily::Smt => "smt",
+        SolverFamily::Smt(..) => "smt",
         SolverFamily::Minion => "minion",
     };
 

--- a/crates/conjure-cp-core/src/rule_engine/mod.rs
+++ b/crates/conjure-cp-core/src/rule_engine/mod.rs
@@ -78,8 +78,8 @@ pub use conjure_cp_rule_macros::register_rule;
 /// ```rust
 /// use conjure_cp_core::rule_engine::register_rule_set;
 /// use conjure_cp_core::solver::SolverFamily;
-/// register_rule_set!("MyRuleSet", (), SolverFamily::Minion);
-/// register_rule_set!("AnotherRuleSet", (), (SolverFamily::Minion, SolverFamily::Sat));
+/// register_rule_set!("MyRuleSet", (), |f: &SolverFamily| matches!(f, SolverFamily::Minion));
+/// register_rule_set!("AnotherRuleSet", (), |f: &SolverFamily| matches!(f, SolverFamily::Minion | SolverFamily::Sat));
 /// ```
 #[doc(inline)]
 pub use conjure_cp_rule_macros::register_rule_set;
@@ -236,7 +236,7 @@ pub fn get_rule_set_by_name(name: &str) -> Option<&'static RuleSet<'static>> {
 /// use conjure_cp_core::solver::SolverFamily;
 /// use conjure_cp_core::rule_engine::{get_rule_sets_for_solver_family, register_rule_set};
 ///
-/// register_rule_set!("CNF", (), SolverFamily::Sat);
+/// register_rule_set!("CNF", (), |f: &SolverFamily| matches!(f, SolverFamily::Sat));
 ///
 /// let rule_sets = get_rule_sets_for_solver_family(SolverFamily::Sat);
 /// assert_eq!(rule_sets.len(), 2);
@@ -247,12 +247,7 @@ pub fn get_rule_sets_for_solver_family(
 ) -> Vec<&'static RuleSet<'static>> {
     get_all_rule_sets()
         .iter()
-        .filter(|rule_set| {
-            rule_set
-                .solver_families
-                .iter()
-                .any(|family| family.eq(&solver_family))
-        })
+        .filter(|rule_set| rule_set.applies_to_family(&solver_family))
         .copied()
         .collect()
 }

--- a/crates/conjure-cp-core/src/solver/adaptors/smt/adaptor.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/smt/adaptor.rs
@@ -36,13 +36,13 @@ impl Default for Smt {
 impl Smt {
     /// Constructs a new adaptor using the given theories for representing the relevant constructs.
     pub fn new(int_theory: IntTheory, matrix_theory: MatrixTheory) -> Self {
-        let theories = TheoryConfig {
+        let theory_config = TheoryConfig {
             ints: int_theory,
             matrices: matrix_theory,
         };
         Smt {
-            theory_config: theories.clone(),
-            store: SymbolStore::new(theories),
+            theory_config,
+            store: SymbolStore::new(theory_config),
             ..Default::default()
         }
     }
@@ -93,7 +93,7 @@ impl SolverAdaptor for Smt {
     }
 
     fn get_family(&self) -> SolverFamily {
-        SolverFamily::Smt
+        SolverFamily::Smt(self.theory_config)
     }
 
     fn get_name(&self) -> &'static str {

--- a/crates/conjure-cp-core/src/solver/adaptors/smt/theories.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/smt/theories.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString};
 
 /// A collection of theories to use for encoding various CO AST constructs.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, JsonSchema, Default)]
 pub struct TheoryConfig {
     pub ints: IntTheory,
     pub matrices: MatrixTheory,

--- a/crates/conjure-cp-core/src/solver/mod.rs
+++ b/crates/conjure-cp-core/src/solver/mod.rs
@@ -108,6 +108,7 @@ use std::error::Error;
 use std::fmt::{Debug, Display};
 use std::io::Write;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
@@ -120,7 +121,7 @@ use thiserror::Error;
 use crate::Model;
 use crate::ast::{Literal, Name};
 use crate::context::Context;
-use crate::solver::adaptors::smt::IntTheory;
+use crate::solver::adaptors::smt::{IntTheory, MatrixTheory, TheoryConfig};
 use crate::stats::SolverStats;
 
 use self::model_modifier::ModelModifier;
@@ -135,24 +136,54 @@ mod private;
 pub mod states;
 
 #[derive(
-    Debug,
-    EnumString,
-    EnumIter,
-    Display,
-    PartialEq,
-    Eq,
-    Hash,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-    ValueEnum,
+    Debug, EnumIter, Display, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, JsonSchema,
 )]
 pub enum SolverFamily {
     Sat,
-    Smt,
+    Smt(TheoryConfig),
     Minion,
+}
+
+impl FromStr for SolverFamily {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_ascii_lowercase();
+
+        match s.as_str() {
+            "minion" => Ok(SolverFamily::Minion),
+            "sat" => Ok(SolverFamily::Sat),
+            "smt" => Ok(SolverFamily::Smt(TheoryConfig::default())),
+            other => {
+                // allow forms like `smt-bv-atomic` or `smt-lia-arrays`
+                if other.starts_with("smt-") {
+                    let parts = other.split('-').skip(1);
+                    let mut ints = IntTheory::default();
+                    let mut matrices = MatrixTheory::default();
+
+                    for token in parts {
+                        match token {
+                            "lia" => ints = IntTheory::Lia,
+                            "bv" => ints = IntTheory::Bv,
+                            "arrays" => matrices = MatrixTheory::Arrays,
+                            "atomic" => matrices = MatrixTheory::Atomic,
+                            other_token => {
+                                return Err(format!(
+                                    "unknown SMT theory option '{other_token}', must be one of bv|lia|arrays|atomic"
+                                ));
+                            }
+                        }
+                    }
+
+                    Ok(SolverFamily::Smt(TheoryConfig { ints, matrices }))
+                } else {
+                    Err(format!(
+                        "unknown solver family '{other}', expected 'minion', 'sat' or 'smt[(bv|lia)-(arrays|atomic)]'"
+                    ))
+                }
+            }
+        }
+    }
 }
 
 /// The type for user-defined callbacks for use with [Solver].

--- a/crates/conjure-cp-rules/src/minion.rs
+++ b/crates/conjure-cp-rules/src/minion.rs
@@ -29,7 +29,9 @@ use uniplate::Uniplate;
 
 use ApplicationError::RuleNotApplicable;
 
-register_rule_set!("Minion", ("Base"), (SolverFamily::Minion));
+register_rule_set!("Minion", ("Base"), |f: &SolverFamily| {
+    matches!(f, SolverFamily::Minion)
+});
 
 #[register_rule(("Minion", 4200))]
 fn introduce_producteq(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {

--- a/crates/conjure-cp-rules/src/sat/boolean.rs
+++ b/crates/conjure-cp-rules/src/sat/boolean.rs
@@ -249,7 +249,10 @@ pub fn tseytin_xor(
 
 // BOOLEAN SAT ENCODING RULES:
 
-register_rule_set!("SAT", ("Base"), (SolverFamily::Sat));
+register_rule_set!("SAT", ("Base"), |f: &SolverFamily| matches!(
+    f,
+    SolverFamily::Sat
+));
 
 /// Converts a single boolean atom to a clause
 ///

--- a/crates/conjure-cp-rules/src/select_representation.rs
+++ b/crates/conjure-cp-rules/src/select_representation.rs
@@ -6,7 +6,10 @@ use conjure_cp::{
         ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
         register_rule_set,
     },
-    solver::SolverFamily,
+    solver::{
+        SolverFamily,
+        adaptors::smt::{MatrixTheory, TheoryConfig},
+    },
 };
 use itertools::Itertools;
 use std::sync::Arc;
@@ -14,11 +17,15 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use uniplate::Biplate;
 
-register_rule_set!(
-    "Representations",
-    ("Base"),
-    (SolverFamily::Sat, SolverFamily::Minion)
-);
+register_rule_set!("Representations", ("Base"), |f: &SolverFamily| matches!(
+    f,
+    SolverFamily::Sat
+        | SolverFamily::Minion
+        | SolverFamily::Smt(TheoryConfig {
+            matrices: MatrixTheory::Atomic,
+            ..
+        })
+));
 
 // special case rule to select representations for matrices in one go.
 //

--- a/crates/conjure-cp-rules/src/smt/bitvector_encoding.rs
+++ b/crates/conjure-cp-rules/src/smt/bitvector_encoding.rs
@@ -2,8 +2,17 @@ use conjure_cp::ast::{Expression, Metadata, Moo, SymbolTable};
 use conjure_cp::rule_engine::{
     ApplicationError, ApplicationResult, Reduction, register_rule, register_rule_set,
 };
+use conjure_cp::solver::SolverFamily;
+use conjure_cp::solver::adaptors::smt::{IntTheory, TheoryConfig};
 
-register_rule_set!("SmtBvInts", ("Base"));
+// Only applicable when the Bitvector theory is being used for integers
+register_rule_set!("SmtBvInts", ("Base"), |f: &SolverFamily| matches!(
+    f,
+    SolverFamily::Smt(TheoryConfig {
+        ints: IntTheory::Bv,
+        ..
+    })
+));
 
 #[register_rule(("SmtBvInts", 1000))]
 fn fold_list_exprs_pairwise(expr: &Expression, _: &SymbolTable) -> ApplicationResult {

--- a/crates/conjure-cp-rules/src/smt/smt_rules.rs
+++ b/crates/conjure-cp-rules/src/smt/smt_rules.rs
@@ -8,7 +8,10 @@ use conjure_cp::rule_engine::{
 use conjure_cp::solver::SolverFamily;
 use uniplate::Uniplate;
 
-register_rule_set!("Smt", ("Base"), (SolverFamily::Smt));
+// These rules are applicable regardless of what theories are used.
+register_rule_set!("Smt", ("Base"), |f: &SolverFamily| {
+    matches!(f, SolverFamily::Smt(..))
+});
 
 #[register_rule(("Smt", 1000))]
 fn flatten_indomain(expr: &Expr, _: &SymbolTable) -> ApplicationResult {

--- a/tests-integration/tests/integration_tests.rs
+++ b/tests-integration/tests/integration_tests.rs
@@ -6,6 +6,7 @@ use conjure_cp::defaults::DEFAULT_RULE_SETS;
 use conjure_cp::parse::tree_sitter::parse_essence_file_native;
 use conjure_cp::rule_engine::rewrite_naive;
 use conjure_cp::solver::Solver;
+use conjure_cp::solver::adaptors::smt::TheoryConfig;
 use conjure_cp::solver::adaptors::*;
 use conjure_cp_cli::utils::testing::{normalize_solutions_for_comparison, read_human_rule_trace};
 use glob::glob;
@@ -284,7 +285,7 @@ fn integration_test_inner(
         let solver_fam = if config.solve_with_sat {
             SolverFamily::Sat
         } else if config.solve_with_smt {
-            SolverFamily::Smt
+            SolverFamily::Smt(TheoryConfig::default())
         } else {
             SolverFamily::Minion
         };
@@ -448,8 +449,12 @@ fn integration_test_inner(
         let username_solutions_json = solutions_to_json(&solutions);
         assert_eq!(username_solutions_json, expected_solutions_json);
     } else if config.solve_with_smt {
-        let expected_solutions_json =
-            read_solutions_json(path, essence_base, "expected", SolverFamily::Smt)?;
+        let expected_solutions_json = read_solutions_json(
+            path,
+            essence_base,
+            "expected",
+            SolverFamily::Smt(TheoryConfig::default()),
+        )?;
         let username_solutions_json = solutions_to_json(&solutions);
         assert_eq!(username_solutions_json, expected_solutions_json);
     }


### PR DESCRIPTION
## Description

This PR is to separate out an unrelated change from #1224 for more discussion.

Here we refactor rule sets to hold a predicate over SolverFamily rather than a list of accepted solver families. This allows for better configuration when solver settings influence rule application.