### PR TITLE
fix(perf): disable verbose logging in production builds

### DIFF
--- a/crates/conjure-cp-core/src/rule_engine/rewrite_naive.rs
+++ b/crates/conjure-cp-core/src/rule_engine/rewrite_naive.rs
@@ -129,6 +129,8 @@ fn try_rewrite_model(
 
                 match (rd.rule.application)(&expr, &submodel.symbols()) {
                     Ok(red) => {
+                        // when called a lot, this becomes very expensive!
+                        #[cfg(debug_assertions)]
                         log_verbose_rule_attempt(
                             run_start,
                             priority,
@@ -161,6 +163,8 @@ fn try_rewrite_model(
                         ));
                     }
                     Err(_) => {
+                        // when called a lot, this becomes very expensive!
+                        #[cfg(debug_assertions)]
                         log_verbose_rule_attempt(
                             run_start,
                             priority,
@@ -168,16 +172,6 @@ fn try_rewrite_model(
                             rd.rule_set.name,
                             "fail",
                             &expr,
-                        );
-
-                        // when called a lot, this becomes very expensive!
-                        #[cfg(debug_assertions)]
-                        tracing::trace!(
-                            "Rule attempted but not applied: {} (priority {}, rule set {}), to expression: {}",
-                            rd.rule.name,
-                            priority,
-                            rd.rule_set.name,
-                            expr
                         );
                     }
                 }


### PR DESCRIPTION
## Description

Reinstates the old behaviour of only printing verbose traces of rule application attempts in debug builds.

## Rationale

In production builds, there is no verbose trace file to actually print them to, but all the work of generating the pretty-printed trace is still done. As a result, we spend as much as 40% of CPU time serialising/pretty-printing things and dispatching trace events for no benefit. 

The stack traces of these tracing functions also pollute the output of perf/samply and make performance investigation harder!

This PR also removes the duplicate call to `trace!` as `log_verbose_rule_attempt` now seems to do the same thing
