### PR TITLE
feat: solver timeout in global args and SMT backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "conjure-cp-rules",
  "git-version",
  "glob",
+ "humantime",
  "itertools 0.14.0",
  "rayon",
  "schemars 1.1.0",
@@ -1095,6 +1096,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ versions = "7.0.0"
 walkdir = "2.5.0"
 polyquine = "0.0.8"
 num-traits = "0.2.19"
+humantime = "2.3.0"
 
 # Always use release profile options for z3 crate to minimise size
 [profile.dev.package.z3-sys]

--- a/crates/conjure-cp-cli/Cargo.toml
+++ b/crates/conjure-cp-cli/Cargo.toml
@@ -27,6 +27,7 @@ tempfile = { workspace = true }
 itertools = { workspace = true }
 clap_complete = { workspace = true }
 rayon = { workspace = true }
+humantime = { workspace = true }
 
 [features]
 

--- a/crates/conjure-cp-cli/src/cli.rs
+++ b/crates/conjure-cp-cli/src/cli.rs
@@ -124,6 +124,12 @@ pub struct GlobalArgs {
     /// rewriting.
     #[arg(long, default_value_t = false, global = true, help_heading = DEBUG_HELP_HEADING)]
     pub exit_after_unrolling: bool,
+
+    /// Stop the solver after the given timeout.
+    ///
+    /// Currently only SMT supports this feature.
+    #[arg(long, global = true, help_heading = OPTIMISATIONS_HELP_HEADING)]
+    pub solver_timeout: Option<humantime::Duration>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/crates/conjure-cp-cli/src/solve.rs
+++ b/crates/conjure-cp-cli/src/solve.rs
@@ -6,6 +6,7 @@ use std::{
     path::PathBuf,
     process::exit,
     sync::{Arc, RwLock},
+    time::Duration,
 };
 
 use anyhow::{anyhow, ensure};
@@ -63,7 +64,7 @@ pub fn run_solve_command(global_args: GlobalArgs, solve_args: Args) -> anyhow::R
     let context = init_context(&global_args, input_file)?;
     let model = parse(&global_args, Arc::clone(&context))?;
     let rewritten_model = rewrite(model, &global_args, Arc::clone(&context))?;
-    let solver = init_solver(global_args.solver);
+    let solver = init_solver(&global_args);
 
     if solve_args.no_run_solver {
         println!("{}", &rewritten_model);
@@ -142,11 +143,19 @@ pub(crate) fn init_context(
     Ok(context)
 }
 
-pub(crate) fn init_solver(family: SolverFamily) -> Solver {
+pub(crate) fn init_solver(global_args: &GlobalArgs) -> Solver {
+    let family = global_args.solver;
+    let solver_timeout = global_args
+        .solver_timeout
+        .map(|dur| Duration::from(dur).as_millis());
+
     match family {
         SolverFamily::Minion => Solver::new(Minion::default()),
         SolverFamily::Sat => Solver::new(Sat::default()),
-        SolverFamily::Smt(TheoryConfig { ints, matrices }) => Solver::new(Smt::new(ints, matrices)),
+        SolverFamily::Smt(TheoryConfig { ints, matrices }) => {
+            let timeout_ms = solver_timeout.map(|ms| u64::try_from(ms).expect("Timeout too large"));
+            Solver::new(Smt::new(timeout_ms, ints, matrices))
+        }
     }
 }
 

--- a/crates/conjure-cp-cli/src/test_solve.rs
+++ b/crates/conjure-cp-cli/src/test_solve.rs
@@ -26,7 +26,7 @@ pub fn run_test_solve_command(global_args: GlobalArgs, local_args: Args) -> anyh
     let model = solve::parse(&global_args, Arc::clone(&context))?;
     let rewritten_model = solve::rewrite(model, &global_args, Arc::clone(&context))?;
 
-    let solver = init_solver(global_args.solver);
+    let solver = init_solver(&global_args);
 
     // now we are stealing from the integration tester
 

--- a/crates/conjure-cp-core/src/solver/adaptors/smt/adaptor.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/smt/adaptor.rs
@@ -1,4 +1,6 @@
-use z3::Solver;
+use std::sync::Mutex;
+
+use z3::{Config, PrepareSynchronized, Solver, Translate, with_z3_config};
 
 use super::convert_model::*;
 use super::store::*;
@@ -17,6 +19,8 @@ pub struct Smt {
     /// Assertions are added to this solver instance when loading the model.
     solver_inst: Solver,
 
+    solver_cfg: Config,
+
     theory_config: TheoryConfig,
 }
 
@@ -28,6 +32,7 @@ impl Default for Smt {
             __non_constructable: private::Internal,
             store: SymbolStore::new(TheoryConfig::default()),
             solver_inst: Solver::new(),
+            solver_cfg: Config::new(),
             theory_config: TheoryConfig::default(),
         }
     }
@@ -35,13 +40,22 @@ impl Default for Smt {
 
 impl Smt {
     /// Constructs a new adaptor using the given theories for representing the relevant constructs.
-    pub fn new(int_theory: IntTheory, matrix_theory: MatrixTheory) -> Self {
+    pub fn new(
+        timeout_msec: Option<u64>,
+        int_theory: IntTheory,
+        matrix_theory: MatrixTheory,
+    ) -> Self {
         let theory_config = TheoryConfig {
             ints: int_theory,
             matrices: matrix_theory,
         };
+
+        let mut solver_cfg = Config::new();
+        timeout_msec.inspect(|ms| solver_cfg.set_timeout_msec(*ms));
+
         Smt {
             theory_config,
+            solver_cfg,
             store: SymbolStore::new(theory_config),
             ..Default::default()
         }
@@ -54,16 +68,22 @@ impl SolverAdaptor for Smt {
         callback: SolverCallback,
         _: private::Internal,
     ) -> Result<SolveSuccess, SolverError> {
-        let solutions = self
-            .solver_inst
-            .solutions(&self.store, true)
-            .take_while(|store| (callback)(store.as_literals_map().unwrap()));
+        let solver_send = self.solver_inst.synchronized();
+        let store_send = self.store.synchronized();
 
-        // Consume iterator and get whether there are solutions
-        let search_complete = match solutions.count() {
-            0 => SearchComplete::NoSolutions,
-            _ => SearchComplete::HasSolutions,
-        };
+        // Apply config when getting solutions
+        let search_complete = with_z3_config(&self.solver_cfg, move || {
+            let solver = solver_send.recover();
+            let solutions = solver
+                .solutions(store_send.recover(), true)
+                .take_while(|store| (callback)(store.as_literals_map().unwrap()));
+
+            // Consume iterator and get whether there are solutions
+            match solutions.count() {
+                0 => SearchComplete::NoSolutions,
+                _ => SearchComplete::HasSolutions,
+            }
+        });
 
         Ok(SolveSuccess {
             // TODO: get solver stats

--- a/crates/conjure-cp-core/src/solver/mod.rs
+++ b/crates/conjure-cp-core/src/solver/mod.rs
@@ -189,9 +189,9 @@ impl FromStr for SolverFamily {
 /// The type for user-defined callbacks for use with [Solver].
 ///
 /// Note that this enforces thread safety
-pub type SolverCallback = Box<dyn Fn(HashMap<Name, Literal>) -> bool + Send>;
+pub type SolverCallback = Box<dyn Fn(HashMap<Name, Literal>) -> bool + Send + Sync>;
 pub type SolverMutCallback =
-    Box<dyn Fn(HashMap<Name, Literal>, Box<dyn ModelModifier>) -> bool + Send>;
+    Box<dyn Fn(HashMap<Name, Literal>, Box<dyn ModelModifier>) -> bool + Send + Sync>;
 
 /// A common interface for calling underlying solver APIs inside a [`Solver`].
 ///


### PR DESCRIPTION
## Description

This PR adds a `--solver-timeout` CLI option to limit the time spent by the solver. Currently only the Z3 backend supports this feature.

How this is implemented depends on the solver library being used. I will open an issue for implementing this feature with the other solver backends.

## How to test/review

Run with a very small timeout and using the SMT backend:

```
conjure-oxide solve -s smt --solver-timeout 1ms tests-integration/tests/integration/smt/matrix/nqueens-4/input.eprime
```