### PR TITLE
fix: Support Expr in Range Bounds

### DIFF
--- a/crates/conjure-cp-core/src/parse/parse_model.rs
+++ b/crates/conjure-cp-core/src/parse/parse_model.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::{Arc, RwLock};
 use ustr::Ustr;
 
@@ -564,6 +566,47 @@ fn parse_domain_value_int(obj: &JsonValue, symbols: &SymbolTable) -> Option<i32>
         .or_else(|| try_parse_reference(obj, symbols))
 }
 
+fn parse_domain_value_intval(
+    obj: &JsonValue,
+    symbols: &SymbolTablePtr,
+) -> Option<IntVal> {
+    parser_trace!("trying to parse domain value: {}", obj);
+
+    if let Some(val) = parse_domain_value_int(obj, &symbols.read()) {
+        return Some(IntVal::Const(val));
+    }
+
+    let expr = parse_expression(obj, symbols)?;
+    Some(IntVal::Expr(Moo::new(expr)))
+}
+
+fn parse_domain_int_with_expr(
+    obj: &JsonValue,
+    symbols: &SymbolTablePtr,
+) -> Option<DomainPtr> {
+    let mut ranges = Vec::new();
+    let arr = obj.as_array()?[1].as_array()?;
+
+    for range in arr {
+        let range = range.as_object()?.iter().next()?;
+        match range.0.as_str() {
+            "RangeBounded" => {
+                let arr = range.1.as_array()?;
+                let lo = parse_domain_value_intval(&arr[0], symbols)?;
+                let hi = parse_domain_value_intval(&arr[1], symbols)?;
+                ranges.push(Range::Bounded(lo, hi));
+            }
+            "RangeSingle" => {
+                let num = parse_domain_value_intval(range.1, symbols)?;
+                ranges.push(Range::Single(num));
+            }
+            _ => return None,
+        }
+    }
+
+    Some(Domain::int(ranges))
+}
+
 // this needs an explicit type signature to force the closures to have the same type
 type BinOp = Box<dyn Fn(Metadata, Moo<Expression>, Moo<Expression>) -> Expression>;
 type UnaryOp = Box<dyn Fn(Metadata, Moo<Expression>) -> Expression>;
@@ -924,12 +967,21 @@ fn parse_comprehension(
                         let name = gen_inner.pointer("/0/Single/Name")?.as_str()?;
                         let (domain_name, domain_value) =
                             gen_inner.pointer("/1")?.as_object()?.iter().next()?;
-                        let domain = parse_domain(
+
+                        let result = parse_domain(
                             domain_name,
                             domain_value,
                             &mut generator_symboltable.write(),
-                        )
-                        .ok()?;
+                        );
+
+                        let domain = match result {
+                            Ok(dom) => dom,
+                            Err(_) if domain_name == "DomainInt" => {
+                                parse_domain_int_with_expr(domain_value, &generator_symboltable)?
+                            }
+                            Err(_) => return None,
+                        };
+
                         comprehension.generator(DeclarationPtr::new_var(name.into(), domain))
                     }
                     // TODO: this is temporary until comprehensions support "in expr" generators


### PR DESCRIPTION
Currently, the parser does not support expressions in ranges. I've described a minimal breaking example that crashes below:
```eprime 
find x : int (1..10)
letting m be 5

such that 
  forAll i : int(m-1..10) .
    x + i = 10,

  forAll i : int(1+m .. 10) .
    x + i = 10,
```

```
thread 'main' (1035949) panicked at crates/conjure-cp-core/src/parse/parse_model.rs:1130:88:
called `Option::unwrap()` on a `None` value
```

Nested comprehensions are the specific case where this happens (inner quantifier references outer quantifier variable).

When `parse_expression` tries to parse a domain such as `int(m + 1..10)`, it calls `parse_domain` which in turn runs `parse_int_domain` which uses `parse_domain_value_int` which cannot handle expressions or references.  

The proposed fix is to first attempt `parse_domain` and then as a fall back attempt to parse the domain as an expression itself. `parse_domain_int_with_expr` calls `parse_domain_value_intval` which simply wraps the domain bounds in an `IntVal` which supports `Expr`. 

Down the line, when we attempt to resolve the domain bounds, `eval_constant` now has the ability to recursively evaluate lettings when it encounters a reference.