### PR TITLE
refactor: use `Reference` instead of names in `collect_like_terms`

### DIFF
--- a/crates/conjure-cp-core/src/ast/expressions.rs
+++ b/crates/conjure-cp-core/src/ast/expressions.rs
@@ -1055,11 +1055,11 @@ impl Expression {
         }
     }
 
-    /// If the expression is a list, returns the inner expressions.
+    /// If the expression is a list, returns a *copied* vector of the inner expressions.
     ///
     /// A list is any a matrix with the domain `int(1..)`. This includes matrix literals without
     /// any explicitly specified domain.
-    pub fn unwrap_list(self) -> Option<Vec<Expression>> {
+    pub fn unwrap_list(&self) -> Option<Vec<Expression>> {
         match self {
             Expression::AbstractLiteral(_, matrix @ AbstractLiteral::Matrix(_, _)) => {
                 matrix.unwrap_list().cloned()

--- a/crates/conjure-cp-core/src/ast/reference.rs
+++ b/crates/conjure-cp-core/src/ast/reference.rs
@@ -19,7 +19,9 @@ use super::{
 /// 1. Encapsulate the serde pragmas (e.g., serializing as IDs rather than full objects)
 /// 2. Enable type-directed traversals of references via uniplate
 #[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Uniplate, Derivative)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Uniplate, Derivative,
+)]
 #[derivative(Hash)]
 #[uniplate()]
 #[biplate(to=DeclarationPtr)]


### PR DESCRIPTION
## Key changes

- Adds `derive(Ord)` for `Reference`
- Makes `Expression::unwrap_list` take `self` by reference to avoid some unnecessary clones.
  The underlying `AbstractLiteral::unwrap_list` method also takes self by reference and clones elements where necessary.
- Replaces `Name` with `Reference` in `collect_like_terms` rule (inside `normalisers.rs`)


This yields either a slight performance uplift or no significant effect on our performance tests (e.g.  1.05 ± 0.03 times faster than baseline on BIBD, 1.05 ± 0.04 times faster than baseline on 20 Queens)

closes #933 