### PR TITLE
fix: unbounded int domain membership was backwards

### DIFF
--- a/crates/conjure-cp-core/src/ast/domains/range.rs
+++ b/crates/conjure-cp-core/src/ast/domains/range.rs
@@ -46,8 +46,8 @@ impl<A: Ord> Range<A> {
         match self {
             Range::Single(x) => x == val,
             Range::Bounded(x, y) => x <= val && val <= y,
-            Range::UnboundedR(x) => x >= val,
-            Range::UnboundedL(x) => x <= val,
+            Range::UnboundedR(x) => x <= val,
+            Range::UnboundedL(x) => val <= x,
             Range::Unbounded => true,
         }
     }


### PR DESCRIPTION
## Description

Minor bug introduced in 50ca2e7, which caused one-sided unbounded ranges to incorrectly calculate whether they contain a number.