### PR TITLE
fix(ci): include more targets for RustDoc in coverage reports

### DIFF
--- a/.github/workflows/doc-coverage.yml
+++ b/.github/workflows/doc-coverage.yml
@@ -1,4 +1,4 @@
-name: Documentation Coverage
+name: RustDoc Coverage
 
 # WARNING: This workflow runs on `pull_request_target` and checks out PR code.
 # It therefore executes untrusted code with access to repository secrets, including
@@ -12,6 +12,7 @@ on:
       - tests-integration/**
       - tools/ci/generate-doc-coverage-summary-md.bash
       - tools/ci/generate-doc-coverage-report-md.bash
+      - tools/ci/list-doc-coverage-targets.bash
   push:
     branches:
       - main
@@ -20,6 +21,7 @@ on:
       - tests-integration/**
       - tools/ci/generate-doc-coverage-summary-md.bash
       - tools/ci/generate-doc-coverage-report-md.bash
+      - tools/ci/list-doc-coverage-targets.bash
       - .github/workflows/doc-coverage.yml
       - .github/workflows/code-coverage.yml
       - .github/workflows/rustdoc.yml
@@ -82,11 +84,11 @@ jobs:
       - name: Install pandoc
         uses: pandoc/actions/setup@v1
 
-      - name: Build documentation coverage report
+      - name: Build RustDoc coverage report
         run: |
           mkdir -p deploy
           {
-            echo "# Documentation Coverage Report"
+            echo "# RustDoc Coverage Report"
             echo ""
             ./tools/ci/generate-doc-coverage-summary-md.bash
             echo ""
@@ -137,7 +139,7 @@ jobs:
           target-folder: ${{ steps.deploy.outputs.folder }}
           commit-message: "Actions: Doc coverage for ${{ steps.deploy.outputs.label }}"
 
-      - name: Compute documentation coverage stats for PR
+      - name: Compute RustDoc coverage stats for PR
         if: ${{ github.event_name == 'pull_request_target' }}
         id: stats
         env:
@@ -220,7 +222,7 @@ jobs:
           app-id: ${{ secrets.CONJURE_BOT_ID }}
           private-key: ${{ secrets.CONJURE_BOT_PRIVATE_KEY }}
 
-      - name: Comment documentation coverage on PR
+      - name: Comment RustDoc coverage on PR
         if: ${{ github.event_name == 'pull_request_target' }}
         continue-on-error: true
         uses: actions/github-script@v8
@@ -249,11 +251,11 @@ jobs:
               const marker = "<!-- coverage-docs-report -->";
               const mainLine = process.env.MAIN_AVAILABLE === "true"
                 ? `Main: ${process.env.MAIN_DOCS_PCT}% documented, ${process.env.MAIN_EXAMPLES_PCT}% with examples (${process.env.MAIN_EXAMPLES}/${process.env.MAIN_DOCS}/${process.env.MAIN_TOTAL})\nDelta: docs ${process.env.DELTA_DOCS_PP} pp, examples ${process.env.DELTA_EXAMPLES_PP} pp`
-                : "Main baseline: unavailable (run main documentation coverage first)";
+                : "Main baseline: unavailable (run main RustDoc coverage first)";
 
               const body = [
                 marker,
-                "## Documentation Coverage",
+                "## RustDoc Coverage",
                 "",
                 `Report: ${process.env.REPORT_URL}`,
                 "",

--- a/tools/ci/generate-doc-coverage-report-md.bash
+++ b/tools/ci/generate-doc-coverage-report-md.bash
@@ -1,25 +1,45 @@
 #!/usr/bin/env bash
 #
-# Calculates documentation coverage, pretty printing the resulting tables as Github
+# Calculates RustDoc coverage, pretty printing the resulting tables as Github
 # Flavoured Markdown for consumption by Github Actions.
 #
 # Author: niklasdewally
 # Date: 2024/12/04
 
-CRATES="conjure-cp minion-sys tree-morph"
-JQ_SCRIPT=$(cat <<- 'EOF'
-# convert object {"file":{total:...,with_docs:....}}, to array [{file:...,total:...,}]
-# add percentages and check / cross emojis to each file
+set -euo pipefail
 
-[keys[] as $k
-  | .[$k]
-  | .file = $k
-  | .percentage = ((.with_docs / .total)*100 | round)
-  | .percentage_examples = ((.with_examples / .total)*100 | round)
-  | .emoji = (if .percentage < 90 then "❌" else "✅" end) 
-  | .emoji_examples = (if .percentage_examples < 90 then "❌" else "✅" end) 
- ]
-| sort_by(.percentage)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+JQ_SCRIPT=$(cat <<- 'EOF'
+def merge_reports:
+  reduce .[] as $report ({};
+    reduce ($report | to_entries[]) as $entry (.;
+      .[$entry.key] = if has($entry.key) then
+        {
+          total: (.[$entry.key].total + $entry.value.total),
+          with_docs: (.[$entry.key].with_docs + $entry.value.with_docs),
+          with_examples: (.[$entry.key].with_examples + $entry.value.with_examples)
+        }
+      else
+        $entry.value
+      end
+    )
+  );
+
+merge_reports
+| to_entries
+| map(
+    {
+      file: .key,
+      with_docs: .value.with_docs,
+      with_examples: .value.with_examples,
+      total: .value.total,
+      percentage: (if .value.total > 0 then ((100 * .value.with_docs / .value.total) | round) else 0 end),
+      percentage_examples: (if .value.total > 0 then ((100 * .value.with_examples / .value.total) | round) else 0 end)
+    }
+    | .emoji = (if .percentage < 90 then "❌" else "✅" end)
+    | .emoji_examples = (if .percentage_examples < 90 then "❌" else "✅" end)
+  )
+| sort_by(.percentage, .file)
 | . as $coverage_info
 
 # pretty print each row as csv
@@ -38,15 +58,24 @@ JQ_SCRIPT=$(cat <<- 'EOF'
 
 EOF)
 
-for crate in ${CRATES}; do
-  echo "## Documentation coverage for \`${crate}\`"
+while IFS=$'\t' read -r crate flag1 flag2; do
+  flags=()
+  if [[ -n "${flag1:-}" ]]; then
+    flags+=("${flag1}")
+  fi
+  if [[ -n "${flag2:-}" ]]; then
+    flags+=("${flag2}")
+  fi
+
+  echo "## RustDoc coverage for \`${crate}\`"
   echo ""
-  RUSTDOCFLAGS='-Z unstable-options --show-coverage --output-format=json' cargo +nightly doc -p ${crate} --no-deps |\
-    jq -r "${JQ_SCRIPT}" |\
+  RUSTDOCFLAGS='-Z unstable-options --show-coverage --output-format=json' \
+    cargo +nightly doc -p "${crate}" "${flags[@]}" --no-deps |\
+    jq -s -r "${JQ_SCRIPT}" |\
     pandoc -f csv -t gfm |\
     # pandoc escapes ` in generated markdown, but we want to use it as formatting
     sed 's/\\`/`/g' |\
     sed 's/\\\*/\*/g' 
 
   echo ""
-done
+done < <(bash "${SCRIPT_DIR}/list-doc-coverage-targets.bash")

--- a/tools/ci/generate-doc-coverage-summary-md.bash
+++ b/tools/ci/generate-doc-coverage-summary-md.bash
@@ -1,29 +1,50 @@
 #!/usr/bin/env bash
 #
-# Prints a per-crate summary of documentation coverage in markdown, for consumption by Github Actions.
+# Prints a per-crate summary of RustDoc coverage in markdown, for consumption by Github Actions.
 #
 # Author: niklasdewally
 # Date: 2024/12/04
 
-CRATES="conjure-cp minion-sys tree-morph"
-JQ_SCRIPT=$(cat <<- 'EOF'
-# add percentages to each file
+set -euo pipefail
 
-[keys[] as $k
-  | .[$k]
-  | .file = $k
-  | .percentage = ((.with_docs / .total)*100 | round)
-  | .percentage_examples = ((.with_examples / .total)*100 | round)
- ] as $coverage_info
- | ($coverage_info | [.[].percentage] | add / length | round) as $avg
- | ($coverage_info | [.[].percentage_examples] | add / length | round) as $avg_examples
- | ($coverage_info | [.[].with_examples] | add) as $with_examples
- | ($coverage_info | [.[].with_docs] | add) as $with_docs
- | ($coverage_info | [.[].total] | add) as $total
- | "\($avg_examples)% with examples, \($avg)% documented -- \($with_examples)/\($with_docs)/\($total)"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+JQ_SCRIPT=$(cat <<- 'EOF'
+def merge_reports:
+  reduce .[] as $report ({};
+    reduce ($report | to_entries[]) as $entry (.;
+      .[$entry.key] = if has($entry.key) then
+        {
+          total: (.[$entry.key].total + $entry.value.total),
+          with_docs: (.[$entry.key].with_docs + $entry.value.with_docs),
+          with_examples: (.[$entry.key].with_examples + $entry.value.with_examples)
+        }
+      else
+        $entry.value
+      end
+    )
+  );
+
+merge_reports as $coverage_by_file
+| ($coverage_by_file | to_entries | map(.value + {file: .key})) as $coverage_info
+| ($coverage_info | map(.with_examples) | add // 0) as $with_examples
+| ($coverage_info | map(.with_docs) | add // 0) as $with_docs
+| ($coverage_info | map(.total) | add // 0) as $total
+| (if $total > 0 then ((100 * $with_examples / $total) | round) else 0 end) as $percentage_examples
+| (if $total > 0 then ((100 * $with_docs / $total) | round) else 0 end) as $percentage_docs
+| "\($percentage_examples)% with examples, \($percentage_docs)% documented -- \($with_examples)/\($with_docs)/\($total)"
 EOF)
 
-for crate in ${CRATES}; do
+while IFS=$'\t' read -r crate flag1 flag2; do
+  flags=()
+  if [[ -n "${flag1:-}" ]]; then
+    flags+=("${flag1}")
+  fi
+  if [[ -n "${flag2:-}" ]]; then
+    flags+=("${flag2}")
+  fi
+
   echo -n "**${crate}:** "
-  RUSTDOCFLAGS='-Z unstable-options --show-coverage --output-format=json' cargo +nightly doc -p ${crate} --no-deps | jq -r "${JQ_SCRIPT}"
-done
+  RUSTDOCFLAGS='-Z unstable-options --show-coverage --output-format=json' \
+    cargo +nightly doc -p "${crate}" "${flags[@]}" --no-deps | \
+    jq -s -r "${JQ_SCRIPT}"
+done < <(bash "${SCRIPT_DIR}/list-doc-coverage-targets.bash")

--- a/tools/ci/list-doc-coverage-targets.bash
+++ b/tools/ci/list-doc-coverage-targets.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cargo metadata --format-version=1 --no-deps | jq -r '
+  [
+    .packages[]
+    | select(.name != "tests-integration")
+    | {
+        name: .name,
+        has_lib: any(.targets[]; (.kind | index("lib")) or (.kind | index("proc-macro"))),
+        has_bin: any(.targets[]; .kind | index("bin"))
+      }
+    | select(.has_lib or .has_bin)
+  ]
+  | sort_by(.name)
+  | .[]
+  | [
+      .name,
+      (if .has_lib then "--lib" else empty end),
+      (if .has_bin then "--bins" else empty end)
+    ]
+  | @tsv
+'

--- a/tools/generate-doc-coverage-report-html.bash
+++ b/tools/generate-doc-coverage-report-html.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Generates the documentation coverage report as a html file.
+# Generates the RustDoc coverage report as a html file.
 #
 # Similar to ci/generate-doc-coverage-report-md, but generates a full report as
 # html, not just the data tables.
@@ -11,7 +11,7 @@
 # Date: 2024/12/04
 
 {
-  echo "# Documentation coverage report for \`$(git rev-parse --short HEAD)\`"
+  echo "# RustDoc Coverage Report for \`$(git rev-parse --short HEAD)\`"
   echo "" 
   bash $(dirname "$0")/ci/generate-doc-coverage-report-md.bash 
 } | pandoc -t html5 --shift-heading-level-by=-1 --toc --standalone 


### PR DESCRIPTION
Did you notice that the coverage report percentages never changed? It was because we were running it on a very limited scope. Run it for more targets (all crates) now.