### PR TITLE
fix(build): propagate z3-bundled through workspace crates

### DIFF
--- a/crates/conjure-cp-cli/Cargo.toml
+++ b/crates/conjure-cp-cli/Cargo.toml
@@ -33,7 +33,7 @@ humantime = { workspace = true }
 
 default = ["extra-rule-checks"]
 extra-rule-checks = ["conjure-cp/extra-rule-checks"]
-z3-bundled = ["conjure-cp/z3-bundled"]
+z3-bundled = ["conjure-cp/z3-bundled", "conjure-cp-rules/z3-bundled", "conjure-cp-lsp/z3-bundled"]
 
 [lints]
 workspace = true

--- a/crates/conjure-cp-essence-macros/Cargo.toml
+++ b/crates/conjure-cp-essence-macros/Cargo.toml
@@ -3,6 +3,10 @@ name = "conjure-cp-essence-macros"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+z3-bundled = ["conjure-cp-essence-parser/z3-bundled"]
+
 [lib]
 proc-macro = true
 

--- a/crates/conjure-cp-essence-parser/Cargo.toml
+++ b/crates/conjure-cp-essence-parser/Cargo.toml
@@ -3,6 +3,10 @@ name = "conjure-cp-essence-parser"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+z3-bundled = ["conjure-cp-core/z3-bundled"]
+
 [dependencies]
 conjure-cp-core = { path = "../conjure-cp-core" }
 tree-sitter-essence = { path = "../tree-sitter-essence" }

--- a/crates/conjure-cp-lsp/Cargo.toml
+++ b/crates/conjure-cp-lsp/Cargo.toml
@@ -3,6 +3,10 @@ name = "conjure-cp-lsp"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+z3-bundled = ["conjure-cp-essence-parser/z3-bundled"]
+
 [dependencies]
 tokio = { version = "1.49.0", features = ["full"] }
 tower-lsp = "0.20.0"

--- a/crates/conjure-cp-rules/Cargo.toml
+++ b/crates/conjure-cp-rules/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 default = []
+z3-bundled = ["conjure-cp/z3-bundled"]
 extra-rule-checks = []
 
 [dependencies]

--- a/crates/conjure-cp/Cargo.toml
+++ b/crates/conjure-cp/Cargo.toml
@@ -10,7 +10,11 @@ conjure-cp-essence-parser = { version = "0.1.0", path = "../conjure-cp-essence-p
 
 [features]
 default = []
-z3-bundled = ["conjure-cp-core/z3-bundled"]
+z3-bundled = [
+    "conjure-cp-core/z3-bundled",
+    "conjure-cp-essence-macros/z3-bundled",
+    "conjure-cp-essence-parser/z3-bundled",
+]
 extra-rule-checks = ["conjure-cp-core/extra-rule-checks"]
 
 [lints]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [features]
 default = []
-z3-bundled = ["conjure-cp-cli/z3-bundled"]
+z3-bundled = ["conjure-cp/z3-bundled", "conjure-cp-cli/z3-bundled"]
 extra-rule-checks = [
     "conjure-cp/extra-rule-checks",
     "conjure-cp-cli/extra-rule-checks",


### PR DESCRIPTION
we just had to propagate the feature to several other crates.

nightly release (which is the only CI workflow that uses z3-bundled( has been failing last few days. hoping it'll be fixed by this.