### PR TITLE
feat: minion sigsegv on midsearch variable addition diagnostic (draft)

### DIFF
--- a/crates/minion-sys/build.rs
+++ b/crates/minion-sys/build.rs
@@ -87,6 +87,7 @@ fn bind() {
         .allowlist_function("instance_free")
         .allowlist_function("instance_addSearchOrder")
         .allowlist_function("instance_addConstraint")
+        .allowlist_function("instance_addConstraintMidsearch")
         .allowlist_function("instance_addTupleTableSymbol")
         .allowlist_function("instance_getTupleTableSymbol")
         .allowlist_function("printMatrix_addVar")

--- a/crates/minion-sys/src/ffi.rs
+++ b/crates/minion-sys/src/ffi.rs
@@ -6,7 +6,8 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::{CString, c_void};
+    use std::ffi::{CString, c_char, c_void};
+    use std::process::{Command, ExitStatus};
 
     use super::*;
 
@@ -14,6 +15,242 @@ mod tests {
     static X_VAL: AtomicI32 = AtomicI32::new(0);
     static Y_VAL: AtomicI32 = AtomicI32::new(0);
     static Z_VAL: AtomicI32 = AtomicI32::new(0);
+    const MIDSEARCH_SCENARIO_ENV: &str = "MINION_MIDSEARCH_SCENARIO";
+    const MIDSEARCH_CHILD_TEST: &str = "ffi::tests::midsearch_child_runner";
+
+    #[derive(Clone, Copy, Debug)]
+    enum MidsearchScenario {
+        AddVarOnly,
+        AddVarThenAddEqConstraint,
+    }
+
+    impl MidsearchScenario {
+        fn as_env_value(self) -> &'static str {
+            match self {
+                MidsearchScenario::AddVarOnly => "add_var_only",
+                MidsearchScenario::AddVarThenAddEqConstraint => "add_var_then_add_eq_constraint",
+            }
+        }
+
+        fn from_env_value(value: &str) -> Option<Self> {
+            match value {
+                "add_var_only" => Some(MidsearchScenario::AddVarOnly),
+                "add_var_then_add_eq_constraint" => {
+                    Some(MidsearchScenario::AddVarThenAddEqConstraint)
+                }
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct MidsearchState {
+        scenario: MidsearchScenario,
+        instance: *mut ProbSpec_CSPInstance,
+        callback_count: u32,
+        added_var_ok: bool,
+        looked_up_new_var_ok: bool,
+        add_constraint_result: Option<bool>,
+    }
+
+    #[derive(Debug)]
+    struct MidsearchOutcome {
+        run_code: ReturnCodes,
+        callback_count: u32,
+        added_var_ok: bool,
+        looked_up_new_var_ok: bool,
+        add_constraint_result: Option<bool>,
+    }
+
+    #[derive(Default, Debug)]
+    struct SpawnStats {
+        ok: usize,
+        nonzero: usize,
+        signal_11: usize,
+        signal_6: usize,
+        other_signal: usize,
+    }
+
+    #[cfg(unix)]
+    fn status_signal(status: &ExitStatus) -> Option<i32> {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal()
+    }
+
+    #[cfg(not(unix))]
+    fn status_signal(_: &ExitStatus) -> Option<i32> {
+        None
+    }
+
+    fn classify_status(status: &ExitStatus, stats: &mut SpawnStats) {
+        if status.success() {
+            stats.ok += 1;
+            return;
+        }
+
+        stats.nonzero += 1;
+
+        match status_signal(status) {
+            Some(11) => stats.signal_11 += 1,
+            Some(6) => stats.signal_6 += 1,
+            Some(_) => stats.other_signal += 1,
+            None => {}
+        }
+    }
+
+    unsafe fn build_two_var_instance(instance: *mut ProbSpec_CSPInstance) {
+        let x_name = b"x\0";
+        let y_name = b"y\0";
+
+        assert!(newVar_ffi_safe(
+            instance,
+            x_name.as_ptr() as *mut c_char,
+            VariableType_VAR_BOUND,
+            0,
+            1
+        ));
+        assert!(newVar_ffi_safe(
+            instance,
+            y_name.as_ptr() as *mut c_char,
+            VariableType_VAR_BOUND,
+            0,
+            1
+        ));
+
+        let mut x_var = ProbSpec_Var {
+            type_m: VariableType_VAR_CONSTANT,
+            pos_m: 0,
+        };
+        let mut y_var = ProbSpec_Var {
+            type_m: VariableType_VAR_CONSTANT,
+            pos_m: 0,
+        };
+        assert!(getVarByName_safe(
+            instance,
+            x_name.as_ptr() as *mut c_char,
+            &mut x_var
+        ));
+        assert!(getVarByName_safe(
+            instance,
+            y_name.as_ptr() as *mut c_char,
+            &mut y_var
+        ));
+
+        printMatrix_addVar(instance, x_var);
+        printMatrix_addVar(instance, y_var);
+
+        let search_vars = vec_var_new();
+        vec_var_push_back(search_vars, x_var);
+        vec_var_push_back(search_vars, y_var);
+        let search_order = searchOrder_new(search_vars, VarOrderEnum_ORDER_STATIC, false);
+        instance_addSearchOrder(instance, search_order);
+    }
+
+    unsafe extern "C" fn midsearch_mutation_callback(
+        ctx: *mut MinionContext,
+        userdata: *mut c_void,
+    ) -> bool {
+        let state = &mut *(userdata as *mut MidsearchState);
+        state.callback_count += 1;
+
+        if state.callback_count > 1 {
+            return false;
+        }
+
+        let dyn_name = b"dyn_mid\0";
+        state.added_var_ok = newVar_ffi_safe(
+            state.instance,
+            dyn_name.as_ptr() as *mut c_char,
+            VariableType_VAR_BOUND,
+            0,
+            1,
+        );
+
+        let mut dyn_var = ProbSpec_Var {
+            type_m: VariableType_VAR_CONSTANT,
+            pos_m: 0,
+        };
+        state.looked_up_new_var_ok = getVarByName_safe(
+            state.instance,
+            dyn_name.as_ptr() as *mut c_char,
+            &mut dyn_var,
+        );
+
+        if matches!(state.scenario, MidsearchScenario::AddVarThenAddEqConstraint)
+            && state.added_var_ok
+            && state.looked_up_new_var_ok
+        {
+            let x_name = b"x\0";
+            let mut x_var = ProbSpec_Var {
+                type_m: VariableType_VAR_CONSTANT,
+                pos_m: 0,
+            };
+            if getVarByName_safe(state.instance, x_name.as_ptr() as *mut c_char, &mut x_var) {
+                let eq = constraint_new(ConstraintType_CT_EQ);
+                constraint_addVar(eq, &mut dyn_var);
+                constraint_addVar(eq, &mut x_var);
+                state.add_constraint_result =
+                    Some(instance_addConstraintMidsearch(ctx, state.instance, eq));
+            } else {
+                state.add_constraint_result = Some(false);
+            }
+        }
+
+        false
+    }
+
+    unsafe fn run_midsearch_scenario_once(scenario: MidsearchScenario) -> MidsearchOutcome {
+        let ctx = minion_newContext();
+        let options = searchOptions_new();
+        let args = searchMethod_new();
+        let instance = instance_new();
+
+        (*options).silent = true;
+        (*options).print_solution = false;
+
+        build_two_var_instance(instance);
+
+        let mut state = MidsearchState {
+            scenario,
+            instance,
+            callback_count: 0,
+            added_var_ok: false,
+            looked_up_new_var_ok: false,
+            add_constraint_result: None,
+        };
+
+        let run_code = runMinion(
+            ctx,
+            options,
+            args,
+            instance,
+            Some(midsearch_mutation_callback),
+            (&mut state as *mut MidsearchState).cast::<c_void>(),
+        );
+
+        minion_freeContext(ctx);
+
+        MidsearchOutcome {
+            run_code,
+            callback_count: state.callback_count,
+            added_var_ok: state.added_var_ok,
+            looked_up_new_var_ok: state.looked_up_new_var_ok,
+            add_constraint_result: state.add_constraint_result,
+        }
+    }
+
+    fn run_midsearch_child(scenario: MidsearchScenario) -> ExitStatus {
+        let current_test_binary =
+            std::env::current_exe().expect("could not find current test binary");
+
+        Command::new(current_test_binary)
+            .arg("--exact")
+            .arg(MIDSEARCH_CHILD_TEST)
+            .arg("--nocapture")
+            .env(MIDSEARCH_SCENARIO_ENV, scenario.as_env_value())
+            .status()
+            .expect("could not execute child test")
+    }
 
     pub extern "C" fn hello_from_rust(ctx: *mut MinionContext, _userdata: *mut c_void) -> bool {
         unsafe {
@@ -113,5 +350,76 @@ mod tests {
 
             minion_freeContext(ctx);
         }
+    }
+
+    #[test]
+    fn midsearch_child_runner() {
+        let Ok(scenario_raw) = std::env::var(MIDSEARCH_SCENARIO_ENV) else {
+            return;
+        };
+        let scenario = MidsearchScenario::from_env_value(&scenario_raw)
+            .expect("invalid value for MINION_MIDSEARCH_SCENARIO");
+
+        let outcome = unsafe { run_midsearch_scenario_once(scenario) };
+
+        assert_eq!(
+            outcome.run_code, ReturnCodes_OK,
+            "runMinion failed in child with outcome={outcome:#?}"
+        );
+        assert!(
+            outcome.callback_count >= 1,
+            "callback was never called; outcome={outcome:#?}"
+        );
+        assert!(
+            outcome.added_var_ok,
+            "newVar_ffi_safe failed in callback; outcome={outcome:#?}"
+        );
+        assert!(
+            outcome.looked_up_new_var_ok,
+            "getVarByName_safe for new variable failed; outcome={outcome:#?}"
+        );
+
+        if matches!(scenario, MidsearchScenario::AddVarThenAddEqConstraint) {
+            assert_eq!(
+                outcome.add_constraint_result,
+                Some(true),
+                "mid-search eq constraint using fresh variable failed; outcome={outcome:#?}"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "diagnostic stress test; runs child processes to detect crashes while mutating model mid-search"]
+    fn midsearch_variable_addition_stress() {
+        let scenarios = [
+            MidsearchScenario::AddVarOnly,
+            MidsearchScenario::AddVarThenAddEqConstraint,
+        ];
+        let iterations = 40usize;
+        let mut any_failures = false;
+
+        for scenario in scenarios {
+            let mut stats = SpawnStats::default();
+
+            for _ in 0..iterations {
+                let status = run_midsearch_child(scenario);
+                classify_status(&status, &mut stats);
+            }
+
+            eprintln!(
+                "midsearch scenario={} iterations={} stats={stats:?}",
+                scenario.as_env_value(),
+                iterations
+            );
+
+            if stats.nonzero > 0 {
+                any_failures = true;
+            }
+        }
+
+        assert!(
+            !any_failures,
+            "at least one subprocess crashed/failed in mid-search variable-addition stress run"
+        );
     }
 }


### PR DESCRIPTION
## Description

This PR adds a minimal reproducible crash harness for Minion mid-search mutation, so we can reliably demonstrate and debug the failure mode needed for CDP work

## Related issues

Issue #1763 

## Key changes

- Added diagnostic tests in crates/minion-sys/src/ffi.rs

## How to test/review

Run baseline (should pass):
```bash
MINION_MIDSEARCH_SCENARIO=add_var_only \
cargo test -p minion-sys ffi::tests::midsearch_child_runner -- --exact --nocapture
```

Run crash repro (expected segfault / signal 11):
```bash
MINION_MIDSEARCH_SCENARIO=add_var_then_add_eq_constraint \
cargo test -p minion-sys ffi::tests::midsearch_child_runner -- --exact --nocapture
```

Run stress harness (expected failure due to repeated segfaults in crash scenario):
```bash
cargo test -p minion-sys ffi::tests::midsearch_variable_addition_stress \
  -- --ignored --exact --nocapture
```