### PR TITLE
refactor(metadata): Remove cleanliness tracking from metadata. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,13 +931,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1572,22 +1571,13 @@ dependencies = [
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "libz-rs-sys"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
-dependencies = [
- "zlib-rs",
 ]
 
 [[package]]
@@ -2022,9 +2012,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppmd-rust"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558c559f0450f16f2a27a1f017ef38468c1090c9ce63c8e51366232d53717b4"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -3954,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4025,9 +4015,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"

--- a/crates/conjure-cp-core/src/ast/expressions.rs
+++ b/crates/conjure-cp-core/src/ast/expressions.rs
@@ -47,8 +47,8 @@ use super::{
 // lot bigger still when we start using it for memoisation, so it should really be
 // boxed ~niklasdewally
 
-// expect size of Expression to be 112 bytes
-static_assertions::assert_eq_size!([u8; 104], Expression);
+// expect size of Expression to be 96 bytes
+static_assertions::assert_eq_size!([u8; 96], Expression);
 
 /// Represents different types of expressions used to define rules and constraints in the model.
 ///
@@ -971,17 +971,6 @@ impl Expression {
             }
         }
         true
-    }
-
-    pub fn is_clean(&self) -> bool {
-        let metadata = self.get_meta();
-        metadata.clean
-    }
-
-    pub fn set_clean(&mut self, bool_value: bool) {
-        let mut metadata = self.get_meta();
-        metadata.clean = bool_value;
-        self.set_meta(metadata);
     }
 
     /// True if the expression is an associative and commutative operator

--- a/crates/conjure-cp-core/src/ast/metadata.rs
+++ b/crates/conjure-cp-core/src/ast/metadata.rs
@@ -10,22 +10,13 @@ derive_unplateable!(Metadata);
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct Metadata {
-    pub clean: bool,
     pub etype: Option<ReturnType>,
 }
 
 impl Metadata {
     pub fn new() -> Metadata {
         Metadata {
-            clean: false,
             etype: None,
-        }
-    }
-
-    pub fn clone_dirty(&self) -> Metadata {
-        Metadata {
-            clean: false,
-            ..self.clone()
         }
     }
 }

--- a/crates/conjure-cp-rules/src/lex.rs
+++ b/crates/conjure-cp-rules/src/lex.rs
@@ -11,12 +11,12 @@ use itertools::Itertools as _;
 fn normalise_lex_gt_geq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     match expr {
         Expr::LexGt(metadata, a, b) => Ok(Reduction::pure(Expr::LexLt(
-            metadata.clone_dirty(),
+            metadata.clone(),
             b.clone(),
             a.clone(),
         ))),
         Expr::LexGeq(metadata, a, b) => Ok(Reduction::pure(Expr::LexLeq(
-            metadata.clone_dirty(),
+            metadata.clone(),
             b.clone(),
             a.clone(),
         ))),

--- a/crates/conjure-cp-rules/src/minion.rs
+++ b/crates/conjure-cp-rules/src/minion.rs
@@ -558,7 +558,7 @@ fn introduce_diveq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(Expr::MinionDivEqUndefZero(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(a.clone()),
         Moo::new(b.clone()),
         Moo::new(val),
@@ -609,7 +609,7 @@ fn introduce_modeq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(Expr::MinionModuloEqUndefZero(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(a.clone()),
         Moo::new(b.clone()),
         Moo::new(val),
@@ -1216,7 +1216,7 @@ fn geq_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     Ok(Reduction::pure(Expr::FlatIneq(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(y),
         Moo::new(x),
         Box::new(Lit::Int(0)),
@@ -1243,7 +1243,7 @@ fn leq_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     Ok(Reduction::pure(Expr::FlatIneq(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(x),
         Moo::new(y),
         Box::new(Lit::Int(0)),
@@ -1282,7 +1282,7 @@ fn x_leq_y_plus_k_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     Ok(Reduction::pure(Expr::FlatIneq(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(x),
         Moo::new(y.clone()),
         Box::new(k.clone()),
@@ -1319,7 +1319,7 @@ fn y_plus_k_geq_x_to_ineq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     Ok(Reduction::pure(Expr::FlatIneq(
-        meta.clone_dirty(),
+        meta.clone(),
         Moo::new(x),
         Moo::new(y.clone()),
         Box::new(k.clone()),
@@ -1350,7 +1350,7 @@ fn not_literal_to_wliteral(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
                 && reference.ptr().domain().is_some_and(|d| d.is_bool())
             {
                 return Ok(Reduction::pure(Expr::FlatWatchedLiteral(
-                    m.clone_dirty(),
+                    m.clone(),
                     reference,
                     Lit::Bool(false),
                 )));

--- a/crates/conjure-cp-rules/src/normalisers/bool.rs
+++ b/crates/conjure-cp-rules/src/normalisers/bool.rs
@@ -66,13 +66,13 @@ fn distribute_or_over_and(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
                                 let mut new_or_contents = rest.clone();
                                 new_or_contents.push(e.clone());
                                 new_and_contents.push(Expr::Or(
-                                    metadata.clone_dirty(),
+                                    metadata.clone(),
                                     Moo::new(into_matrix_expr![new_or_contents]),
                                 ))
                             }
 
                             Ok(Reduction::pure(Expr::And(
-                                metadata.clone_dirty(),
+                                metadata,
                                 Moo::new(into_matrix_expr![new_and_contents]),
                             )))
                         }


### PR DESCRIPTION
The `clean` variable alongside the getter, setter and clone functions regarding it for `Metadata` was never used within conjure-oxide. Clean/dirty tracking is better handled internally by the rewriters.