### PR TITLE
fix: AbstractLiteral display

### DIFF
--- a/crates/conjure-cp-core/src/ast/literals.rs
+++ b/crates/conjure-cp-core/src/ast/literals.rs
@@ -672,7 +672,7 @@ impl Display for Literal {
         match &self {
             Literal::Int(i) => write!(f, "{i}"),
             Literal::Bool(b) => write!(f, "{b}"),
-            Literal::AbstractLiteral(l) => write!(f, "{l:?}"),
+            Literal::AbstractLiteral(l) => write!(f, "{l}"),
         }
     }
 }

--- a/tests-integration/tests/integration/basic/div/01/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/div/01/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -387,7 +387,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)])
 
@@ -399,11 +399,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__62,__83;int(1..)]);int(1..)])
@@ -416,12 +416,12 @@ and([__62,__83;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__62,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
@@ -429,13 +429,13 @@ __83
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83
@@ -444,12 +444,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83
 new clauses:
@@ -457,21 +457,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83
 new clauses:
   (__62)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__83)
 
@@ -579,13 +579,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) @ __98}
+{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])) @ __98}
 
 --
 
-(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __108
 new variables:

--- a/tests-integration/tests/integration/basic/div/01/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/div/01/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -387,7 +387,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)])
 
@@ -399,11 +399,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__62,__83;int(1..)]);int(1..)])
@@ -416,12 +416,12 @@ and([__62,__83;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__62,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
@@ -429,13 +429,13 @@ __83
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83
@@ -444,12 +444,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83
 new clauses:
@@ -457,21 +457,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83
 new clauses:
   (__62)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__83)
 
@@ -579,13 +579,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) @ __98}
+{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])) @ __98}
 
 --
 
-(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __108
 new variables:

--- a/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,77 +11,77 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)]
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i], 
    ~~> index_to_bubble ([("Bubble", 6000)])
-{Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])}
+{[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])}
 
 --
 
-({Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])} = i), 
+({[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])} = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] = i)
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] = i)
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i], 
    ~~> matrix_to_list ([("Base", 2000)])
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)][i, i]
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)][i, i] = i), 
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) })[i, i] = i)
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i] = i)
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i], 
    ~~> remove_dimension_from_matrix_indexing ([("Base", 2000)])
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i]
+[[1,2,3;int(1..3)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i]
 
 --
 
-Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[1,2,3;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [1,2,3;int(1..)][i]
 
 --
 
-([[1,2,3;int(1..)][i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i)
 
 --
 
-Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[4,5,6;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [4,5,6;int(1..)][i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],[4,5,6;int(1..)][i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i)
 
 --
 
-Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[7,8,9;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [7,8,9;int(1..)][i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],[7,8,9;int(1..)][i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i] = i)
 
 --
 
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i];int(1..)][i], 
+[[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i], 
    ~~> flatten_matrix_literal ([("Minion", 1000)])
 [__0,__1,__2;int(1..)][i]
 new variables:
@@ -89,9 +89,9 @@ new variables:
   find __1: int(4..6)
   find __2: int(7..9)
 new constraints:
-  __0 =aux Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i]
-  __1 =aux Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i]
-  __2 =aux Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i]
+  __0 =aux [1,2,3;int(1..)][i]
+  __1 =aux [4,5,6;int(1..)][i]
+  __2 =aux [7,8,9;int(1..)][i]
 
 --
 
@@ -101,19 +101,19 @@ __minion_element_one([__0,__1,__2],i,i)
 
 --
 
-__0 =aux Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__0 =aux [1,2,3;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([1,2,3],i,__0)
 
 --
 
-__1 =aux Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__1 =aux [4,5,6;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([4,5,6],i,__1)
 
 --
 
-__2 =aux Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__2 =aux [7,8,9;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([7,8,9],i,__2)
 

--- a/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,77 +11,77 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)]
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i], 
    ~~> index_to_bubble ([("Bubble", 6000)])
-{Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])}
+{[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])}
 
 --
 
-({Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])} = i), 
+({[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] @ and([__inDomain(i,int(1..3)),__inDomain(i,int(1..3));int(1..)])} = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i] = i)
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i] = i)
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..3)][i, i], 
    ~~> matrix_to_list ([("Base", 2000)])
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)][i, i]
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)][i, i] = i), 
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) })[i, i] = i)
+([[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i] = i)
 
 --
 
-Matrix([AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) })[i, i], 
+[[1,2,3;int(1..3)],[4,5,6;int(1..3)],[7,8,9;int(1..3)];int(1..)][i, i], 
    ~~> remove_dimension_from_matrix_indexing ([("Base", 2000)])
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i]
+[[1,2,3;int(1..3)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i]
 
 --
 
-Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[1,2,3;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [1,2,3;int(1..)][i]
 
 --
 
-([[1,2,3;int(1..)][i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..3)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i)
 
 --
 
-Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[4,5,6;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [4,5,6;int(1..)][i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],[4,5,6;int(1..)][i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..3)][i];int(1..)][i] = i)
 
 --
 
-Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([Bounded(1, 3)]) })[i], 
+[7,8,9;int(1..3)][i], 
    ~~> matrix_to_list ([("Base", 2000)])
 [7,8,9;int(1..)][i]
 
 --
 
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],[7,8,9;int(1..)][i];int(1..)][i] = i), 
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i] = i), 
    ~~> constant_evaluator ([("Constant", 9001)])
-([Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i];int(1..)][i] = i)
+([[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i] = i)
 
 --
 
-[Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i],Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i];int(1..)][i], 
+[[1,2,3;int(1..)][i],[4,5,6;int(1..)][i],[7,8,9;int(1..)][i];int(1..)][i], 
    ~~> flatten_matrix_literal ([("Minion", 1000)])
 [__0,__1,__2;int(1..)][i]
 new variables:
@@ -89,9 +89,9 @@ new variables:
   find __1: int(4..6)
   find __2: int(7..9)
 new constraints:
-  __0 =aux Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i]
-  __1 =aux Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i]
-  __2 =aux Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i]
+  __0 =aux [1,2,3;int(1..)][i]
+  __1 =aux [4,5,6;int(1..)][i]
+  __2 =aux [7,8,9;int(1..)][i]
 
 --
 
@@ -101,19 +101,19 @@ __minion_element_one([__0,__1,__2],i,i)
 
 --
 
-__0 =aux Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__0 =aux [1,2,3;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([1,2,3],i,__0)
 
 --
 
-__1 =aux Matrix([Int(4), Int(5), Int(6)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__1 =aux [4,5,6;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([4,5,6],i,__1)
 
 --
 
-__2 =aux Matrix([Int(7), Int(8), Int(9)], Moo { inner: Int([UnboundedR(1)]) })[i], 
+__2 =aux [7,8,9;int(1..)][i], 
    ~~> introduce_element_from_index ([("Minion", 4400)])
 __minion_element_one([7,8,9],i,__2)
 

--- a/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -67,45 +67,45 @@ SATInt(Log, [true,true,false;int(1..)] [3, 3])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -185,7 +185,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __25
 new variables:
@@ -231,21 +231,21 @@ new clauses:
 --
 
 __25,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__25)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -291,19 +291,19 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -349,17 +349,17 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -405,15 +405,15 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __69
 new variables:

--- a/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -67,45 +67,45 @@ SATInt(Log, [true,true,false;int(1..)] [3, 3])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -185,7 +185,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __25
 new variables:
@@ -231,21 +231,21 @@ new clauses:
 --
 
 __25,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__25)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -291,19 +291,19 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -349,17 +349,17 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -405,15 +405,15 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __69
 new variables:

--- a/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/02/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_2,__52#sat_direct_int_3,__52#sat_direct_int_4;int(1..)] [2, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_2,__52#sat_direct_int_3,__52#sat_direct_int_4;int(1..)] [2, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 4]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_02,__40#sat_order_int_03,__40#sat_order_int_04;int(1..)] [2, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_02,__40#sat_order_int_03,__40#sat_order_int_04;int(1..)] [2, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_2,__52#sat_direct_int_3,__52#sat_direct_int_4;int(1..)] [2, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_2,__52#sat_direct_int_3,__52#sat_direct_int_4;int(1..)] [2, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 4]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/03/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_02,__40#sat_order_int_03,__40#sat_order_int_04;int(1..)] [2, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_02,__40#sat_order_int_03,__40#sat_order_int_04;int(1..)] [2, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 and([__8,__17;int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 or([and([__34,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__34,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 and([__34,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51
 new clauses:
   (__34)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3]))
 new clauses:
   (__51)
 
@@ -428,7 +428,7 @@ SATInt(Direct, [true;int(1..)] [7, 7])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_4,__52#sat_direct_int_5,__52#sat_direct_int_6,__52#sat_direct_int_7;int(1..)] [4, 7]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Direct, [__52#sat_direct_int_4,__52#sat_direct_int_5,__52#sat_direct_int_6,__52#sat_direct_int_7;int(1..)] [4, 7]) >= SATInt(Direct, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __73
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [true,true,true,false;int(1..)] [7, 7])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [4, 7]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__6,__13;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 and([__6,__13;int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 or([and([__26,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__26,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 and([__26,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39
 new clauses:
   (__26)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3]))
 new clauses:
   (__39)
 
@@ -384,7 +384,7 @@ SATInt(Order, [true;int(1..)] [7, 7])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_04,__40#sat_order_int_05,__40#sat_order_int_06,__40#sat_order_int_07;int(1..)] [4, 7]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Order, [__40#sat_order_int_04,__40#sat_order_int_05,__40#sat_order_int_06,__40#sat_order_int_07;int(1..)] [4, 7]) >= SATInt(Order, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __56
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 and([__8,__17;int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 or([and([__34,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__34,__51;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 and([__34,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51
 new clauses:
   (__34)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3]))
 new clauses:
   (__51)
 
@@ -428,7 +428,7 @@ SATInt(Direct, [true;int(1..)] [7, 7])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_4,__52#sat_direct_int_5,__52#sat_direct_int_6,__52#sat_direct_int_7;int(1..)] [4, 7]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Direct, [__52#sat_direct_int_4,__52#sat_direct_int_5,__52#sat_direct_int_6,__52#sat_direct_int_7;int(1..)] [4, 7]) >= SATInt(Direct, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __73
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [true,true,true,false;int(1..)] [7, 7])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [4, 7]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/04/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__6,__13;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 and([__6,__13;int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 or([and([__26,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__26,__39;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 and([__26,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39
 new clauses:
   (__26)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3]))
 new clauses:
   (__39)
 
@@ -384,7 +384,7 @@ SATInt(Order, [true;int(1..)] [7, 7])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_04,__40#sat_order_int_05,__40#sat_order_int_06,__40#sat_order_int_07;int(1..)] [4, 7]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Order, [__40#sat_order_int_04,__40#sat_order_int_05,__40#sat_order_int_06,__40#sat_order_int_07;int(1..)] [4, 7]) >= SATInt(Order, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __56
 new variables:

--- a/tests-integration/tests/integration/basic/max/05/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/05/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/basic/max/05/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/05/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/max/05/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/05/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/basic/max/05/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/max/05/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -67,45 +67,45 @@ SATInt(Log, [true,true,false;int(1..)] [3, 3])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -185,7 +185,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __25
 new variables:
@@ -231,21 +231,21 @@ new clauses:
 --
 
 __25,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__25)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -291,19 +291,19 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -349,17 +349,17 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -405,15 +405,15 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __69
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -67,45 +67,45 @@ SATInt(Log, [true,true,false;int(1..)] [3, 3])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -185,7 +185,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__12,__13,__14;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __25
 new variables:
@@ -231,21 +231,21 @@ new clauses:
 --
 
 __25,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__25)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -291,19 +291,19 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -349,17 +349,17 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -405,15 +405,15 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __69
 new variables:

--- a/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/02/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_01,b#sat_order_int_02,b#sat_order_int_03;int(1..)] [1, 3]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__12,__25;int(1..)]);int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__12,__25;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__12,__25;int(1..)]),
 or([and([__38,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 or([and([__38,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__38,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 and([__38,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __12,
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __25,
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __38,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__38)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3;int(1..)] [1, 3]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -427,7 +427,7 @@ SATInt(Direct, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2,__52#sat_direct_int_3;int(1..)] [1, 3]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 3]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/03/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__9,__19;int(1..)]);int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__9,__19;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__9,__19;int(1..)]),
 or([and([__29,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 or([and([__29,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__29,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 and([__29,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __9,
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __19,
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __29,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39
 new clauses:
   (__29)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03;int(1..)] [1, 3]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__39)
 
@@ -383,7 +383,7 @@ SATInt(Order, [true;int(1..)] [3, 3])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02,__40#sat_order_int_03;int(1..)] [1, 3]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 and([__8,__17;int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 or([and([__34,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__34,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 and([__34,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51
 new clauses:
   (__34)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Direct, [true;int(1..)] [2, 2])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2;int(1..)] [1, 2]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2;int(1..)] [1, 2]) >= SATInt(Direct, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [true,true,true,false;int(1..)] [7, 7])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 2]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__6,__13;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 and([__6,__13;int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 or([and([__26,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__26,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 and([__26,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39
 new clauses:
   (__26)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3]))
 new clauses:
   (__39)
 
@@ -382,7 +382,7 @@ SATInt(Order, [true;int(1..)] [2, 2])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02;int(1..)] [1, 2]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02;int(1..)] [1, 2]) >= SATInt(Order, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -271,7 +271,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)])
 
@@ -283,11 +283,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 and([__8,__17;int(1..)]),
 or([and([__34,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 or([and([__34,__51;int(1..)]);int(1..)])
@@ -300,12 +300,12 @@ and([__34,__51;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 and([__34,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
@@ -313,13 +313,13 @@ __51
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __8,
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51
@@ -328,12 +328,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __17,
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51
 new clauses:
@@ -341,21 +341,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __34,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51
 new clauses:
   (__34)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2;int(1..)] [1, 2]),SATInt(Direct, [b#sat_direct_int_4,b#sat_direct_int_5,b#sat_direct_int_6,b#sat_direct_int_7;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [3, 3]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Direct, [true;int(1..)] [2, 2])
 
 --
 
-(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2;int(1..)] [1, 2]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Direct, [__52#sat_direct_int_1,__52#sat_direct_int_2;int(1..)] [1, 2]) >= SATInt(Direct, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -68,45 +68,45 @@ SATInt(Log, [true,true,true,false;int(1..)] [7, 7])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 
 --
 
@@ -213,7 +213,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 2]) >= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -276,21 +276,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __47
 new variables:
@@ -336,19 +336,19 @@ new clauses:
 --
 
 __47,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__47)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [1, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -394,17 +394,17 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -467,15 +467,15 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [4, 7]) <= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:

--- a/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/04/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -227,7 +227,7 @@ new clauses:
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 or([and([__6,__13;int(1..)]);int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)])
 
@@ -239,11 +239,11 @@ and([__6,__13;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 and([__6,__13;int(1..)]),
 or([and([__26,__39;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 or([and([__26,__39;int(1..)]);int(1..)])
@@ -256,12 +256,12 @@ and([__26,__39;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 and([__26,__39;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
@@ -269,13 +269,13 @@ __39
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __6,
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39
@@ -284,12 +284,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __13,
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39
 new clauses:
@@ -297,21 +297,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __26,
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39
 new clauses:
   (__26)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3])),
 __39, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02;int(1..)] [1, 2]),SATInt(Order, [b#sat_order_int_04,b#sat_order_int_05,b#sat_order_int_06,b#sat_order_int_07;int(1..)] [4, 7]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [3, 3]))
 new clauses:
   (__39)
 
@@ -382,7 +382,7 @@ SATInt(Order, [true;int(1..)] [2, 2])
 
 --
 
-(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02;int(1..)] [1, 2]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Order, [__40#sat_order_int_01,__40#sat_order_int_02;int(1..)] [1, 2]) >= SATInt(Order, [true;int(1..)] [3, 3])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __50
 new variables:

--- a/tests-integration/tests/integration/basic/min/05/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/05/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/basic/min/05/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/05/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/min/05/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/05/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/basic/min/05/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/min/05/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/basic/negativeTable/01/tree-sitter-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/negativeTable/01/tree-sitter-naive-native-minion-expected-rule-trace.txt
@@ -11,19 +11,19 @@ negativeTable([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..2)])
 
 negativeTable([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-negativeTable([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 2)]) }))
+negativeTable([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..2)])
 
 --
 
-negativeTable([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 2)]) })), 
+negativeTable([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..2)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-negativeTable([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)])
+negativeTable([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..)])
 
 --
 
-negativeTable([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)]), 
+negativeTable([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-negativeTable([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+negativeTable([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..)])
 
 --
 
@@ -34,5 +34,5 @@ find b: int(1..3)
 
 such that
 
-negativeTable([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+negativeTable([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -23,7 +23,7 @@ such that
    ~~> constant_evaluator ([("Constant", 9001)])
 (x[a] = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -45,12 +45,12 @@ x#record_to_atom[a],
 
 ({x#record_to_atom[1] @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#record_to_atom[1] = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -69,12 +69,12 @@ x#record_to_atom[b],
 
 (x#record_to_atom[1] = true),
 ({x#record_to_atom[2] @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#record_to_atom[1] = true),
 (x#record_to_atom[2] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -121,15 +121,15 @@ x#record_to_atom_2
 
 --
 
-(y#record_to_atom = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])), 
+(y#record_to_atom = {a: false,b: 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(y#record_to_atom[1] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[1]),(y#record_to_atom[2] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[2]);int(1..)])
+and([(y#record_to_atom[1] = {a: false,b: 4}[1]),(y#record_to_atom[2] = {a: false,b: 4}[2]);int(1..)])
 
 --
 
 Reify(true, x#record_to_atom_1),
 (x#record_to_atom_2 = 3),
-and([(y#record_to_atom[1] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[1]),(y#record_to_atom[2] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[2]);int(1..)]),
+and([(y#record_to_atom[1] = {a: false,b: 4}[1]),(y#record_to_atom[2] = {a: false,b: 4}[2]);int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
 Reify(true, x#record_to_atom_1),

--- a/tests-integration/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -23,7 +23,7 @@ such that
    ~~> constant_evaluator ([("Constant", 9001)])
 (x[a] = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -45,12 +45,12 @@ x#record_to_atom[a],
 
 ({x#record_to_atom[1] @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#record_to_atom[1] = true),
 (x[b] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -69,12 +69,12 @@ x#record_to_atom[b],
 
 (x#record_to_atom[1] = true),
 ({x#record_to_atom[2] @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#record_to_atom[1] = true),
 (x#record_to_atom[2] = 3),
-(y = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])),
+(y = {a: false,b: 4}),
 (y = z)
 
 --
@@ -121,15 +121,15 @@ x#record_to_atom_2
 
 --
 
-(y#record_to_atom = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])), 
+(y#record_to_atom = {a: false,b: 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(y#record_to_atom[1] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[1]),(y#record_to_atom[2] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[2]);int(1..)])
+and([(y#record_to_atom[1] = {a: false,b: 4}[1]),(y#record_to_atom[2] = {a: false,b: 4}[2]);int(1..)])
 
 --
 
 Reify(true, x#record_to_atom_1),
 (x#record_to_atom_2 = 3),
-and([(y#record_to_atom[1] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[1]),(y#record_to_atom[2] = Record([RecordValue { name: User(u!("a")), value: Bool(false) }, RecordValue { name: User(u!("b")), value: Int(4) }])[2]);int(1..)]),
+and([(y#record_to_atom[1] = {a: false,b: 4}[1]),(y#record_to_atom[2] = {a: false,b: 4}[2]);int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
 Reify(true, x#record_to_atom_1),

--- a/tests-integration/tests/integration/basic/table/01/tree-sitter-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/01/tree-sitter-naive-native-minion-expected-rule-trace.txt
@@ -12,19 +12,19 @@ table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];
 
 table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([x,y,z;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) }))
+table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)])
 
 --
 
-table([x,y,z;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })), 
+table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([x,y,z;int(1..)], [Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)])
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 
 --
 
-table([x,y,z;int(1..)], [Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)]), 
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([x,y,z;int(1..)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 
 --
 
@@ -36,5 +36,5 @@ find z: int(1..3)
 
 such that
 
-table([x,y,z;int(1..)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/table/01/via-conjure-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/01/via-conjure-naive-native-minion-expected-rule-trace.txt
@@ -12,19 +12,19 @@ table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];
 
 table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([x,y,z;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) }))
+table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)])
 
 --
 
-table([x,y,z;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 3)]) })), 
+table([x,y,z;int(1..3)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..3)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([x,y,z;int(1..)], [Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)])
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 
 --
 
-table([x,y,z;int(1..)], [Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)]), 
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([x,y,z;int(1..)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 
 --
 
@@ -36,5 +36,5 @@ find z: int(1..3)
 
 such that
 
-table([x,y,z;int(1..)], Matrix([AbstractLiteral(Matrix([Int(1), Int(1), Int(2)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(2), Int(1), Int(3)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([x,y,z;int(1..)], [[1,1,2;int(1..3)],[1,2,3;int(1..3)],[2,1,3;int(1..3)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/table/02/tree-sitter-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/02/tree-sitter-naive-native-minion-expected-rule-trace.txt
@@ -11,19 +11,19 @@ table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3
 
 table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 3)]) }))
+table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)])
 
 --
 
-table([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 3)]) })), 
+table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)])
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 
 --
 
-table([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)]), 
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 
 --
 
@@ -34,5 +34,5 @@ find b: int(0..2)
 
 such that
 
-table([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/table/02/via-conjure-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/02/via-conjure-naive-native-minion-expected-rule-trace.txt
@@ -11,19 +11,19 @@ table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3
 
 table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 3)]) }))
+table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)])
 
 --
 
-table([a,b;int(1..2)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([Bounded(1, 3)]) })), 
+table([a,b;int(1..2)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..3)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)])
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 
 --
 
-table([a,b;int(1..)], [Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) }),Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) });int(1..)]), 
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 
 --
 
@@ -34,5 +34,5 @@ find b: int(0..2)
 
 such that
 
-table([a,b;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(1), Int(0)], Moo { inner: Int([Bounded(1, 2)]) })), AbstractLiteral(Matrix([Int(2), Int(2)], Moo { inner: Int([Bounded(1, 2)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([a,b;int(1..)], [[0,1;int(1..2)],[1,0;int(1..2)],[2,2;int(1..2)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/table/03/tree-sitter-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/03/tree-sitter-naive-native-minion-expected-rule-trace.txt
@@ -12,19 +12,19 @@ table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)])
 
 table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([p,q,r;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 2)]) }))
+table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)])
 
 --
 
-table([p,q,r;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 2)]) })), 
+table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([p,q,r;int(1..)], [Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)])
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 
 --
 
-table([p,q,r;int(1..)], [Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)]), 
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([p,q,r;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 
 --
 
@@ -36,5 +36,5 @@ find r: int(0..1)
 
 such that
 
-table([p,q,r;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/table/03/via-conjure-naive-native-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/table/03/via-conjure-naive-native-minion-expected-rule-trace.txt
@@ -12,19 +12,19 @@ table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)])
 
 table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([p,q,r;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 2)]) }))
+table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)])
 
 --
 
-table([p,q,r;int(1..3)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([Bounded(1, 2)]) })), 
+table([p,q,r;int(1..3)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..2)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-table([p,q,r;int(1..)], [Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)])
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 
 --
 
-table([p,q,r;int(1..)], [Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) }),Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) });int(1..)]), 
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-table([p,q,r;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 
 --
 
@@ -36,5 +36,5 @@ find r: int(0..1)
 
 such that
 
-table([p,q,r;int(1..)], Matrix([AbstractLiteral(Matrix([Int(0), Int(1), Int(0)], Moo { inner: Int([Bounded(1, 3)]) })), AbstractLiteral(Matrix([Int(1), Int(0), Int(1)], Moo { inner: Int([Bounded(1, 3)]) }))], Moo { inner: Int([UnboundedR(1)]) }))
+table([p,q,r;int(1..)], [[0,1,0;int(1..3)],[1,0,1;int(1..3)];int(1..)])
 

--- a/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,7 +10,7 @@ such that
 
 (x = (2,3)), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(x = Tuple([Int(2), Int(3)]))
+(x = (2,3))
 
 --
 
@@ -23,13 +23,13 @@ new variables:
 
 --
 
-(x#tuple_to_atom = Tuple([Int(2), Int(3)])), 
+(x#tuple_to_atom = (2,3)), 
    ~~> tuple_to_constant ([("Base", 2000)])
-and([(x#tuple_to_atom[1] = Tuple([Int(2), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(2), Int(3)])[2]);int(1..)])
+and([(x#tuple_to_atom[1] = (2,3)[1]),(x#tuple_to_atom[2] = (2,3)[2]);int(1..)])
 
 --
 
-and([(x#tuple_to_atom[1] = Tuple([Int(2), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(2), Int(3)])[2]);int(1..)]), 
+and([(x#tuple_to_atom[1] = (2,3)[1]),(x#tuple_to_atom[2] = (2,3)[2]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#tuple_to_atom[1] = 2),
 (x#tuple_to_atom[2] = 3)

--- a/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,7 +10,7 @@ such that
 
 (x = (2,3)), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(x = Tuple([Int(2), Int(3)]))
+(x = (2,3))
 
 --
 
@@ -23,13 +23,13 @@ new variables:
 
 --
 
-(x#tuple_to_atom = Tuple([Int(2), Int(3)])), 
+(x#tuple_to_atom = (2,3)), 
    ~~> tuple_to_constant ([("Base", 2000)])
-and([(x#tuple_to_atom[1] = Tuple([Int(2), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(2), Int(3)])[2]);int(1..)])
+and([(x#tuple_to_atom[1] = (2,3)[1]),(x#tuple_to_atom[2] = (2,3)[2]);int(1..)])
 
 --
 
-and([(x#tuple_to_atom[1] = Tuple([Int(2), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(2), Int(3)])[2]);int(1..)]), 
+and([(x#tuple_to_atom[1] = (2,3)[1]),(x#tuple_to_atom[2] = (2,3)[2]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#tuple_to_atom[1] = 2),
 (x#tuple_to_atom[2] = 3)

--- a/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,7 +11,7 @@ such that
 
 (x = (1,3)), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(x = Tuple([Int(1), Int(3)]))
+(x = (1,3))
 
 --
 
@@ -24,13 +24,13 @@ new variables:
 
 --
 
-(x#tuple_to_atom = Tuple([Int(1), Int(3)])), 
+(x#tuple_to_atom = (1,3)), 
    ~~> tuple_to_constant ([("Base", 2000)])
-and([(x#tuple_to_atom[1] = Tuple([Int(1), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(1), Int(3)])[2]);int(1..)])
+and([(x#tuple_to_atom[1] = (1,3)[1]),(x#tuple_to_atom[2] = (1,3)[2]);int(1..)])
 
 --
 
-and([(x#tuple_to_atom[1] = Tuple([Int(1), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(1), Int(3)])[2]);int(1..)]), 
+and([(x#tuple_to_atom[1] = (1,3)[1]),(x#tuple_to_atom[2] = (1,3)[2]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#tuple_to_atom[1] = 1),
 (x#tuple_to_atom[2] = 3)

--- a/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,7 +11,7 @@ such that
 
 (x = (1,3)), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(x = Tuple([Int(1), Int(3)]))
+(x = (1,3))
 
 --
 
@@ -24,13 +24,13 @@ new variables:
 
 --
 
-(x#tuple_to_atom = Tuple([Int(1), Int(3)])), 
+(x#tuple_to_atom = (1,3)), 
    ~~> tuple_to_constant ([("Base", 2000)])
-and([(x#tuple_to_atom[1] = Tuple([Int(1), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(1), Int(3)])[2]);int(1..)])
+and([(x#tuple_to_atom[1] = (1,3)[1]),(x#tuple_to_atom[2] = (1,3)[2]);int(1..)])
 
 --
 
-and([(x#tuple_to_atom[1] = Tuple([Int(1), Int(3)])[1]),(x#tuple_to_atom[2] = Tuple([Int(1), Int(3)])[2]);int(1..)]), 
+and([(x#tuple_to_atom[1] = (1,3)[1]),(x#tuple_to_atom[2] = (1,3)[2]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x#tuple_to_atom[1] = 1),
 (x#tuple_to_atom[2] = 3)

--- a/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ or([;int(1..0)])
 
 or([;int(1..0)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-or(Matrix([], Moo { inner: Int([Bounded(1, 0)]) }))
+or([;int(1..0)])
 
 --
 
-or(Matrix([], Moo { inner: Int([Bounded(1, 0)]) })), 
+or([;int(1..0)]), 
    ~~> matrix_to_list ([("Base", 2000)])
 or([;int(1..)])
 

--- a/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ or([;int(1..0)])
 
 or([;int(1..0)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-or(Matrix([], Moo { inner: Int([Bounded(1, 0)]) }))
+or([;int(1..0)])
 
 --
 
-or(Matrix([], Moo { inner: Int([Bounded(1, 0)]) })), 
+or([;int(1..0)]), 
    ~~> matrix_to_list ([("Base", 2000)])
 or([;int(1..)])
 

--- a/tests-integration/tests/integration/cnf/comparison/better_direct/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/better_direct/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -212,17 +212,17 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -233,11 +233,11 @@ and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -246,18 +246,18 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -268,12 +268,12 @@ and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -282,19 +282,19 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -305,13 +305,13 @@ and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -320,20 +320,20 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -344,14 +344,14 @@ and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -360,21 +360,21 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -385,15 +385,15 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -402,16 +402,16 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -456,16 +456,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -473,16 +473,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__5)
 
@@ -528,32 +528,32 @@ __11,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__11)
 
@@ -598,31 +598,31 @@ __17,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__17)
 
@@ -666,30 +666,30 @@ __23,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__23)
 
@@ -732,29 +732,29 @@ new clauses:
 __29,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__29)
 
@@ -796,28 +796,28 @@ new clauses:
 
 __35,
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__35)
 
@@ -858,33 +858,33 @@ new clauses:
 --
 
 __41,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__41)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -930,31 +930,31 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:
@@ -1000,29 +1000,29 @@ new clauses:
 --
 
 __63,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__63)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -1068,27 +1068,27 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __85
 new variables:
@@ -1134,25 +1134,25 @@ new clauses:
 --
 
 __85,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__85)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __96
 new variables:
@@ -1198,23 +1198,23 @@ new clauses:
 --
 
 __96,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__96)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __107
 new variables:
@@ -1260,21 +1260,21 @@ new clauses:
 --
 
 __107,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__107)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __118
 new variables:
@@ -1320,19 +1320,19 @@ new clauses:
 --
 
 __118,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__118)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -1378,17 +1378,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -1434,15 +1434,15 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __151
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/better_direct/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/better_direct/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -212,17 +212,17 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -233,11 +233,11 @@ and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -246,18 +246,18 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -268,12 +268,12 @@ and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -282,19 +282,19 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -305,13 +305,13 @@ and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -320,20 +320,20 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -344,14 +344,14 @@ and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -360,21 +360,21 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -385,15 +385,15 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -402,16 +402,16 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -456,16 +456,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -473,16 +473,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__5)
 
@@ -528,32 +528,32 @@ __11,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__11)
 
@@ -598,31 +598,31 @@ __17,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__17)
 
@@ -666,30 +666,30 @@ __23,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__23)
 
@@ -732,29 +732,29 @@ new clauses:
 __29,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__29)
 
@@ -796,28 +796,28 @@ new clauses:
 
 __35,
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__35)
 
@@ -858,33 +858,33 @@ new clauses:
 --
 
 __41,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__41)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -930,31 +930,31 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:
@@ -1000,29 +1000,29 @@ new clauses:
 --
 
 __63,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__63)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -1068,27 +1068,27 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __85
 new variables:
@@ -1134,25 +1134,25 @@ new clauses:
 --
 
 __85,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__85)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __96
 new variables:
@@ -1198,23 +1198,23 @@ new clauses:
 --
 
 __96,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__96)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __107
 new variables:
@@ -1260,21 +1260,21 @@ new clauses:
 --
 
 __107,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__107)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __118
 new variables:
@@ -1320,19 +1320,19 @@ new clauses:
 --
 
 __118,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__118)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -1378,17 +1378,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -1434,15 +1434,15 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __151
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/better_log/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/better_log/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -212,17 +212,17 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -233,11 +233,11 @@ and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -246,18 +246,18 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -268,12 +268,12 @@ and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -282,19 +282,19 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -305,13 +305,13 @@ and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -320,20 +320,20 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -344,14 +344,14 @@ and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -360,21 +360,21 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -385,15 +385,15 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -402,16 +402,16 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -456,16 +456,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -473,16 +473,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__5)
 
@@ -528,32 +528,32 @@ __11,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__11)
 
@@ -598,31 +598,31 @@ __17,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__17)
 
@@ -666,30 +666,30 @@ __23,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__23)
 
@@ -732,29 +732,29 @@ new clauses:
 __29,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__29)
 
@@ -796,28 +796,28 @@ new clauses:
 
 __35,
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__35)
 
@@ -858,33 +858,33 @@ new clauses:
 --
 
 __41,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__41)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -930,31 +930,31 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:
@@ -1000,29 +1000,29 @@ new clauses:
 --
 
 __63,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__63)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -1068,27 +1068,27 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __85
 new variables:
@@ -1134,25 +1134,25 @@ new clauses:
 --
 
 __85,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__85)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __96
 new variables:
@@ -1198,23 +1198,23 @@ new clauses:
 --
 
 __96,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__96)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __107
 new variables:
@@ -1260,21 +1260,21 @@ new clauses:
 --
 
 __107,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__107)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __118
 new variables:
@@ -1320,19 +1320,19 @@ new clauses:
 --
 
 __118,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__118)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -1378,17 +1378,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -1434,15 +1434,15 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __151
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/better_log/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/better_log/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -212,17 +212,17 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -233,11 +233,11 @@ and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -246,18 +246,18 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -268,12 +268,12 @@ and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -282,19 +282,19 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -305,13 +305,13 @@ and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -320,20 +320,20 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -344,14 +344,14 @@ and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -360,21 +360,21 @@ or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)])
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)])
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)])
 
 --
 
@@ -385,15 +385,15 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]));int(1..)]), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -402,16 +402,16 @@ and([(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 
 --
 
@@ -456,16 +456,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
@@ -473,16 +473,16 @@ __5,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__5)
 
@@ -528,32 +528,32 @@ __11,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__11)
 
@@ -598,31 +598,31 @@ __17,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__17)
 
@@ -666,30 +666,30 @@ __23,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__23)
 
@@ -732,29 +732,29 @@ new clauses:
 __29,
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__29)
 
@@ -796,28 +796,28 @@ new clauses:
 
 __35,
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) != SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__35)
 
@@ -858,33 +858,33 @@ new clauses:
 --
 
 __41,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__41)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -930,31 +930,31 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c1#sat_log_int_00,c1#sat_log_int_01,c1#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:
@@ -1000,29 +1000,29 @@ new clauses:
 --
 
 __63,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__63)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -1068,27 +1068,27 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c2#sat_log_int_00,c2#sat_log_int_01,c2#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __85
 new variables:
@@ -1134,25 +1134,25 @@ new clauses:
 --
 
 __85,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__85)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __96
 new variables:
@@ -1198,23 +1198,23 @@ new clauses:
 --
 
 __96,
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__96)
 
 --
 
-(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c3#sat_log_int_00,c3#sat_log_int_01,c3#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __107
 new variables:
@@ -1260,21 +1260,21 @@ new clauses:
 --
 
 __107,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__107)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __118
 new variables:
@@ -1320,19 +1320,19 @@ new clauses:
 --
 
 __118,
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__118)
 
 --
 
-(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c4#sat_log_int_00,c4#sat_log_int_01,c4#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -1378,17 +1378,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -1434,15 +1434,15 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3]))
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [c5#sat_log_int_00,c5#sat_log_int_01,c5#sat_log_int_02;int(1..)] [1, 3]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __151
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/sparse_direct/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_direct/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -405,7 +405,7 @@ new clauses:
 (SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)])
 
 --
@@ -426,16 +426,16 @@ new clauses:
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 __84, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __116
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/sparse_direct/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_direct/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -405,7 +405,7 @@ new clauses:
 (SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)])
 
 --
@@ -426,16 +426,16 @@ new clauses:
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 __84, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __116
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/sparse_log/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_log/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -405,7 +405,7 @@ new clauses:
 (SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)])
 
 --
@@ -426,16 +426,16 @@ new clauses:
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 __84, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __116
 new variables:

--- a/tests-integration/tests/integration/cnf/comparison/sparse_log/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_log/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -405,7 +405,7 @@ new clauses:
 (SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([__13,__27,__41,__55,__69,__83;int(1..)])
 
 --
@@ -426,16 +426,16 @@ new clauses:
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 __84, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [x#sat_log_int_00,x#sat_log_int_01,x#sat_log_int_02,x#sat_log_int_03,x#sat_log_int_04,x#sat_log_int_05,x#sat_log_int_06;int(1..)] [1, 50]) > SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __116
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/01-eq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/01-eq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -94,37 +94,37 @@ __11,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __11,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
 __11,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__11)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __37
 new variables:
@@ -221,15 +221,15 @@ new clauses:
 --
 
 __37,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__37)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/01-eq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/01-eq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -94,37 +94,37 @@ __11,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __11,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
 __11,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__11)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __37
 new variables:
@@ -221,15 +221,15 @@ new clauses:
 --
 
 __37,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__37)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/02-eq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/02-eq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -70,37 +70,37 @@ __5,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __5,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
 __5,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __5,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 
 --
 
 __5,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 new clauses:
   (__5)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __16
 new variables:
@@ -146,15 +146,15 @@ new clauses:
 --
 
 __16,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 new clauses:
   (__16)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __27
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/02-eq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/02-eq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -70,37 +70,37 @@ __5,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __5,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)])
 
 --
 
 __5,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __5,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 
 --
 
 __5,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 new clauses:
   (__5)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __16
 new variables:
@@ -146,15 +146,15 @@ new clauses:
 --
 
 __16,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2]))
 new clauses:
   (__16)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [0, 2]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __27
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/02-neq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/02-neq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -44,27 +44,27 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_neq ([("SAT_Log", 4100)])
 __11
 new variables:
@@ -114,17 +114,17 @@ new clauses:
 --
 
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__11)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __37
 new variables:
@@ -221,15 +221,15 @@ new clauses:
 --
 
 __37,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__37)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/02-neq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/02-neq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -44,27 +44,27 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) != SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_neq ([("SAT_Log", 4100)])
 __11
 new variables:
@@ -114,17 +114,17 @@ new clauses:
 --
 
 __11,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__11)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __37
 new variables:
@@ -221,15 +221,15 @@ new clauses:
 --
 
 __37,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__37)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __63
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/03-ineq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/03-ineq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -126,98 +126,98 @@ or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,true;int(1..)] [-2, -2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __16
 new variables:
@@ -285,23 +285,23 @@ new clauses:
 __16,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__16)
 
@@ -384,22 +384,22 @@ new clauses:
 
 __33,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__33)
 
@@ -478,27 +478,27 @@ new clauses:
 --
 
 __49,
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__49)
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __65
 new variables:
@@ -561,25 +561,25 @@ new clauses:
 --
 
 __65,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__65)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __81
 new variables:
@@ -642,23 +642,23 @@ new clauses:
 --
 
 __81,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__81)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __97
 new variables:
@@ -721,21 +721,21 @@ new clauses:
 --
 
 __97,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__97)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __113
 new variables:
@@ -798,19 +798,19 @@ new clauses:
 --
 
 __113,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__113)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -873,17 +873,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __145
 new variables:
@@ -946,15 +946,15 @@ new clauses:
 --
 
 __145,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__145)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __161
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/03-ineq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/03-ineq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -126,98 +126,98 @@ or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
--(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+-(SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_neg ([("SAT_Log", 4100)])
 SATInt(Log, [__3,__4,__6;int(1..)] [-2, -2])
 new variables:
@@ -330,23 +330,23 @@ new clauses:
 __24,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__24)
 
@@ -429,22 +429,22 @@ new clauses:
 
 __41,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__41)
 
@@ -523,27 +523,27 @@ new clauses:
 --
 
 __57,
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__57)
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __73
 new variables:
@@ -606,25 +606,25 @@ new clauses:
 --
 
 __73,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__73)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __89
 new variables:
@@ -687,23 +687,23 @@ new clauses:
 --
 
 __89,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__89)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __105
 new variables:
@@ -766,21 +766,21 @@ new clauses:
 --
 
 __105,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__105)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __121
 new variables:
@@ -843,19 +843,19 @@ new clauses:
 --
 
 __121,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__121)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __137
 new variables:
@@ -918,17 +918,17 @@ new clauses:
 --
 
 __137,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__137)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __153
 new variables:
@@ -991,15 +991,15 @@ new clauses:
 --
 
 __153,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__153)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __169
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/05-neg/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/05-neg/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -170,148 +170,148 @@ or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __7,
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__7)
 
@@ -323,7 +323,7 @@ SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) = SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __15
 new variables:
@@ -360,24 +360,24 @@ new clauses:
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
 __15,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__15)
 
@@ -477,29 +477,29 @@ new clauses:
 --
 
 __34,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__34)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __50
 new variables:
@@ -562,27 +562,27 @@ new clauses:
 --
 
 __50,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__50)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __66
 new variables:
@@ -645,25 +645,25 @@ new clauses:
 --
 
 __66,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__66)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __82
 new variables:
@@ -726,23 +726,23 @@ new clauses:
 --
 
 __82,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__82)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __98
 new variables:
@@ -805,21 +805,21 @@ new clauses:
 --
 
 __98,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__98)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __114
 new variables:
@@ -882,19 +882,19 @@ new clauses:
 --
 
 __114,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__114)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __130
 new variables:
@@ -957,17 +957,17 @@ new clauses:
 --
 
 __130,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__130)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __146
 new variables:
@@ -1030,15 +1030,15 @@ new clauses:
 --
 
 __146,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__146)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __162
 new variables:

--- a/tests-integration/tests/integration/cnf/int_direct/05-neg/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_direct/05-neg/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -134,124 +134,124 @@ or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_
 or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]))) = SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -261,7 +261,7 @@ SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) = SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) = SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __7
 new variables:
@@ -297,27 +297,27 @@ new clauses:
 --
 
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) = -(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]))),
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__7)
 
@@ -417,31 +417,31 @@ new clauses:
 --
 
 __26,
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(-(SATInt(Log, [false,true,false;int(1..)] [2, 2])) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__26)
 
 --
 
--(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+-(SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_neg ([("SAT_Log", 4100)])
 SATInt(Log, [__30,__31,__33;int(1..)] [-2, -2])
 new variables:
@@ -520,29 +520,29 @@ new clauses:
 --
 
 __42,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__42)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __58
 new variables:
@@ -605,27 +605,27 @@ new clauses:
 --
 
 __58,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__58)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __74
 new variables:
@@ -688,25 +688,25 @@ new clauses:
 --
 
 __74,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__74)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __90
 new variables:
@@ -769,23 +769,23 @@ new clauses:
 --
 
 __90,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__90)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __106
 new variables:
@@ -848,21 +848,21 @@ new clauses:
 --
 
 __106,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__106)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __122
 new variables:
@@ -925,19 +925,19 @@ new clauses:
 --
 
 __122,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__122)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __138
 new variables:
@@ -1000,17 +1000,17 @@ new clauses:
 --
 
 __138,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__138)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __154
 new variables:
@@ -1073,15 +1073,15 @@ new clauses:
 --
 
 __154,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__154)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01,d#sat_log_int_02,d#sat_log_int_03;int(1..)] [-5, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __170
 new variables:

--- a/tests-integration/tests/integration/cnf/int_order/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_order/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -78,37 +78,37 @@ __7,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
 __7,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__7)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __23
 new variables:
@@ -171,15 +171,15 @@ new clauses:
 --
 
 __23,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__23)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __39
 new variables:

--- a/tests-integration/tests/integration/cnf/int_order/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_order/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -42,27 +42,27 @@ SATInt(Log, [true,false,true,false;int(1..)] [5, 5])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, [true,false;int(1..)] [1, 1]))),
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, [true,false;int(1..)] [1, 1]))),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, [true,false;int(1..)] [1, 1]))),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) = -(SATInt(Log, [true,false;int(1..)] [1, 1]))),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
--(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+-(SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_neg ([("SAT_Log", 4100)])
 SATInt(Log, [__2,__3;int(1..)] [-1, -1])
 new variables:
@@ -130,17 +130,17 @@ new clauses:
 --
 
 __12,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__12)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __28
 new variables:
@@ -203,15 +203,15 @@ new clauses:
 --
 
 __28,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__28)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __44
 new variables:

--- a/tests-integration/tests/integration/cnf/int_order_2/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_order_2/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -78,37 +78,37 @@ __7,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
 __7,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__7)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __23
 new variables:
@@ -171,15 +171,15 @@ new clauses:
 --
 
 __23,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__23)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __39
 new variables:

--- a/tests-integration/tests/integration/cnf/int_order_2/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/int_order_2/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -78,37 +78,37 @@ __7,
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
 __7,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
 __7,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__7)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, Matrix([Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [0, 0])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) >= SATInt(Log, [false;int(1..)] [0, 0])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __23
 new variables:
@@ -171,15 +171,15 @@ new clauses:
 --
 
 __23,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__23)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [0, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __39
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/01-lt/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/01-lt/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -44,27 +44,27 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __26
 new variables:
@@ -164,17 +164,17 @@ new clauses:
 --
 
 __26,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__26)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -271,15 +271,15 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __78
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/01-lt/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/01-lt/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -44,27 +44,27 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 (SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) < SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __26
 new variables:
@@ -164,17 +164,17 @@ new clauses:
 --
 
 __26,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__26)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-6, -6])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) >= SATInt(Log, [false,true,false,true;int(1..)] [-6, -6])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -271,15 +271,15 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [-6, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __78
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/02-add/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/02-add/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -73,45 +73,45 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
@@ -264,7 +264,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__0,__3,__8,__13,__18,__23,__28;int(1..)] [2, 40]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [__0,__3,__8,__13,__18,__23,__28;int(1..)] [2, 40]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __45
 new variables:
@@ -321,21 +321,21 @@ new clauses:
 --
 
 __45,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__45)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __71
 new variables:
@@ -432,19 +432,19 @@ new clauses:
 --
 
 __71,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__71)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __97
 new variables:
@@ -541,17 +541,17 @@ new clauses:
 --
 
 __97,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__97)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __123
 new variables:
@@ -648,15 +648,15 @@ new clauses:
 --
 
 __123,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__123)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __149
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/02-add/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/02-add/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -73,45 +73,45 @@ SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)])
 
 --
 
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]));int(1..)]), 
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 
 --
 
@@ -264,7 +264,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__0,__3,__8,__13,__18,__23,__28;int(1..)] [2, 40]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [__0,__3,__8,__13,__18,__23,__28;int(1..)] [2, 40]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __45
 new variables:
@@ -321,21 +321,21 @@ new clauses:
 --
 
 __45,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__45)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __71
 new variables:
@@ -432,19 +432,19 @@ new clauses:
 --
 
 __71,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__71)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __97
 new variables:
@@ -541,17 +541,17 @@ new clauses:
 --
 
 __97,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__97)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __123
 new variables:
@@ -648,15 +648,15 @@ new clauses:
 --
 
 __123,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20]))
 new clauses:
   (__123)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [20, 20])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 20]) <= SATInt(Log, [false,false,true,false,true,false;int(1..)] [20, 20])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __149
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/03-ranges/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/03-ranges/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -98,10 +98,10 @@ new clauses:
 or([__5;int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 or([__5;int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
@@ -111,41 +111,41 @@ __5
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__5)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __42
 new variables:
@@ -279,19 +279,19 @@ new clauses:
 --
 
 __42,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__42)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __79
 new variables:
@@ -425,17 +425,17 @@ new clauses:
 --
 
 __79,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__79)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __95
 new variables:
@@ -498,15 +498,15 @@ new clauses:
 --
 
 __95,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__95)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __111
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/03-ranges/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/03-ranges/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -98,10 +98,10 @@ new clauses:
 or([__5;int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 or([__5;int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
@@ -111,41 +111,41 @@ __5
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
 __5,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__5)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02;int(1..)] [3, 3]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __42
 new variables:
@@ -279,19 +279,19 @@ new clauses:
 --
 
 __42,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__42)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false), Bool(false), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [100, 100])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) < SATInt(Log, [false,false,true,false,false,true,true,false;int(1..)] [100, 100])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __79
 new variables:
@@ -425,17 +425,17 @@ new clauses:
 --
 
 __79,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__79)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __95
 new variables:
@@ -498,15 +498,15 @@ new clauses:
 --
 
 __95,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__95)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __111
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/04-complex-add/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/04-complex-add/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -162,12 +162,12 @@ or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= S
 or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]);int(1..)]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]);int(1..)]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
@@ -177,148 +177,148 @@ sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_i
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)])
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)])
+and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 
 --
 
@@ -511,29 +511,29 @@ new clauses:
 --
 
 __38,
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__38)
 
@@ -785,7 +785,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__66,__69,__74,__79,__84,__89;int(1..)] [14, 27]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])), 
+(SATInt(Log, [__66,__69,__74,__79,__84,__89;int(1..)] [14, 27]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __119
 new variables:
@@ -885,33 +885,33 @@ new clauses:
 --
 
 __119,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__119)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -991,31 +991,31 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __161
 new variables:
@@ -1095,29 +1095,29 @@ new clauses:
 --
 
 __161,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__161)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __182
 new variables:
@@ -1197,27 +1197,27 @@ new clauses:
 --
 
 __182,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__182)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __203
 new variables:
@@ -1297,25 +1297,25 @@ new clauses:
 --
 
 __203,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__203)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __229
 new variables:
@@ -1412,23 +1412,23 @@ new clauses:
 --
 
 __229,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__229)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __255
 new variables:
@@ -1525,21 +1525,21 @@ new clauses:
 --
 
 __255,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__255)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __261
 new variables:
@@ -1568,19 +1568,19 @@ new clauses:
 --
 
 __261,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__261)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __267
 new variables:
@@ -1609,17 +1609,17 @@ new clauses:
 --
 
 __267,
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__267)
 
 --
 
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __288
 new variables:
@@ -1699,15 +1699,15 @@ new clauses:
 --
 
 __288,
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__288)
 
 --
 
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __309
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/04-complex-add/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/04-complex-add/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -162,12 +162,12 @@ or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= S
 or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]);int(1..2)]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]);int(1..2)]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
@@ -177,148 +177,148 @@ sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_i
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17]));int(1..)]),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17]));int(1..)]),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)])
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)]),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+and([(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)]),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)])
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)])
+and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)])
 
 --
 
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]));int(1..)]), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+and([(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (sum([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]);int(1..2)]) = SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17])),
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 
 --
 
@@ -511,29 +511,29 @@ new clauses:
 --
 
 __38,
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(sum([SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]),SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]),SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]);int(1..2)]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__38)
 
@@ -785,7 +785,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__66,__69,__74,__79,__84,__89;int(1..)] [14, 27]) > SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [16, 16])), 
+(SATInt(Log, [__66,__69,__74,__79,__84,__89;int(1..)] [14, 27]) > SATInt(Log, [false,false,false,false,true,false;int(1..)] [16, 16])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __119
 new variables:
@@ -885,33 +885,33 @@ new clauses:
 --
 
 __119,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__119)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __140
 new variables:
@@ -991,31 +991,31 @@ new clauses:
 --
 
 __140,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__140)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __161
 new variables:
@@ -1095,29 +1095,29 @@ new clauses:
 --
 
 __161,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__161)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) >= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __182
 new variables:
@@ -1197,27 +1197,27 @@ new clauses:
 --
 
 __182,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__182)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [8, 8])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [5, 8]) <= SATInt(Log, [false,false,false,true,false;int(1..)] [8, 8])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __203
 new variables:
@@ -1297,25 +1297,25 @@ new clauses:
 --
 
 __203,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__203)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) >= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __229
 new variables:
@@ -1412,23 +1412,23 @@ new clauses:
 --
 
 __229,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__229)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [17, 17])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03,c#sat_log_int_04,c#sat_log_int_05;int(1..)] [9, 17]) <= SATInt(Log, [true,false,false,false,true,false;int(1..)] [17, 17])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __255
 new variables:
@@ -1525,21 +1525,21 @@ new clauses:
 --
 
 __255,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])),
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])),
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__255)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, Matrix([Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-2, -2])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) >= SATInt(Log, [false,true;int(1..)] [-2, -2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __261
 new variables:
@@ -1568,19 +1568,19 @@ new clauses:
 --
 
 __261,
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__261)
 
 --
 
-(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [d#sat_log_int_00,d#sat_log_int_01;int(1..)] [-2, 1]) <= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __267
 new variables:
@@ -1609,17 +1609,17 @@ new clauses:
 --
 
 __267,
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])),
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])),
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__267)
 
 --
 
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [7, 7])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) >= SATInt(Log, [true,true,true,false;int(1..)] [7, 7])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __288
 new variables:
@@ -1699,15 +1699,15 @@ new clauses:
 --
 
 __288,
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9]))
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9]))
 new clauses:
   (__288)
 
 --
 
-(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [9, 9])), 
+(SATInt(Log, [e#sat_log_int_00,e#sat_log_int_01,e#sat_log_int_02,e#sat_log_int_03,e#sat_log_int_04;int(1..)] [7, 9]) <= SATInt(Log, [true,false,false,true,false;int(1..)] [9, 9])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __309
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/05-product/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/05-product/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -73,9 +73,9 @@ SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(product([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]);int(1..)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)])
+(product([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]);int(1..)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)])
 
 --
 
@@ -2080,7 +2080,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__448,__451,__454,__457,__460,__463,__466,__469,__472,__475,__478;int(1..)] [1, 900]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [__448,__451,__454,__457,__460,__463,__466,__469,__472,__475,__478;int(1..)] [1, 900]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __503
 new variables:
@@ -2164,58 +2164,58 @@ new clauses:
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)])
 
 --
 
 __503,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)])
 
 --
 
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 
 --
 
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__503)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __529
 new variables:
@@ -2312,19 +2312,19 @@ new clauses:
 --
 
 __529,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__529)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __555
 new variables:
@@ -2421,17 +2421,17 @@ new clauses:
 --
 
 __555,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__555)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __581
 new variables:
@@ -2528,15 +2528,15 @@ new clauses:
 --
 
 __581,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__581)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __607
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/05-product/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/05-product/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -73,9 +73,9 @@ SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(product([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]);int(1..2)]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)])
+(product([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]);int(1..2)]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)])
 
 --
 
@@ -2080,7 +2080,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__448,__451,__454,__457,__460,__463,__466,__469,__472,__475,__478;int(1..)] [1, 900]) = SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [__448,__451,__454,__457,__460,__463,__466,__469,__472,__475,__478;int(1..)] [1, 900]) = SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_eq ([("SAT_Log", 9100)])
 __503
 new variables:
@@ -2164,58 +2164,58 @@ new clauses:
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)])
 
 --
 
 __503,
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)])
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)])
 
 --
 
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]));int(1..)]), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 
 --
 
 __503,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__503)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __529
 new variables:
@@ -2312,19 +2312,19 @@ new clauses:
 --
 
 __529,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__529)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04,a#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __555
 new variables:
@@ -2421,17 +2421,17 @@ new clauses:
 --
 
 __555,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__555)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __581
 new variables:
@@ -2528,15 +2528,15 @@ new clauses:
 --
 
 __581,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30]))
 new clauses:
   (__581)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [30, 30])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04,b#sat_log_int_05;int(1..)] [1, 30]) <= SATInt(Log, [false,true,true,true,true,false;int(1..)] [30, 30])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __607
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -69,45 +69,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -214,7 +214,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 4]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -277,21 +277,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -354,19 +354,19 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __68
 new variables:
@@ -429,17 +429,17 @@ new clauses:
 --
 
 __68,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__68)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __84
 new variables:
@@ -502,15 +502,15 @@ new clauses:
 --
 
 __84,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __100
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67
 new clauses:
   (__54)
 
 --
 
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__68#sat_direct_int_1,__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4;int(1..)] [1, 4]) <= SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -69,45 +69,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(min([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -214,7 +214,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [1, 4]) <= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -277,21 +277,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -354,19 +354,19 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __68
 new variables:
@@ -429,17 +429,17 @@ new clauses:
 --
 
 __68,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__68)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __84
 new variables:
@@ -502,15 +502,15 @@ new clauses:
 --
 
 __84,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __100
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/07-min/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51
 new clauses:
   (__41)
 
 --
 
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(min([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) <= SATInt(Order, [true;int(1..)] [2, 2]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [4, 4])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Order, [__52#sat_order_int_01,__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04;int(1..)] [1, 4]) <= SATInt(Order, [true;int(1..)] [2, 2])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __67
 new clauses:
   (__54)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) >= SATInt(Direct, [true;int(1..)] [4, 4])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -69,45 +69,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -214,7 +214,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 5]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 5]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -277,21 +277,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -354,19 +354,19 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __68
 new variables:
@@ -429,17 +429,17 @@ new clauses:
 --
 
 __68,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__68)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __84
 new variables:
@@ -502,15 +502,15 @@ new clauses:
 --
 
 __84,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __100
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/tree-sitter-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __51
 new clauses:
   (__41)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) >= SATInt(Order, [true;int(1..)] [4, 4])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -329,7 +329,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)])
 
@@ -341,11 +341,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 and([__20,__41;int(1..)]),
 or([and([__54,__67;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 or([and([__54,__67;int(1..)]);int(1..)])
@@ -358,12 +358,12 @@ and([__54,__67;int(1..)])
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 and([__54,__67;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 __54,
@@ -371,13 +371,13 @@ __67
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __20,
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __41,
 __54,
 __67
@@ -386,12 +386,12 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __41,
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __54,
 __67
 new clauses:
@@ -399,21 +399,21 @@ new clauses:
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __54,
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __67
 new clauses:
   (__54)
 
 --
 
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4])),
 __67, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Direct, [a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4,a#sat_direct_int_5;int(1..)] [1, 5]),SATInt(Direct, [b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Direct, [true;int(1..)] [4, 4]))
 new clauses:
   (__67)
 
@@ -486,7 +486,7 @@ SATInt(Direct, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) >= SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Direct, [__68#sat_direct_int_2,__68#sat_direct_int_3,__68#sat_direct_int_4,__68#sat_direct_int_5;int(1..)] [2, 5]) >= SATInt(Direct, [true;int(1..)] [4, 4])), 
    ~~> ineq_sat_direct ([("SAT", 9100)])
 __85
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -69,45 +69,45 @@ SATInt(Log, [false,false,true,false;int(1..)] [4, 4])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)])
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)])
 
 --
 
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]));int(1..)]), 
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]),SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 
 --
 
@@ -214,7 +214,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 5]) >= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [__17,__18,__19,__20;int(1..)] [2, 5]) >= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __36
 new variables:
@@ -277,21 +277,21 @@ new clauses:
 --
 
 __36,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__36)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) >= SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __52
 new variables:
@@ -354,19 +354,19 @@ new clauses:
 --
 
 __52,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__52)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [1, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __68
 new variables:
@@ -429,17 +429,17 @@ new clauses:
 --
 
 __68,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__68)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) >= SATInt(Log, [false,true,false;int(1..)] [2, 2])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __84
 new variables:
@@ -502,15 +502,15 @@ new clauses:
 --
 
 __84,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4]))
 new clauses:
   (__84)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [2, 4]) <= SATInt(Log, [false,false,true,false;int(1..)] [4, 4])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __100
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/08-max/via-conjure-naive-via-solver-ac-sat-order-expected-rule-trace.txt
@@ -269,7 +269,7 @@ new clauses:
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 or([and([__15,__31;int(1..)]);int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)])
 
@@ -281,11 +281,11 @@ and([__15,__31;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 and([__15,__31;int(1..)]),
 or([and([__41,__51;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 or([and([__41,__51;int(1..)]);int(1..)])
@@ -298,12 +298,12 @@ and([__41,__51;int(1..)])
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 and([__41,__51;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 __41,
@@ -311,13 +311,13 @@ __51
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __15,
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __31,
 __41,
 __51
@@ -326,12 +326,12 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __31,
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __41,
 __51
 new clauses:
@@ -339,21 +339,21 @@ new clauses:
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __41,
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __51
 new clauses:
   (__41)
 
 --
 
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])),
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4])),
 __51, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]))
+(max([SATInt(Order, [a#sat_order_int_01,a#sat_order_int_02,a#sat_order_int_03,a#sat_order_int_04,a#sat_order_int_05;int(1..)] [1, 5]),SATInt(Order, [b#sat_order_int_02,b#sat_order_int_03,b#sat_order_int_04;int(1..)] [2, 4]);int(1..2)]) >= SATInt(Order, [true;int(1..)] [4, 4]))
 new clauses:
   (__51)
 
@@ -426,7 +426,7 @@ SATInt(Order, [true;int(1..)] [5, 5])
 
 --
 
-(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) >= SATInt(Order, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4])), 
+(SATInt(Order, [__52#sat_order_int_02,__52#sat_order_int_03,__52#sat_order_int_04,__52#sat_order_int_05;int(1..)] [2, 5]) >= SATInt(Order, [true;int(1..)] [4, 4])), 
    ~~> ineq_sat_order ([("SAT_Order", 9100)])
 __65
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/09-abs/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/09-abs/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -77,51 +77,51 @@ SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)])
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)])
 
 --
 
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)])
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)])
 
 --
 
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]), 
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> minus_to_sum ([("Base", 8400)])
-sum([SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]),-(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)])
+sum([SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]),-(SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)])
 
 --
 
@@ -222,7 +222,7 @@ new clauses:
 
 --
 
--(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+-(SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_neg ([("SAT_Log", 4100)])
 SATInt(Log, [__21,__22;int(1..)] [-1, -1])
 new variables:
@@ -575,7 +575,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__65,__68,__73,__78,__83,__88;int(1..)] [0, 21]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__65,__68,__73,__78,__83,__88;int(1..)] [0, 21]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __117
 new variables:
@@ -672,21 +672,21 @@ new clauses:
 --
 
 __117,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__117)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __138
 new variables:
@@ -766,19 +766,19 @@ new clauses:
 --
 
 __138,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__138)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __159
 new variables:
@@ -858,17 +858,17 @@ new clauses:
 --
 
 __159,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__159)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __180
 new variables:
@@ -948,15 +948,15 @@ new clauses:
 --
 
 __180,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__180)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __201
 new variables:

--- a/tests-integration/tests/integration/cnf/integer/09-abs/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/integer/09-abs/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -77,51 +77,51 @@ SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])
 or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..2)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)])
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..2)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)])
 
 --
 
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..2)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..2)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..2)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)])
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..2)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)])
 
 --
 
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..2)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]));int(1..)]), 
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..2)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))|;int(1..2)]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(sum([|SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10])|,|(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1]))|;int(1..2)]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) - SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> minus_to_sum ([("Base", 8400)])
-sum([SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]),-(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]));int(1..)])
+sum([SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]),-(SATInt(Log, [true,false;int(1..)] [1, 1]));int(1..)])
 
 --
 
@@ -222,7 +222,7 @@ new clauses:
 
 --
 
--(SATInt(Log, Matrix([Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+-(SATInt(Log, [true,false;int(1..)] [1, 1])), 
    ~~> cnf_int_neg ([("SAT_Log", 4100)])
 SATInt(Log, [__21,__22;int(1..)] [-1, -1])
 new variables:
@@ -575,7 +575,7 @@ new clauses:
 
 --
 
-(SATInt(Log, [__65,__68,__73,__78,__83,__88;int(1..)] [0, 21]) <= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [3, 3])), 
+(SATInt(Log, [__65,__68,__73,__78,__83,__88;int(1..)] [0, 21]) <= SATInt(Log, [true,true,false;int(1..)] [3, 3])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __117
 new variables:
@@ -672,21 +672,21 @@ new clauses:
 --
 
 __117,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__117)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __138
 new variables:
@@ -766,19 +766,19 @@ new clauses:
 --
 
 __138,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__138)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03,a#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __159
 new variables:
@@ -858,17 +858,17 @@ new clauses:
 --
 
 __159,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__159)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-10, -10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) >= SATInt(Log, [false,true,true,false,true;int(1..)] [-10, -10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __180
 new variables:
@@ -948,15 +948,15 @@ new clauses:
 --
 
 __180,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10]))
 new clauses:
   (__180)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03,b#sat_log_int_04;int(1..)] [-10, 10]) <= SATInt(Log, [false,true,false,true,false;int(1..)] [10, 10])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __201
 new variables:

--- a/tests-integration/tests/integration/cnf/order_ineq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/order_ineq/tree-sitter-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -126,98 +126,98 @@ or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __16
 new variables:
@@ -285,23 +285,23 @@ new clauses:
 __16,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__16)
 
@@ -384,22 +384,22 @@ new clauses:
 
 __33,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__33)
 
@@ -478,27 +478,27 @@ new clauses:
 --
 
 __49,
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__49)
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __65
 new variables:
@@ -561,25 +561,25 @@ new clauses:
 --
 
 __65,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__65)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __81
 new variables:
@@ -642,23 +642,23 @@ new clauses:
 --
 
 __81,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__81)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __97
 new variables:
@@ -721,21 +721,21 @@ new clauses:
 --
 
 __97,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__97)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __113
 new variables:
@@ -798,19 +798,19 @@ new clauses:
 --
 
 __113,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__113)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -873,17 +873,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __145
 new variables:
@@ -946,15 +946,15 @@ new clauses:
 --
 
 __145,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__145)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __161
 new variables:

--- a/tests-integration/tests/integration/cnf/order_ineq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/cnf/order_ineq/via-conjure-naive-via-solver-ac-sat-log-expected-rule-trace.txt
@@ -126,98 +126,98 @@ or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_
 or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
 or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+and([(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)])
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)])
 
 --
 
-or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]);int(1..)]), 
+or([and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]);int(1..)]), 
    ~~> remove_unit_vector_or ([("Base", 8800)])
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)])
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)])
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]));int(1..)]), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+and([(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]));int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,true,false;int(1..)] [2, 2]) < SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __16
 new variables:
@@ -285,23 +285,23 @@ new clauses:
 __16,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) > SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5])),
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__16)
 
@@ -384,22 +384,22 @@ new clauses:
 
 __33,
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
 (SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__33)
 
@@ -478,27 +478,27 @@ new clauses:
 --
 
 __49,
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__49)
 
 --
 
-(SATInt(Log, Matrix([Bool(false), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
+(SATInt(Log, [false,false,true,false;int(1..)] [4, 4]) >= SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __65
 new variables:
@@ -561,25 +561,25 @@ new clauses:
 --
 
 __65,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__65)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __81
 new variables:
@@ -642,23 +642,23 @@ new clauses:
 --
 
 __81,
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__81)
 
 --
 
-(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [a#sat_log_int_00,a#sat_log_int_01,a#sat_log_int_02,a#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __97
 new variables:
@@ -721,21 +721,21 @@ new clauses:
 --
 
 __97,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__97)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __113
 new variables:
@@ -798,19 +798,19 @@ new clauses:
 --
 
 __113,
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__113)
 
 --
 
-(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [b#sat_log_int_00,b#sat_log_int_01,b#sat_log_int_02,b#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __129
 new variables:
@@ -873,17 +873,17 @@ new clauses:
 --
 
 __129,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])),
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])),
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__129)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, Matrix([Bool(true), Bool(true), Bool(false), Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [-5, -5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) >= SATInt(Log, [true,true,false,true;int(1..)] [-5, -5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __145
 new variables:
@@ -946,15 +946,15 @@ new clauses:
 --
 
 __145,
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> remove_single_atom ([("SAT", 8400)])
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5]))
 new clauses:
   (__145)
 
 --
 
-(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, Matrix([Bool(true), Bool(false), Bool(true), Bool(false)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Log, [c#sat_log_int_00,c#sat_log_int_01,c#sat_log_int_02,c#sat_log_int_03;int(1..)] [-5, 5]) <= SATInt(Log, [true,false,true,false;int(1..)] [5, 5])), 
    ~~> cnf_int_ineq ([("SAT_Log", 4100)])
 __161
 new variables:

--- a/tests-integration/tests/integration/eprime-minion/partial-eval-02-or-and/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/eprime-minion/partial-eval-02-or-and/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -17,7 +17,7 @@ or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([or([a,b;int(1..2)]),false;int(1..2)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)])
 
 --
@@ -35,23 +35,23 @@ or([a,b,false;int(1..)])
 --
 
 or([a,b,false;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([a,b;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)])
 
 --
 
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]), 
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..)])
+or([allDiff([1,2,3;int(1..3)]),true;int(1..)])
 
 --
 
 or([a,b;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([a,b;int(1..)]),

--- a/tests-integration/tests/integration/eprime-minion/partial-eval-or-and/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/eprime-minion/partial-eval-or-and/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -17,7 +17,7 @@ or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([or([a,b;int(1..2)]),false;int(1..2)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)])
 
 --
@@ -35,23 +35,23 @@ or([a,b,false;int(1..)])
 --
 
 or([a,b,false;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([a,b;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]),
 and([c,true;int(1..2)])
 
 --
 
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..2)]), 
+or([allDiff([1,2,3;int(1..3)]),true;int(1..2)]), 
    ~~> matrix_to_list ([("Base", 2000)])
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..)])
+or([allDiff([1,2,3;int(1..3)]),true;int(1..)])
 
 --
 
 or([a,b;int(1..)]),
-or([allDiff(Matrix([Int(1), Int(2), Int(3)], Moo { inner: Int([Bounded(1, 3)]) })),true;int(1..)]),
+or([allDiff([1,2,3;int(1..3)]),true;int(1..)]),
 and([c,true;int(1..2)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 or([a,b;int(1..)]),

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -474,7 +474,7 @@ new clauses:
 or([and([__40,__81;int(1..)]);int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 or([and([__40,__81;int(1..)]);int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)])
 
@@ -486,11 +486,11 @@ and([__40,__81;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 and([__40,__81;int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 or([and([__94,__107;int(1..)]);int(1..)])
@@ -503,12 +503,12 @@ and([__94,__107;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 and([__94,__107;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 __94,
@@ -516,13 +516,13 @@ __107
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __81,
 __94,
 __107
@@ -531,12 +531,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __81,
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __94,
 __107
 new clauses:
@@ -544,21 +544,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __107
 new clauses:
   (__94)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5]))
 new clauses:
   (__107)
 
@@ -675,13 +675,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) @ __123} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+({SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) @ __123} = SATInt(Direct, [true;int(1..)] [5, 5])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])) @ __123}
+{(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, [true;int(1..)] [5, 5])) @ __123}
 
 --
 
-(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, [true;int(1..)] [5, 5])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __135
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -474,7 +474,7 @@ new clauses:
 or([and([__40,__81;int(1..)]);int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 or([and([__40,__81;int(1..)]);int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)])
 
@@ -486,11 +486,11 @@ and([__40,__81;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 and([__40,__81;int(1..)]),
 or([and([__94,__107;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 or([and([__94,__107;int(1..)]);int(1..)])
@@ -503,12 +503,12 @@ and([__94,__107;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 and([__94,__107;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 __94,
@@ -516,13 +516,13 @@ __107
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __40,
 __81,
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __81,
 __94,
 __107
@@ -531,12 +531,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __81,
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __94,
 __107
 new clauses:
@@ -544,21 +544,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __94,
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __107
 new clauses:
   (__94)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5])),
 __107, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_1,x#sat_direct_int_2,x#sat_direct_int_3,x#sat_direct_int_4,x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10;int(1..)] [1, 10]), SATInt(Direct, [y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4;int(1..)] [2, 4])) = SATInt(Direct, [true;int(1..)] [5, 5]))
 new clauses:
   (__107)
 
@@ -675,13 +675,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) @ __123} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+({SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) @ __123} = SATInt(Direct, [true;int(1..)] [5, 5])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])) @ __123}
+{(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, [true;int(1..)] [5, 5])) @ __123}
 
 --
 
-(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [5, 5])), 
+(SATInt(Direct, [__108,__109,__110,__111,__112,__113;int(1..)] [0, 5]) = SATInt(Direct, [true;int(1..)] [5, 5])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __135
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __237
 new clauses:
   (__208)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__237)
 
@@ -1278,29 +1278,29 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)]), 
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __257
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __257, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__257)
 
@@ -1702,13 +1702,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __237
 new clauses:
   (__208)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__237)
 
@@ -1278,29 +1278,29 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)]), 
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __257
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),
 __257, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__257)
 
@@ -1702,13 +1702,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __237
 new clauses:
   (__208)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__237)
 
@@ -1278,29 +1278,29 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)]), 
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __257
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __257, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__257)
 
@@ -1702,13 +1702,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> neq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __237
 new clauses:
   (__208)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) != SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__237)
 
@@ -1278,29 +1278,29 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)]), 
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __257
 
 --
 
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10])),
 __257, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))
+(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) != SATInt(Direct, [true;int(1..)] [10, 10]))
 new clauses:
   (__257)
 
@@ -1702,13 +1702,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) != SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> neq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __237
 new clauses:
   (__208)
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])))
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])))
 new clauses:
   (__237)
 
@@ -1278,15 +1278,15 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
@@ -1686,13 +1686,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -979,7 +979,7 @@ or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 or([and([__64,__129;int(1..)]);int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)])
@@ -992,12 +992,12 @@ and([__64,__129;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 and([__64,__129;int(1..)]),
 or([and([__154,__179;int(1..)]);int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 or([and([__154,__179;int(1..)]);int(1..)]),
@@ -1011,13 +1011,13 @@ and([__154,__179;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 and([__154,__179;int(1..)]),
 or([and([__208,__237;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1032,14 +1032,14 @@ and([__208,__237;int(1..)])
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
 __179,
 and([__208,__237;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1049,7 +1049,7 @@ __237
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __64,
 __129,
 __154,
@@ -1057,7 +1057,7 @@ __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __129,
 __154,
 __179,
@@ -1068,14 +1068,14 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __129,
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __154,
 __179,
 __208,
@@ -1085,13 +1085,13 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __154,
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __179,
 __208,
 __237
@@ -1100,12 +1100,12 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __179,
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __208,
 __237
 new clauses:
@@ -1113,21 +1113,21 @@ new clauses:
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __208,
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __237
 new clauses:
   (__208)
 
 --
 
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10]))),
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10]))),
 __237, 
    ~~> remove_single_atom ([("SAT", 8400)])
-!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])))
+!((UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), UnsafeDiv(SATInt(Direct, [y#sat_direct_int_0,y#sat_direct_int_1,y#sat_direct_int_2,y#sat_direct_int_3,y#sat_direct_int_4,y#sat_direct_int_5;int(1..)] [0, 5]), SATInt(Direct, [z#sat_direct_int_0,z#sat_direct_int_1,z#sat_direct_int_2,z#sat_direct_int_3,z#sat_direct_int_4,z#sat_direct_int_5,z#sat_direct_int_6;int(1..)] [0, 6]))) = SATInt(Direct, [true;int(1..)] [10, 10])))
 new clauses:
   (__237)
 
@@ -1278,15 +1278,15 @@ UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int
 
 --
 
-({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) @ __257} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}
 
 --
 
-{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __257}, 
+{(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __257}, 
    ~~> expand_bubble ([("Bubble", 8900)])
-and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])),__257;int(1..)])
+and([(UnsafeDiv(SATInt(Direct, [x#sat_direct_int_5,x#sat_direct_int_6,x#sat_direct_int_7,x#sat_direct_int_8,x#sat_direct_int_9,x#sat_direct_int_10,x#sat_direct_int_11,x#sat_direct_int_12,x#sat_direct_int_13,x#sat_direct_int_14,x#sat_direct_int_15,x#sat_direct_int_16,x#sat_direct_int_17,x#sat_direct_int_18,x#sat_direct_int_19,x#sat_direct_int_20;int(1..)] [5, 20]), SATInt(Direct, [__238,__239,__240,__241,__242,__243;int(1..)] [0, 5])) = SATInt(Direct, [true;int(1..)] [10, 10])),__257;int(1..)])
 
 --
 
@@ -1686,13 +1686,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+({SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) @ __290} = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])) @ __290}
+{(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])) @ __290}
 
 --
 
-(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [10, 10])), 
+(SATInt(Direct, [__258,__259,__260,__261,__262,__263,__264,__265,__266,__267,__268,__269,__270,__271,__272,__273,__274,__275,__276,__277,__278;int(1..)] [0, 20]) = SATInt(Direct, [true;int(1..)] [10, 10])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __332
 new variables:

--- a/tests-integration/tests/integration/sets/concat/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/concat/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,23 +12,23 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2)])
+{2}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(2)]) subset (Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2), Int(3)]))), 
+({2} subset ({2,3} intersect {1,2,3})), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/concat/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/concat/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,23 +12,23 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2)])
+{2}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(2)]) subset (Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2), Int(3)]))), 
+({2} subset ({2,3} intersect {1,2,3})), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/In/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/In/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,11 +11,11 @@ such that
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-3 in Set([Int(1), Int(2), Int(3)]), 
+3 in {1,2,3}, 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/In/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/In/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,11 +11,11 @@ such that
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-3 in Set([Int(1), Int(2), Int(3)]), 
+3 in {1,2,3}, 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in ({1,2,4} intersect {1,2,3})
 
 a in ({1,2,4} intersect {1,2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2)])
+a in {1,2}
 
 --
 
-a in Set([Int(1), Int(2)]), 
+a in {1,2}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2])
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in ({1,2,4} intersect {1,2,3})
 
 a in ({1,2,4} intersect {1,2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2)])
+a in {1,2}
 
 --
 
-a in Set([Int(1), Int(2)]), 
+a in {1,2}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2])
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in ({1,2,3} union {3,4,5})
 
 a in ({1,2,3} union {3,4,5}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2), Int(3), Int(4), Int(5)])
+a in {1,2,3,4,5}
 
 --
 
-a in Set([Int(1), Int(2), Int(3), Int(4), Int(5)]), 
+a in {1,2,3,4,5}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2,3,4,5])
 

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in ({1,2,3} union {3,4,5})
 
 a in ({1,2,3} union {3,4,5}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2), Int(3), Int(4), Int(5)])
+a in {1,2,3,4,5}
 
 --
 
-a in Set([Int(1), Int(2), Int(3), Int(4), Int(5)]), 
+a in {1,2,3,4,5}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2,3,4,5])
 

--- a/tests-integration/tests/integration/sets/equals1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/equals1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,23 +11,23 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(1), Int(2), Int(3)])), 
+({1,2,3} = {1,2,3}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)])
+and([({1,2,3} subsetEq {1,2,3}),({1,2,3} subsetEq {1,2,3});int(1..)])
 
 --
 
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)]), 
+and([({1,2,3} subsetEq {1,2,3}),({1,2,3} subsetEq {1,2,3});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/equals1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/equals1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,23 +11,23 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(1), Int(2), Int(3)])), 
+({1,2,3} = {1,2,3}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)])
+and([({1,2,3} subsetEq {1,2,3}),({1,2,3} subsetEq {1,2,3});int(1..)])
 
 --
 
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)])),(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)]), 
+and([({1,2,3} subsetEq {1,2,3}),({1,2,3} subsetEq {1,2,3});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/in/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/in/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in {1,2,3}
 
 a in {1,2,3}, 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2), Int(3)])
+a in {1,2,3}
 
 --
 
-a in Set([Int(1), Int(2), Int(3)]), 
+a in {1,2,3}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2,3])
 

--- a/tests-integration/tests/integration/sets/in/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/in/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ a in {1,2,3}
 
 a in {1,2,3}, 
    ~~> constant_evaluator ([("Constant", 9001)])
-a in Set([Int(1), Int(2), Int(3)])
+a in {1,2,3}
 
 --
 
-a in Set([Int(1), Int(2), Int(3)]), 
+a in {1,2,3}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(a,[1,2,3])
 

--- a/tests-integration/tests/integration/sets/intersect1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/intersect1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,35 +12,35 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2)])
+{2}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2)])
+{1,2}
 
 --
 
-(Set([Int(2)]) = (Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2)]))), 
+({2} = ({2,3} intersect {1,2})), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Set([Int(2)]) = Set([Int(2)]))
+({2} = {2})
 
 --
 
-(Set([Int(2)]) = Set([Int(2)])), 
+({2} = {2}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(2)]) subsetEq Set([Int(2)])),(Set([Int(2)]) subsetEq Set([Int(2)]));int(1..)])
+and([({2} subsetEq {2}),({2} subsetEq {2});int(1..)])
 
 --
 
-and([(Set([Int(2)]) subsetEq Set([Int(2)])),(Set([Int(2)]) subsetEq Set([Int(2)]));int(1..)]), 
+and([({2} subsetEq {2}),({2} subsetEq {2});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/intersect1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/intersect1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,35 +12,35 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2)])
+{2}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2)])
+{1,2}
 
 --
 
-(Set([Int(2)]) = (Set([Int(2), Int(3)]) intersect Set([Int(1), Int(2)]))), 
+({2} = ({2,3} intersect {1,2})), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Set([Int(2)]) = Set([Int(2)]))
+({2} = {2})
 
 --
 
-(Set([Int(2)]) = Set([Int(2)])), 
+({2} = {2}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(2)]) subsetEq Set([Int(2)])),(Set([Int(2)]) subsetEq Set([Int(2)]));int(1..)])
+and([({2} subsetEq {2}),({2} subsetEq {2});int(1..)])
 
 --
 
-and([(Set([Int(2)]) subsetEq Set([Int(2)])),(Set([Int(2)]) subsetEq Set([Int(2)]));int(1..)]), 
+and([({2} subsetEq {2}),({2} subsetEq {2});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/subset/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/subset/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(2), Int(3)]) subset Set([Int(1), Int(2), Int(3)])), 
+({2,3} subset {1,2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/subset/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/subset/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
-(Set([Int(2), Int(3)]) subset Set([Int(1), Int(2), Int(3)])), 
+({2,3} subset {1,2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/subsetEq1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/subsetEq1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3)])), 
+({1,2,3} subsetEq {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 false
 

--- a/tests-integration/tests/integration/sets/subsetEq1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/subsetEq1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3)])), 
+({1,2,3} subsetEq {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 false
 

--- a/tests-integration/tests/integration/sets/supset/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/supset/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) supset Set([Int(2), Int(3)])), 
+({1,2,3} supset {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/supset/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/supset/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) supset Set([Int(2), Int(3)])), 
+({1,2,3} supset {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/supsetEq/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/supsetEq/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) supsetEq Set([Int(2), Int(3)])), 
+({1,2,3} supsetEq {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/supsetEq/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/supsetEq/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -11,17 +11,17 @@ such that
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) supsetEq Set([Int(2), Int(3)])), 
+({1,2,3} supsetEq {2,3}), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/union1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/union1/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,35 +12,35 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2)])
+{1,2}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = (Set([Int(2), Int(3)]) union Set([Int(1), Int(2)]))), 
+({1,2,3} = ({2,3} union {1,2})), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(2), Int(3), Int(1)]))
+({1,2,3} = {2,3,1})
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(2), Int(3), Int(1)])), 
+({1,2,3} = {2,3,1}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3), Int(1)])),(Set([Int(2), Int(3), Int(1)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)])
+and([({1,2,3} subsetEq {2,3,1}),({2,3,1} subsetEq {1,2,3});int(1..)])
 
 --
 
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3), Int(1)])),(Set([Int(2), Int(3), Int(1)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)]), 
+and([({1,2,3} subsetEq {2,3,1}),({2,3,1} subsetEq {1,2,3});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/union1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/union1/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -12,35 +12,35 @@ such that
 
 c, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2), Int(3)])
+{1,2,3}
 
 --
 
 a, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(2), Int(3)])
+{2,3}
 
 --
 
 b, 
    ~~> constant_evaluator ([("Constant", 9001)])
-Set([Int(1), Int(2)])
+{1,2}
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = (Set([Int(2), Int(3)]) union Set([Int(1), Int(2)]))), 
+({1,2,3} = ({2,3} union {1,2})), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(2), Int(3), Int(1)]))
+({1,2,3} = {2,3,1})
 
 --
 
-(Set([Int(1), Int(2), Int(3)]) = Set([Int(2), Int(3), Int(1)])), 
+({1,2,3} = {2,3,1}), 
    ~~> eq_to_subset_eq ([("Base", 8800)])
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3), Int(1)])),(Set([Int(2), Int(3), Int(1)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)])
+and([({1,2,3} subsetEq {2,3,1}),({2,3,1} subsetEq {1,2,3});int(1..)])
 
 --
 
-and([(Set([Int(1), Int(2), Int(3)]) subsetEq Set([Int(2), Int(3), Int(1)])),(Set([Int(2), Int(3), Int(1)]) subsetEq Set([Int(1), Int(2), Int(3)]));int(1..)]), 
+and([({1,2,3} subsetEq {2,3,1}),({2,3,1} subsetEq {1,2,3});int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
 true
 

--- a/tests-integration/tests/integration/sets/union2/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/union2/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ x in ({0,1,2} union {3,4,5})
 
 x in ({0,1,2} union {3,4,5}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-x in Set([Int(0), Int(1), Int(2), Int(3), Int(4), Int(5)])
+x in {0,1,2,3,4,5}
 
 --
 
-x in Set([Int(0), Int(1), Int(2), Int(3), Int(4), Int(5)]), 
+x in {0,1,2,3,4,5}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(x,[0,1,2,3,4,5])
 

--- a/tests-integration/tests/integration/sets/union2/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/sets/union2/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -10,11 +10,11 @@ x in ({0,1,2} union {3,4,5})
 
 x in ({0,1,2} union {3,4,5}), 
    ~~> constant_evaluator ([("Constant", 9001)])
-x in Set([Int(0), Int(1), Int(2), Int(3), Int(4), Int(5)])
+x in {0,1,2,3,4,5}
 
 --
 
-x in Set([Int(0), Int(1), Int(2), Int(3), Int(4), Int(5)]), 
+x in {0,1,2,3,4,5}, 
    ~~> in_set ([("Minion", 1)])
 __minion_w_inset(x,[0,1,2,3,4,5])
 

--- a/tests-integration/tests/integration/smt/int/floor-div/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/smt/int/floor-div/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -213,7 +213,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)])
 
@@ -225,11 +225,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 and([__8,__17;int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 or([and([__26,__35;int(1..)]);int(1..)])
@@ -242,12 +242,12 @@ and([__26,__35;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 and([__26,__35;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 __26,
@@ -255,13 +255,13 @@ __35
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __17,
 __26,
 __35
@@ -270,12 +270,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __17,
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __26,
 __35
 new clauses:
@@ -283,21 +283,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __35
 new clauses:
   (__26)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1]))
 new clauses:
   (__35)
 
@@ -364,13 +364,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) @ __45} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+({SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) @ __45} = SATInt(Direct, [true;int(1..)] [1, 1])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])) @ __45}
+{(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, [true;int(1..)] [1, 1])) @ __45}
 
 --
 
-(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, [true;int(1..)] [1, 1])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __53
 new variables:

--- a/tests-integration/tests/integration/smt/int/floor-div/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/smt/int/floor-div/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -213,7 +213,7 @@ new clauses:
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 or([and([__8,__17;int(1..)]);int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)])
 
@@ -225,11 +225,11 @@ and([__8,__17;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 and([__8,__17;int(1..)]),
 or([and([__26,__35;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 or([and([__26,__35;int(1..)]);int(1..)])
@@ -242,12 +242,12 @@ and([__26,__35;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 and([__26,__35;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 __26,
@@ -255,13 +255,13 @@ __35
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __8,
 __17,
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __17,
 __26,
 __35
@@ -270,12 +270,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __17,
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __26,
 __35
 new clauses:
@@ -283,21 +283,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __26,
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __35
 new clauses:
   (__26)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1])),
 __35, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [3, 4]), SATInt(Direct, [b#sat_direct_int_1,b#sat_direct_int_2;int(1..)] [1, 2])) = SATInt(Direct, [true;int(1..)] [1, 1]))
 new clauses:
   (__35)
 
@@ -364,13 +364,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) @ __45} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+({SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) @ __45} = SATInt(Direct, [true;int(1..)] [1, 1])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])) @ __45}
+{(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, [true;int(1..)] [1, 1])) @ __45}
 
 --
 
-(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [1, 1])), 
+(SATInt(Direct, [__36,__37,__38,__39;int(1..)] [1, 4]) = SATInt(Direct, [true;int(1..)] [1, 1])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __53
 new variables:

--- a/tests-integration/tests/integration/smt/int/simple-div/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/smt/int/simple-div/tree-sitter-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -387,7 +387,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)])
 
@@ -399,11 +399,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__62,__83;int(1..)]);int(1..)])
@@ -416,12 +416,12 @@ and([__62,__83;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__62,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
@@ -429,13 +429,13 @@ __83
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83
@@ -444,12 +444,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83
 new clauses:
@@ -457,21 +457,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83
 new clauses:
   (__62)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__83)
 
@@ -579,13 +579,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) @ __98}
+{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])) @ __98}
 
 --
 
-(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __108
 new variables:

--- a/tests-integration/tests/integration/smt/int/simple-div/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/smt/int/simple-div/via-conjure-naive-via-solver-ac-sat-direct-expected-rule-trace.txt
@@ -387,7 +387,7 @@ new clauses:
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 or([and([__20,__41;int(1..)]);int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)])
 
@@ -399,11 +399,11 @@ and([__20,__41;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 and([__20,__41;int(1..)]),
 or([and([__62,__83;int(1..)]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 or([and([__62,__83;int(1..)]);int(1..)])
@@ -416,12 +416,12 @@ and([__62,__83;int(1..)])
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 and([__62,__83;int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
@@ -429,13 +429,13 @@ __83
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __20,
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83
@@ -444,12 +444,12 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __41,
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83
 new clauses:
@@ -457,21 +457,21 @@ new clauses:
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __62,
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83
 new clauses:
   (__62)
 
 --
 
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])),
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2])),
 __83, 
    ~~> remove_single_atom ([("SAT", 8400)])
-(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2]))
+(UnsafeDiv(SATInt(Direct, [a#sat_direct_int_0,a#sat_direct_int_1,a#sat_direct_int_2,a#sat_direct_int_3,a#sat_direct_int_4;int(1..)] [0, 4]), SATInt(Direct, [b#sat_direct_int_0,b#sat_direct_int_1,b#sat_direct_int_2,b#sat_direct_int_3,b#sat_direct_int_4;int(1..)] [0, 4])) = SATInt(Direct, [true;int(1..)] [2, 2]))
 new clauses:
   (__83)
 
@@ -579,13 +579,13 @@ new clauses:
 
 --
 
-({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+({SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) @ __98} = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> bubble_up ([("Bubble", 8800)])
-{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])) @ __98}
+{(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])) @ __98}
 
 --
 
-(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, Matrix([Bool(true)], Moo { inner: Int([UnboundedR(1)]) }) [2, 2])), 
+(SATInt(Direct, [__84,__85,__86,__87,__88;int(1..)] [0, 4]) = SATInt(Direct, [true;int(1..)] [2, 2])), 
    ~~> eq_sat_direct ([("SAT_Direct", 9100)])
 __108
 new variables:


### PR DESCRIPTION
## Description

Currently literals contains `AbstractLiteral`s get displayed using debug formatting "{l:?}" rather than using any Display implemented for the specific literal.

For example in some cases a set will be displayed in output as 
```
Set([Int(1), Int(2)])
```
instead of what we want which is

```
{1,2}
```

## Related issues

<!-- e.g. Closes #12 or Fixes #45 -->

## Key changes

- Fix AbstractLiteral display
- Ran make test-accept to update the outputs

## How to test/review

<!-- instructions to make the reviewer's life easier-->
