### PR TITLE
fix(Docs): Remove dead wiki link

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,15 +47,13 @@
 
 # Documentation
 
-<!-- TODO: will we keep this? -->
-- [Developer Documentation](./documentation/dev_docs.md)
-
 - [SAT Encoding Types](./documentation/SAT/sat-encoding-types.md)
 - [Rule Types](./documentation/SAT/rule-types.md)
 
 <!-- TODO: will be moved -- likely the content of these will end off here -->
 - [Useful Links](./documentation/links.md)
 - [Essence Parser](./documentation/essence_parser.md)
+<!-- TODO: add the error detection documentations -->
 - [Error Detection](./documentation/error_detection)
 - [Side Projects]()
   - [Conjure Blocks](./documentation/side_projects/Conjure-Blocks.md)

--- a/docs/src/documentation/dev_docs.md
+++ b/docs/src/documentation/dev_docs.md
@@ -1,3 +1,0 @@
-# Developer Documentation
-
-Developer documentation is hosted on the [Github Wiki](https://github.com/conjure-cp/conjure-oxide/wiki).


### PR DESCRIPTION
## Description

I had a look through the docs and found one dead link to the wiki. This was in 'developer docs' which we don't need in general.

## Related issues

#1454 

## Key changes

- Removed developer docs

## How to test/review

From root directory, type the following into the terminal:
```
cd docs
mdbook serve --open
```
And then explore the book.
