### PR TITLE
fix(coverage): normalise grcov html layout

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -111,6 +111,14 @@ grcov "${TARGET_DIR}/coverage" -s . --binary-path ./target/debug -t html\
 
 echo_err "info: html coverage report generated to target/debug/coverage/index.html"
 
+# Some grcov versions/layouts emit HTML under target/debug/coverage/html/.
+# Normalise to a single root to avoid stale or duplicated report trees.
+if [ -d ./target/debug/coverage/html ]; then
+  echo_err "info: normalising grcov html output layout"
+  rsync -a --delete ./target/debug/coverage/html/ ./target/debug/coverage/
+  rm -rf ./target/debug/coverage/html
+fi
+
 grcov "${TARGET_DIR}/coverage" -s . --binary-path ./target/debug -t lcov\
   "${GRCOV_IGNORE_FLAGS[@]}" ${GRCOV_EXCLUDE_FLAG}\
   -o ./target/debug/lcov.info || { echo_err "fatal: lcov coverage generation failed" ; exit 1; }


### PR DESCRIPTION
For some reason sometimes the coverage report end up in an `target/debug/coverage/html` directory and sometimes in `target/debug/coverage`. This causes a stale report to be shown in PRs.

Example #1445

This PR shows `crates/conjure-cp-rules/src/representation/sat_order_int.rs` in the diff report, but not in the full report due it it showing a stale copy.