### PR TITLE
feat(testing): Adding option to use default config when running integration tests

### DIFF
--- a/tests-integration/testconfig.toml
+++ b/tests-integration/testconfig.toml
@@ -1,0 +1,30 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]
+
+rewriter = [
+    "naive",
+    # "morph",
+]
+
+comprehension-expander = [
+    # "native",
+    # "via-solver",
+    "via-solver-ac",
+]
+
+solver = [
+    "minion",
+    # "sat-log",
+    # "sat-direct",
+    # "sat-order",
+    # "smt-bv-arrays-nodiscrete",
+    # "smt-bv-arrays",
+    # "smt-bv-atomic-nodiscrete",
+    # "smt-bv-atomic",
+    # "smt-lia-arrays-nodiscrete",
+    # "smt-lia-arrays",
+    # "smt-lia-atomic-nodiscrete",
+    # "smt-lia-atomic",
+]

--- a/tests-integration/tests/integration_tests.rs
+++ b/tests-integration/tests/integration_tests.rs
@@ -73,6 +73,8 @@ fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(
 
     let file_config: TestConfig = if default_test_config {
         TestConfig::default()
+    } else if let Ok(config_contents) = fs::read_to_string(format!("./testconfig.toml")) {
+        toml::from_str(&config_contents).unwrap()
     } else if let Ok(config_contents) = fs::read_to_string(format!("{path}/config.toml")) {
         toml::from_str(&config_contents).unwrap()
     } else {


### PR DESCRIPTION
## Description
__This is only a hotfix, in lieu of a better testing harness__
Adds a way to force integration tester to use default config instead of provided config.toml
Adds a way to use a universal config file

## Key changes

- New env arg: "DEFCONFIG" is now an environment variable, which, when set, will force conjure oxide's integration tester to use the default config
- a config file 'testconfig.toml' in the `tests-integration` sub-directory will now supersede all testing files

## How to test/review

put the default config file in and run any test with the --no-capture flag. It should tell you that it is running all of the tests that are specified in the default config file
run the integration tester with the "DEFCONFIG" environment variable set and with the --no-capture flag.
