### PR TITLE
ci(nightly): checkout submodules recursively in the nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -237,6 +237,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Install rust
         run: rustup update stable && rustup default stable
@@ -292,6 +295,9 @@ jobs:
         run: chown root:root .
 
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Build release
         run: |


### PR DESCRIPTION
The nightly release build kept failing for a while.