### PR TITLE
fix(ci): avoid submodule --remote updates (use pinned submodule revisions)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ FROM build-environment AS builder
 # grab conjure oxide source
 WORKDIR /build
 COPY . .
-RUN git submodule update  --init --remote --recursive;
+RUN git submodule update --init --recursive;
 
 RUN cargo build --release;
 

--- a/crates/minion-sys/build.sh
+++ b/crates/minion-sys/build.sh
@@ -6,7 +6,8 @@ set -x
 SCRIPT_DIR="$(readlink -f "$(dirname "$0")")"
 cd "$SCRIPT_DIR"
 
-git submodule update --init --recursive --remote -- vendor
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+git -C "$REPO_ROOT" submodule update --init --recursive -- crates/minion-sys/vendor
 
 if [[ -z "$OUT_DIR" ]]; then
   echo "OUT_DIR env variable does not exist - did you run this script through cargo build?"


### PR DESCRIPTION
This is mainly to fix nightly, but also in general I don't think we should be using remote anyway.