### PR TITLE
fix: install openssl dependency perl modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN yum install -y llvm-toolset;
 # openssl headers for Rust's openssl-sys crate
 RUN yum install -y openssl-devel;
 
+# Install openssl dependencies
+RUN yum install -y openssl-libs perl-IPC-Cmd perl-Time-Piece;
+
 # nodejs: required to build treesitter grammar
 
 # treesitter builds fail on the version of node found in this containers


### PR DESCRIPTION
## Description

Building in the minimal Docker environment produces some errors about missing dependencies for building OpenSSL from source.

OpenSSL is used by z3.rs, although the latest 0.19.5 version should be using a bundled implementation instead of building from source.

## Related issues

This lets us reproduce #1327 again :)

Expands on #1308

## How to test/review

See instructions at https://github.com/conjure-cp/conjure-oxide/issues/1327#issue-3673142136
