### PR TITLE
fix(ci): install z3 via homebrew on the macos runners

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -15,6 +15,9 @@ on:
       - rust-toolchain.toml
       - .github/workflows/test-pr.yml
       - .github/workflows/test-main.yml
+  pull_request:
+    paths:
+      - .github/workflows/test-main.yml
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The pavpanchekha/setup-z3 seems to fail on macos.