### PR TITLE
fix: use READ_ONLY_GITHUB_TOKEN to avoid github rate limits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
 
+env:
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
+
 jobs:
   generate_docs:
     name: "Generate documentation site"

--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -24,6 +24,7 @@ env:
   os: ubuntu-latest
   rust_release: stable
   compiler_profile: debug
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
 jobs:
   Check:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,6 +53,9 @@ on:
 permissions:
   contents: write
 
+env:
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
+
 jobs:
   # check if anything has happened in the repo today
   #

--- a/.github/workflows/shear.yml
+++ b/.github/workflows/shear.yml
@@ -14,6 +14,7 @@ env:
   os: ubuntu-latest
   rust_release: nightly
   compiler_profile: debug
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
   release_suffix: linux
   conjure_version: 2.5.1

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -22,6 +22,7 @@ env:
   os: ubuntu-latest
   rust_release: stable
   compiler_profile: debug
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
 jobs:
   # test-pr and test-main are identical, except for:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,6 +18,7 @@ env:
   os: ubuntu-latest
   rust_release: stable
   compiler_profile: debug
+  READ_ONLY_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_TOKEN }}
 
 jobs:
   # test-pr and test-main are identical, except for:


### PR DESCRIPTION
following @toolCHAINZ's advice in #1306

as far as I can see these are all the CI workflows that call cargo/make