### PR TITLE
refactor: use bundled for z3 dep instead of gh-release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,6 +3543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8b6f6371f887a327524718087bf333e6a45db69f6dfe8319909b9111979128"
 dependencies = [
  "bindgen",
+ "cmake",
  "pkg-config",
  "reqwest",
  "serde_json",

--- a/crates/conjure-cp-core/Cargo.toml
+++ b/crates/conjure-cp-core/Cargo.toml
@@ -11,7 +11,7 @@ conjure-cp-rule-macros = { path = "../conjure-cp-rule-macros" }
 conjure-cp-enum-compatibility-macro = { path = "../conjure-cp-enum-compatibility-macro" }
 minion-sys = { path = "../minion-sys" }
 tree-morph = { path = "../tree-morph" }
-z3 = { version = "0.19.4", default-features = false, features = ["gh-release"] }
+z3 = { version = "0.19.4", default-features = false, features = ["bundled"] }
 uniplate = { workspace = true }
 project-root = { workspace = true }
 linkme = { workspace = true }


### PR DESCRIPTION
## Description

Use the bundled version of z3 in the z3-sys dependency, instead of relying on it downloading a pre-compiled binary. Some CI issues might be fixed by this, and we can change back to precompiled once the bug is fixed upstream.

## Related issues

See #1327