### PR TITLE
fix: restore default features to z3 dep

### DIFF
--- a/crates/conjure-cp-core/Cargo.toml
+++ b/crates/conjure-cp-core/Cargo.toml
@@ -13,7 +13,7 @@ conjure-cp-rule-macros = { path = "../conjure-cp-rule-macros" }
 conjure-cp-enum-compatibility-macro = { path = "../conjure-cp-enum-compatibility-macro" }
 minion-sys = { path = "../minion-sys" }
 tree-morph = { path = "../tree-morph" }
-z3 = { version = "0.19.9", default-features = false }
+z3 = { version = "0.19.9" }
 uniplate = { workspace = true }
 parking_lot = { workspace = true }
 project-root = { workspace = true }


### PR DESCRIPTION
## Description

Attempting to fix nightly builds and issues building on local with `--features z3-bundled`.

## Related issues

The issue was likely introduced in merge commit 72320da27.

## How to test/review

Run:

    cargo build --features z3-bundled
