### PR TITLE
ci: remove pages deploy concurrency

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,9 +26,6 @@ on:
       - .github/workflows/rustdoc.yml
   workflow_dispatch:
 
-concurrency:
-  group: reports-deploy
-  cancel-in-progress: false
 
 env:
   os: ubuntu-latest

--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -28,9 +28,6 @@ on:
       - .github/workflows/rustdoc.yml
   workflow_dispatch:
 
-concurrency:
-  group: reports-deploy
-  cancel-in-progress: false
 
 env:
   os: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,6 @@ on:
       - .github/workflows/docs.yml
   workflow_dispatch:
 
-concurrency:
-  group: reports-deploy
-  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -6,9 +6,6 @@ on:
       - main # run for pushes to the main branch
   workflow_dispatch:
 
-concurrency:
-  group: reports-deploy
-  cancel-in-progress: false
 
 env:
   # we define these in the env if they are not defined as matrix parameters


### PR DESCRIPTION
Let's risk it. Otherwise Github cancels these jobs very often.