### PR TITLE
fix(coverage): ignore doc comments in grcov

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -79,6 +79,8 @@ GRCOV_EXCLUDE_LINES=(
   '#\[derive'
   '#\[register_rule'
   'register_rule_set!'
+  '^\s*///'
+  '^\s*//!'
 )
 
 # construct an or regex


### PR DESCRIPTION
Without explicitly ignoring doc comments, we get the reported as not covered.

<img width="1013" height="577" alt="Screenshot 2026-02-10 at 21 33 37" src="https://github.com/user-attachments/assets/c137c522-77e6-4618-9331-e7ccb51c25bc" />

