### PR TITLE
chore: update uniplate to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,18 +3207,18 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniplate"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc74096dfdff85e63755c9d7333cbdb4de02e8b75ca1d9436212cac98f8c606"
+checksum = "9f35833ae3c274302cf7cbe255cb865359bd2fec8fb4adc7f98a96d6e84f59e6"
 dependencies = [
  "uniplate-derive",
 ]
 
 [[package]]
 name = "uniplate-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f1c9028bf55b827c62a3a6967a00f5f03f66caf132e2d95fc4e9db4f815c31"
+checksum = "634c9aabeccd9c999336d8c56e52a223a511ff6a557766ed8e99a9419df48347"
 dependencies = [
  "itertools 0.14.0",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi","env-filter","json",] }
 tree-sitter = "0.26.6"
 tree-sitter-haskell = "0.23.0"
-uniplate = "0.4.5"
+uniplate = "0.4.6"
 ustr = { version = "1.1.0", features = ["serde"] }
 versions = "7.0.0"
 walkdir = "2.5.0"

--- a/crates/tree-morph/Cargo.toml
+++ b/crates/tree-morph/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multipeek = "0.1.2"
 rand = "0.10.0"
-uniplate = "0.4.4"
+uniplate = "0.4.6"
 paste = { workspace = true }
 
 


### PR DESCRIPTION
Update uniplate to 0.4.6. This version contains some performance improvements