### PR TITLE
fix: document the undocumented targets in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ check:
 check-unused-deps: .installed-cargo-extensions.checkpoint
 	cargo +nightly shear --expand
 
+.PHONY: build
+## Builds the conjure-oxide executable
+build:
+	cargo build --bin conjure-oxide
+
 .PHONY: test
 ## Runs all tests
 test:


### PR DESCRIPTION
fix: document the undocumented targets in the makefile, so `make help` is more helpful. also rename coverage to test-coverage.

now `make help` prints the following:

```
Available rules:

check               Runs all hygiene checks. These are the same checks that occur in CI for PRs.
check-unused-deps   Check for unused dependencies using `cargo shear`
fix                 Tries to auto-fix hygiene issues reported by `make check`. Fixes will not be applied if there are
                    uncommitted changes: to always apply fixes, use `make fix-dirty`.
fix-dirty           Tries to auto-fix hygiene issues reported by `make check`. Applies fixes even when there are
                    uncommitted changes.
help                Shows this help text
test                Runs all tests
test-accept         Runs all tests in accept mode, then one more time in normal mode
test-coverage       Runs all tests and produces a coverage report
```