### PR TITLE
ci: enforce locked deps via make

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -55,9 +55,7 @@ jobs:
       - name: "Install rust-toolchain.toml"
         run: rustup toolchain install
 
-      - run: RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) --workspace --all-targets
-      - run: cargo clippy $(EXTRA_CARGO_CHECK_FLAGS) -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
-      - run: cargo fmt --check
+      - run: make check
 
       - name: Save cache
         if: ${{ always() && github.ref == 'refs/heads/main' && steps.restore_cache.outputs.cache-hit != 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,15 @@ include tools/show-help-minified.make
 
 # Extra flags to be passed to `cargo check` (default: -q).
 EXTRA_CARGO_CHECK_FLAGS ?= -q
+# Use Cargo.lock to ensure local builds match CI dependency versions.
+# Override with `CARGO_LOCKED=` if you explicitly want to update the lockfile.
+CARGO_LOCKED ?= --locked
 
 .PHONY: check
 ## Runs all hygiene checks. These are the same checks that occur in CI for PRs.
 check:
-	RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) --workspace
-	RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) --workspace --examples
-	cargo clippy $(EXTRA_CARGO_CHECK_FLAGS) -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
+	RUSTFLAGS="-D warnings" cargo check $(EXTRA_CARGO_CHECK_FLAGS) $(CARGO_LOCKED) --workspace --all-targets
+	cargo clippy $(EXTRA_CARGO_CHECK_FLAGS) $(CARGO_LOCKED) -- -D warnings -A clippy::unwrap_used -A clippy::expect_used
 	cargo fmt --check
 
 .PHONY: check-unused-deps
@@ -20,13 +22,13 @@ check-unused-deps: .installed-cargo-extensions.checkpoint
 .PHONY: build
 ## Builds the conjure-oxide executable
 build:
-	cargo build --bin conjure-oxide
+	cargo build $(CARGO_LOCKED) --bin conjure-oxide
 
 .PHONY: test
 ## Runs all tests
 test:
-	cargo build --bin conjure-oxide # we need to build first, so the conjure-oxide executable is available during testing as it is needed by the custom tests.
-	cargo test --workspace
+	cargo build $(CARGO_LOCKED) --bin conjure-oxide # we need to build first, so the conjure-oxide executable is available during testing as it is needed by the custom tests.
+	cargo test $(CARGO_LOCKED) --workspace
 
 .PHONY: test-coverage
 ## Runs all tests and produces a coverage report
@@ -36,25 +38,25 @@ test-coverage:
 .PHONY: test-accept
 ## Runs all tests in accept mode, then one more time in normal mode
 test-accept:
-	cargo build --bin conjure-oxide
-	ACCEPT=true cargo test --workspace
-	cargo test --workspace
+	cargo build $(CARGO_LOCKED) --bin conjure-oxide
+	ACCEPT=true cargo test $(CARGO_LOCKED) --workspace
+	cargo test $(CARGO_LOCKED) --workspace
 
 .PHONY: fix
 ## Tries to auto-fix hygiene issues reported by `make check`. 
 ## Fixes will not be applied if there are uncommitted changes: to always apply fixes, use `make fix-dirty`.
 fix:
 	cargo fmt --all
-	cargo fix
-	cargo clippy -q --fix
+	cargo fix $(CARGO_LOCKED)
+	cargo clippy -q $(CARGO_LOCKED) --fix
 
 .PHONY: fix-dirty
 ## Tries to auto-fix hygiene issues reported by `make check`. 
 ## Applies fixes even when there are uncommitted changes.
 fix-dirty:
 	cargo fmt --all
-	cargo fix --allow-dirty --allow-staged
-	cargo clippy -q --fix --allow-dirty --allow-staged
+	cargo fix $(CARGO_LOCKED) --allow-dirty --allow-staged
+	cargo clippy -q $(CARGO_LOCKED) --fix --allow-dirty --allow-staged
 
 # install cargo extensions used in this Makefile (cargo-shear)
 .PHONY: install-cargo-extensions


### PR DESCRIPTION
Turns out:

> [Dealing with the Lockfile](https://doc.rust-lang.org/nightly/cargo/commands/cargo-install.html#dealing-with-the-lockfile)
> 
> By default, the Cargo.lock file that is included with the package will be ignored. This means that Cargo will recompute which versions of dependencies to use, possibly using newer versions that have been released since the package was published. The --locked flag can be used to force Cargo to use the packaged Cargo.lock file if it is available.

I thought we were using the lock file by default!

Came up when investigating #1471