### PR TITLE
fix(coverage): ignore line comments in grcov

### DIFF
--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -79,8 +79,7 @@ GRCOV_EXCLUDE_LINES=(
   '#\[derive'
   '#\[register_rule'
   'register_rule_set!'
-  '^\s*///'
-  '^\s*//!'
+  '^[[:space:]]*//'
 )
 
 # construct an or regex


### PR DESCRIPTION
ignore line comments (//) in grcov, instead of /// and //! only