### PR TITLE
feat(testing): add skip to custom tests and expected-time handling to custom and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "tree-morph",
@@ -3037,11 +3038,17 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -3053,13 +3060,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -3835,6 +3860,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,12 @@ test-accept: install
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true cargo test $(CARGO_LOCKED) --workspace
 	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) --workspace
 
+.PHONY: test-accept-times
+## Runs all tests in accept mode, updates the expected run times, then one more time in normal mode
+test-accept-times: install
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-times cargo test $(CARGO_LOCKED) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) --workspace
+
 .PHONY: fix
 ## Tries to auto-fix hygiene issues reported by `make check`. 
 ## Fixes will not be applied if there are uncommitted changes: to always apply fixes, use `make fix-dirty`.

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -17,12 +17,14 @@ workspace = true
 [dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
 conjure-cp = { path = "../crates/conjure-cp", default-features = false }
+toml_edit = "0.22"
 
 [build-dependencies]
 walkdir = "2.5.0"
 serde = { version = "1.0.228", features = ["derive"] }
 conjure-cp = { path = "../crates/conjure-cp", default-features = false }
 toml = "1.0.3"
+toml_edit = "0.22"
 
 [dev-dependencies]
 conjure-cp-rules = { path = "../crates/conjure-cp-rules" }

--- a/tests-integration/build.rs
+++ b/tests-integration/build.rs
@@ -1,5 +1,5 @@
 use std::env::var;
-use std::fs::{File, read_dir};
+use std::fs::{read_dir, File};
 use std::io::{self, Write};
 use std::path::Path;
 

--- a/tests-integration/build.rs
+++ b/tests-integration/build.rs
@@ -1,5 +1,5 @@
 use std::env::var;
-use std::fs::{read_dir, File};
+use std::fs::{File, read_dir};
 use std::io::{self, Write};
 use std::path::Path;
 
@@ -230,8 +230,7 @@ fn get_ignore_attr(cfg: &TestConfig, include_expected_time: bool) -> io::Result<
             "#[ignore = \"this test has been disabled ('skip=true' in its config.toml)\"]\n",
         ))
     } else if include_expected_time
-        && let (Some(expected_time), Some(limit)) =
-        (cfg.expected_time, max_expected_time_limit()?)
+        && let (Some(expected_time), Some(limit)) = (cfg.expected_time, max_expected_time_limit()?)
     {
         if expected_time > limit {
             Ok(format!(

--- a/tests-integration/build.rs
+++ b/tests-integration/build.rs
@@ -224,12 +224,13 @@ fn max_expected_time_limit() -> io::Result<Option<u64>> {
     }
 }
 
-fn get_ignore_attr(cfg: &TestConfig) -> io::Result<String> {
+fn get_ignore_attr(cfg: &TestConfig, include_expected_time: bool) -> io::Result<String> {
     if cfg.skip {
         Ok(String::from(
             "#[ignore = \"this test has been disabled ('skip=true' in its config.toml)\"]\n",
         ))
-    } else if let (Some(expected_time), Some(limit)) =
+    } else if include_expected_time
+        && let (Some(expected_time), Some(limit)) =
         (cfg.expected_time, max_expected_time_limit()?)
     {
         if expected_time > limit {
@@ -252,7 +253,7 @@ fn write_integration_test(
     // TODO: Consider supporting multiple Essence files?
     if essence_files.len() == 1 {
         let cfg = read_config_or_default(&path);
-        let ignore = get_ignore_attr(&cfg)?;
+        let ignore = get_ignore_attr(&cfg, true)?;
 
         write!(
             file,
@@ -271,7 +272,7 @@ fn write_integration_test(
 
 fn write_custom_test(file: &mut File, path: String) -> io::Result<()> {
     let cfg = read_config_or_default(&path);
-    let ignore = get_ignore_attr(&cfg)?;
+    let ignore = get_ignore_attr(&cfg, true)?;
 
     write!(
         file,
@@ -288,7 +289,7 @@ fn write_roundtrip_test(
     essence_file: (String, String),
 ) -> io::Result<()> {
     let cfg = read_config_or_default(&path);
-    let ignore = get_ignore_attr(&cfg)?;
+    let ignore = get_ignore_attr(&cfg, false)?;
 
     write!(
         file,

--- a/tests-integration/build.rs
+++ b/tests-integration/build.rs
@@ -14,10 +14,12 @@ use test_config::TestConfig;
 fn main() -> io::Result<()> {
     println!("cargo:rerun-if-changed=tests/integration");
     println!("cargo:rerun-if-changed=tests/custom");
+    println!("cargo:rerun-if-changed=tests/roundtrip");
     println!("cargo:rerun-if-changed=tests/integration_test_template");
     println!("cargo:rerun-if-changed=tests/custom_test_template");
     println!("cargo:rerun-if-changed=tests/roundtrip_test_template");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=MAX_EXPECTED_TIME");
 
     let out_dir = var("OUT_DIR").map_err(io::Error::other)?; // wrapping in a std::io::Error to match main's error type
 
@@ -202,19 +204,43 @@ fn main() -> io::Result<()> {
 fn read_config_or_default(path: &str) -> TestConfig {
     let config_path = format!("{path}/config.toml");
     if let Ok(contents) = std::fs::read_to_string(&config_path) {
-        toml::from_str(&contents).unwrap_or_default()
+        toml::from_str(&contents)
+            .unwrap_or_else(|err| panic!("failed to parse {config_path}: {err}"))
     } else {
         TestConfig::default()
     }
 }
 
-fn get_ignore_attr(cfg: &TestConfig) -> String {
+fn max_expected_time_limit() -> io::Result<Option<u64>> {
+    match std::env::var("MAX_EXPECTED_TIME") {
+        Ok(value) => value.parse::<u64>().map(Some).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid MAX_EXPECTED_TIME value '{value}': {err}"),
+            )
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(err) => Err(io::Error::other(err)),
+    }
+}
+
+fn get_ignore_attr(cfg: &TestConfig) -> io::Result<String> {
     if cfg.skip {
-        String::from(
+        Ok(String::from(
             "#[ignore = \"this test has been disabled ('skip=true' in its config.toml)\"]\n",
-        )
+        ))
+    } else if let (Some(expected_time), Some(limit)) =
+        (cfg.expected_time, max_expected_time_limit()?)
+    {
+        if expected_time > limit {
+            Ok(format!(
+                "#[ignore = \"this test declares 'expected-time={expected_time}' in its config.toml, which exceeds MAX_EXPECTED_TIME={limit}\"]\n",
+            ))
+        } else {
+            Ok(String::new())
+        }
     } else {
-        String::new()
+        Ok(String::new())
     }
 }
 
@@ -226,7 +252,7 @@ fn write_integration_test(
     // TODO: Consider supporting multiple Essence files?
     if essence_files.len() == 1 {
         let cfg = read_config_or_default(&path);
-        let ignore = get_ignore_attr(&cfg);
+        let ignore = get_ignore_attr(&cfg)?;
 
         write!(
             file,
@@ -245,7 +271,7 @@ fn write_integration_test(
 
 fn write_custom_test(file: &mut File, path: String) -> io::Result<()> {
     let cfg = read_config_or_default(&path);
-    let ignore = get_ignore_attr(&cfg);
+    let ignore = get_ignore_attr(&cfg)?;
 
     write!(
         file,
@@ -262,7 +288,7 @@ fn write_roundtrip_test(
     essence_file: (String, String),
 ) -> io::Result<()> {
     let cfg = read_config_or_default(&path);
-    let ignore = get_ignore_attr(&cfg);
+    let ignore = get_ignore_attr(&cfg)?;
 
     write!(
         file,

--- a/tests-integration/build.rs
+++ b/tests-integration/build.rs
@@ -244,11 +244,15 @@ fn write_integration_test(
 }
 
 fn write_custom_test(file: &mut File, path: String) -> io::Result<()> {
+    let cfg = read_config_or_default(&path);
+    let ignore = get_ignore_attr(&cfg);
+
     write!(
         file,
         include_str!("./tests/custom_test_template"),
         test_name = path.replace("./", "").replace(['/', '-'], "_"),
-        test_dir = path
+        test_dir = path,
+        ignore_attr = ignore
     )
 }
 

--- a/tests-integration/src/accept.rs
+++ b/tests-integration/src/accept.rs
@@ -1,0 +1,31 @@
+use std::env;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AcceptMode {
+    Disabled,
+    Accept,
+    AcceptWithTimes,
+}
+
+impl AcceptMode {
+    pub fn from_env() -> Self {
+        match env::var("ACCEPT").as_deref() {
+            Ok("false") => Self::Disabled,
+            Ok("true") => Self::Accept,
+            Ok("with-times") => Self::AcceptWithTimes,
+            _ => Self::Disabled,
+        }
+    }
+
+    pub fn accepts_outputs(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    pub fn records_expected_time(self) -> bool {
+        matches!(self, Self::AcceptWithTimes)
+    }
+
+    pub fn refresh_hint() -> &'static str {
+        "Run with ACCEPT=true or ACCEPT=with-times"
+    }
+}

--- a/tests-integration/src/golden_files.rs
+++ b/tests-integration/src/golden_files.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use crate::AcceptMode;
+
 /// Returns whether a file name represents an expected golden artifact.
 fn is_expected_golden_file(file_name: &str) -> bool {
     file_name.contains(".expected") || file_name.contains("-expected-")
@@ -46,8 +48,9 @@ pub fn redundant_golden_files_error(
     let context = context.map_or(String::new(), |context| format!(" {context}"));
 
     std::io::Error::other(format!(
-        "Redundant golden files detected in {}{context}:\n{file_list}\nRun with ACCEPT=true to refresh snapshots.",
-        path.display()
+        "Redundant golden files detected in {}{context}:\n{file_list}\n{} to refresh snapshots.",
+        path.display(),
+        AcceptMode::refresh_hint()
     ))
 }
 

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod accept;
 pub mod golden_files;
 pub mod test_config;
 
+pub use accept::AcceptMode;
 pub use test_config::TestConfig;

--- a/tests-integration/src/test_config.rs
+++ b/tests-integration/src/test_config.rs
@@ -36,6 +36,13 @@ fn default_minion_discrete_threshold() -> usize {
     conjure_cp::settings::DEFAULT_MINION_DISCRETE_THRESHOLD
 }
 
+fn deserialise_expected_time<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<u64>::deserialize(deserializer)
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(default)]
 #[serde(deny_unknown_fields)]
@@ -77,12 +84,20 @@ pub struct TestConfig {
 
     // Generate this test but do not run it
     pub skip: bool,
+
+    #[serde(
+        default,
+        rename = "expected-time",
+        deserialize_with = "deserialise_expected_time"
+    )]
+    pub expected_time: Option<u64>,
 }
 
 impl Default for TestConfig {
     fn default() -> Self {
         Self {
             skip: false,
+            expected_time: None,
             parser: vec!["tree-sitter".to_string(), "via-conjure".to_string()],
             rewriter: vec!["naive".to_string()],
             comprehension_expander: vec![

--- a/tests-integration/src/test_config.rs
+++ b/tests-integration/src/test_config.rs
@@ -2,7 +2,12 @@
 
 use conjure_cp::settings::{Parser, QuantifiedExpander, Rewriter, SolverFamily};
 use serde::Deserialize;
+use std::fs;
+use std::io;
+use std::path::Path;
 use std::str::FromStr;
+use std::time::Duration;
+use toml_edit::{DocumentMut, value};
 
 fn parse_values<T>(values: &[String]) -> Result<Vec<T>, String>
 where
@@ -41,6 +46,54 @@ where
     D: serde::Deserializer<'de>,
 {
     Option::<u64>::deserialize(deserializer)
+}
+
+/// Rounds an observed runtime into the coarse `expected-time` buckets used by test configs,
+/// such as `1`, `5`, `10`, `30`, `60`, and so on.
+pub fn round_expected_time(duration: Duration) -> u64 {
+    let seconds = duration.as_secs_f64();
+
+    if seconds <= 1.0 {
+        1
+    } else if seconds <= 5.0 {
+        5
+    } else if seconds <= 10.0 {
+        10
+    } else {
+        ((seconds / 30.0).ceil() as u64) * 30
+    }
+}
+
+/// Inserts or updates the `expected-time` entry in a test `config.toml`.
+pub fn upsert_expected_time_config(path: &Path, expected_time: u64) -> io::Result<()> {
+    let expected_time = i64::try_from(expected_time).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("expected-time is too large to write to TOML: {err}"),
+        )
+    })?;
+
+    let mut document = if path.exists() {
+        let contents = fs::read_to_string(path)?;
+        if contents.trim().is_empty() {
+            DocumentMut::new()
+        } else {
+            contents
+                .parse::<DocumentMut>()
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+        }
+    } else {
+        DocumentMut::new()
+    };
+
+    document["expected-time"] = value(expected_time);
+
+    let mut new_contents = document.to_string();
+    if !new_contents.ends_with('\n') {
+        new_contents.push('\n');
+    }
+
+    fs::write(path, new_contents)
 }
 
 #[derive(Deserialize, Debug)]

--- a/tests-integration/tests/custom/basic-01/config.toml
+++ b/tests-integration/tests/custom/basic-01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/error-01/config.toml
+++ b/tests-integration/tests/custom/error-01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/error-02/config.toml
+++ b/tests-integration/tests/custom/error-02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-domains/01/config.toml
+++ b/tests-integration/tests/custom/expression-domains/01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-domains/02/config.toml
+++ b/tests-integration/tests/custom/expression-domains/02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-domains/03/config.toml
+++ b/tests-integration/tests/custom/expression-domains/03/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-domains/04/config.toml
+++ b/tests-integration/tests/custom/expression-domains/04/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-domains/05/config.toml
+++ b/tests-integration/tests/custom/expression-domains/05/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/expression-generator/01/config.toml
+++ b/tests-integration/tests/custom/expression-generator/01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/expression-generator/02/union1/config.toml
+++ b/tests-integration/tests/custom/expression-generator/02/union1/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/expression-generator/02/union2/config.toml
+++ b/tests-integration/tests/custom/expression-generator/02/union2/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/expression-generator/02/union3/config.toml
+++ b/tests-integration/tests/custom/expression-generator/02/union3/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/expression-generator/03/subseteq1/config.toml
+++ b/tests-integration/tests/custom/expression-generator/03/subseteq1/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/gcm/eprime/config.toml
+++ b/tests-integration/tests/custom/gcm/eprime/config.toml
@@ -1,0 +1,1 @@
+expected-time = 240

--- a/tests-integration/tests/custom/given/01/config.toml
+++ b/tests-integration/tests/custom/given/01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/given/02/config.toml
+++ b/tests-integration/tests/custom/given/02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/given/03/config.toml
+++ b/tests-integration/tests/custom/given/03/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/given/04/config.toml
+++ b/tests-integration/tests/custom/given/04/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/given/05/config.toml
+++ b/tests-integration/tests/custom/given/05/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/given/06/config.toml
+++ b/tests-integration/tests/custom/given/06/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/given/07/config.toml
+++ b/tests-integration/tests/custom/given/07/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/given/08/config.toml
+++ b/tests-integration/tests/custom/given/08/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/logging-01/config.toml
+++ b/tests-integration/tests/custom/logging-01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/logging-02/config.toml
+++ b/tests-integration/tests/custom/logging-02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/logging-03/config.toml
+++ b/tests-integration/tests/custom/logging-03/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/n_queens/config.toml
+++ b/tests-integration/tests/custom/n_queens/config.toml
@@ -1,0 +1,1 @@
+expected-time = 10

--- a/tests-integration/tests/custom/no-logging/config.toml
+++ b/tests-integration/tests/custom/no-logging/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-01/config.toml
+++ b/tests-integration/tests/custom/params-01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-02/config.toml
+++ b/tests-integration/tests/custom/params-02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-03/config.toml
+++ b/tests-integration/tests/custom/params-03/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-04/config.toml
+++ b/tests-integration/tests/custom/params-04/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-05/config.toml
+++ b/tests-integration/tests/custom/params-05/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/params-06/config.toml
+++ b/tests-integration/tests/custom/params-06/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/pretty-01/config.toml
+++ b/tests-integration/tests/custom/pretty-01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/pretty-02/config.toml
+++ b/tests-integration/tests/custom/pretty-02/config.toml
@@ -1,0 +1,1 @@
+expected-time = 1

--- a/tests-integration/tests/custom/rule-trace-aggregates/01/config.toml
+++ b/tests-integration/tests/custom/rule-trace-aggregates/01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 5

--- a/tests-integration/tests/custom/rule-trace-verbose/01/config.toml
+++ b/tests-integration/tests/custom/rule-trace-verbose/01/config.toml
@@ -1,0 +1,1 @@
+expected-time = 30

--- a/tests-integration/tests/custom_test_template
+++ b/tests-integration/tests/custom_test_template
@@ -1,3 +1,4 @@
+#[allow(non_snake_case)]
 #[test]
 {ignore_attr}fn {test_name}() -> Result<(), Box<dyn Error>> {{
     custom_test("{test_dir}")

--- a/tests-integration/tests/custom_test_template
+++ b/tests-integration/tests/custom_test_template
@@ -1,4 +1,4 @@
 #[test]
-fn {test_name}() -> Result<(), Box<dyn Error>> {{
+{ignore_attr}fn {test_name}() -> Result<(), Box<dyn Error>> {{
     custom_test("{test_dir}")
 }}

--- a/tests-integration/tests/custom_tests.rs
+++ b/tests-integration/tests/custom_tests.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Instant;
+use tests_integration::AcceptMode;
 use tests_integration::golden_files::assert_no_redundant_expected_files;
 use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
-use tests_integration::AcceptMode;
 
 pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
     let accept_mode = AcceptMode::from_env();

--- a/tests-integration/tests/custom_tests.rs
+++ b/tests-integration/tests/custom_tests.rs
@@ -1,16 +1,20 @@
 use pretty_assertions::assert_eq;
 use std::borrow::Cow;
 use std::collections::BTreeSet;
-use std::env;
 use std::error::Error;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::time::Instant;
 use tests_integration::golden_files::assert_no_redundant_expected_files;
+use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
+use tests_integration::AcceptMode;
 
 pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
-    let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
+    let accept_mode = AcceptMode::from_env();
+    let accept = accept_mode.accepts_outputs();
+    let started_at = Instant::now();
 
     // Convert test directory to a PathBuf
     let test_path = PathBuf::from(test_dir);
@@ -61,6 +65,11 @@ pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
 
     let allowed_expected_files = expected_custom_files_for_case(&actual_output, &actual_error);
     assert_no_redundant_expected_files(Path::new(&test_path), &allowed_expected_files, None)?;
+
+    if accept_mode.records_expected_time() {
+        let expected_time = round_expected_time(started_at.elapsed());
+        upsert_expected_time_config(&test_path.join("config.toml"), expected_time)?;
+    }
 
     Ok(())
 }

--- a/tests-integration/tests/integration/abc/config.toml
+++ b/tests-integration/tests/integration/abc/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/antichain/config.toml
+++ b/tests-integration/tests/integration/antichain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/abs/0-simple/config.toml
+++ b/tests-integration/tests/integration/basic/abs/0-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/abs/01-simple/config.toml
+++ b/tests-integration/tests/integration/basic/abs/01-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/abs/02-neg/config.toml
+++ b/tests-integration/tests/integration/basic/abs/02-neg/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/abs/03-nested/config.toml
+++ b/tests-integration/tests/integration/basic/abs/03-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/abs/04-bounds/config.toml
+++ b/tests-integration/tests/integration/basic/abs/04-bounds/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/alldiff/01-basic/config.toml
+++ b/tests-integration/tests/integration/basic/alldiff/01-basic/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/alldiff/02-trivially-false/config.toml
+++ b/tests-integration/tests/integration/basic/alldiff/02-trivially-false/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/alldiff/03-trivially-true/config.toml
+++ b/tests-integration/tests/integration/basic/alldiff/03-trivially-true/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/bool/01/config.toml
+++ b/tests-integration/tests/integration/basic/bool/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/bool/02/config.toml
+++ b/tests-integration/tests/integration/basic/bool/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/bool/03/config.toml
+++ b/tests-integration/tests/integration/basic/bool/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/bool/04/config.toml
+++ b/tests-integration/tests/integration/basic/bool/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/comprehension/01/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/comprehension/02/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/comprehension/03/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/comprehension/04-sum/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/04-sum/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/comprehension/05-alldiff/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/05-alldiff/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/comprehension/06/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/06/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/comprehension/07/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/07/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/comprehension/08/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/08/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/comprehension/09/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/09/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/comprehension/10/config.toml
+++ b/tests-integration/tests/integration/basic/comprehension/10/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/div/01/config.toml
+++ b/tests-integration/tests/integration/basic/div/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/div/02/config.toml
+++ b/tests-integration/tests/integration/basic/div/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/div/03/config.toml
+++ b/tests-integration/tests/integration/basic/div/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/div/04/config.toml
+++ b/tests-integration/tests/integration/basic/div/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/div/05/config.toml
+++ b/tests-integration/tests/integration/basic/div/05/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/exists/01-domain-basic/config.toml
+++ b/tests-integration/tests/integration/basic/exists/01-domain-basic/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/exists/03-domain-inequality/config.toml
+++ b/tests-integration/tests/integration/basic/exists/03-domain-inequality/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/exists/04-in-disjunction/config.toml
+++ b/tests-integration/tests/integration/basic/exists/04-in-disjunction/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/exists/05-nested-boolean/config.toml
+++ b/tests-integration/tests/integration/basic/exists/05-nested-boolean/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/expr-in-domain-quantified/config.toml
+++ b/tests-integration/tests/integration/basic/expr-in-domain-quantified/config.toml
@@ -25,3 +25,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/expr-in-domain-variable/config.toml
+++ b/tests-integration/tests/integration/basic/expr-in-domain-variable/config.toml
@@ -25,3 +25,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/flatten/01-no-depth/config.toml
+++ b/tests-integration/tests/integration/basic/flatten/01-no-depth/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/forAll/01-domain-basic/config.toml
+++ b/tests-integration/tests/integration/basic/forAll/01-domain-basic/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/forAll/03-domain-equality/config.toml
+++ b/tests-integration/tests/integration/basic/forAll/03-domain-equality/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/forAll/04-in-conjunction/config.toml
+++ b/tests-integration/tests/integration/basic/forAll/04-in-conjunction/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/forAll/05-nested-boolean/config.toml
+++ b/tests-integration/tests/integration/basic/forAll/05-nested-boolean/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/iff/01-basic/config.toml
+++ b/tests-integration/tests/integration/basic/iff/01-basic/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/iff/02-partial/config.toml
+++ b/tests-integration/tests/integration/basic/iff/02-partial/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/implies/01-basic/config.toml
+++ b/tests-integration/tests/integration/basic/implies/01-basic/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/implies/02-flattening/config.toml
+++ b/tests-integration/tests/integration/basic/implies/02-flattening/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/implies/03-tautologies/config.toml
+++ b/tests-integration/tests/integration/basic/implies/03-tautologies/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/implies/04-needs-normalising/config.toml
+++ b/tests-integration/tests/integration/basic/implies/04-needs-normalising/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/implies/05-no-parentheses/config.toml
+++ b/tests-integration/tests/integration/basic/implies/05-no-parentheses/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/lettings/01-value-bool/config.toml
+++ b/tests-integration/tests/integration/basic/lettings/01-value-bool/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lettings/02-value-int/config.toml
+++ b/tests-integration/tests/integration/basic/lettings/02-value-int/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lettings/03-value-expr/config.toml
+++ b/tests-integration/tests/integration/basic/lettings/03-value-expr/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lettings/04-domain/config.toml
+++ b/tests-integration/tests/integration/basic/lettings/04-domain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lettings/05-letting-in-domain/config.toml
+++ b/tests-integration/tests/integration/basic/lettings/05-letting-in-domain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-geq/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-geq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-gt/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-gt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-leq/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-leq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-long-lt-short/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-long-lt-short/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-lt/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-lt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/const-short-lt-long/config.toml
+++ b/tests-integration/tests/integration/basic/lex/const-short-lt-long/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/long-leq-short/config.toml
+++ b/tests-integration/tests/integration/basic/lex/long-leq-short/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/long-lt-short/config.toml
+++ b/tests-integration/tests/integration/basic/lex/long-lt-short/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/short-leq-long/config.toml
+++ b/tests-integration/tests/integration/basic/lex/short-leq-long/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/lex/short-lt-long/config.toml
+++ b/tests-integration/tests/integration/basic/lex/short-lt-long/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/log-ops/bool-and/config.toml
+++ b/tests-integration/tests/integration/basic/log-ops/bool-and/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/log-ops/bool-double-not/config.toml
+++ b/tests-integration/tests/integration/basic/log-ops/bool-double-not/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/log-ops/bool-not/config.toml
+++ b/tests-integration/tests/integration/basic/log-ops/bool-not/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/log-ops/bool-or/config.toml
+++ b/tests-integration/tests/integration/basic/log-ops/bool-or/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/01-indexing/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/01-indexing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/02-2d-slicing/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/02-2d-slicing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/03-domain-letting/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/03-domain-letting/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/04-value-letting/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/04-value-letting/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/05-value-letting-index/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/05-value-letting-index/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/06-invalid-index/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/06-invalid-index/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/07-invalid-slice/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/07-invalid-slice/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/08-index-is-expr/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/08-index-is-expr/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/09-index-is-expr-offset/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/09-index-is-expr-offset/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/10-value-letting-index-is-expr/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/11-index-matrix-literal/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/11-index-matrix-literal/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/12-alldiff-matrix-literal-needs-flattening/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/12-alldiff-matrix-literal-needs-flattening/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/13-index-matrix-literal-2d/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/13-index-matrix-literal-2d/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/14-matrix-index-matrix/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/14-matrix-index-matrix/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/15-matrix-index-matrix-with-offset/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/15-matrix-index-matrix-with-offset/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/16-matrix-out-bounds/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/16-matrix-out-bounds/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/matrix/17-matrix-out-bounds-reify/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/17-matrix-out-bounds-reify/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/matrix/18-matrix-out-bounds-possibly-undef/config.toml
+++ b/tests-integration/tests/integration/basic/matrix/18-matrix-out-bounds-possibly-undef/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/max/01/config.toml
+++ b/tests-integration/tests/integration/basic/max/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/max/01_1_const/config.toml
+++ b/tests-integration/tests/integration/basic/max/01_1_const/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/max/02/config.toml
+++ b/tests-integration/tests/integration/basic/max/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/max/03/config.toml
+++ b/tests-integration/tests/integration/basic/max/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/max/04/config.toml
+++ b/tests-integration/tests/integration/basic/max/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/max/05/config.toml
+++ b/tests-integration/tests/integration/basic/max/05/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/min/01/config.toml
+++ b/tests-integration/tests/integration/basic/min/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/min/02/config.toml
+++ b/tests-integration/tests/integration/basic/min/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/min/03/config.toml
+++ b/tests-integration/tests/integration/basic/min/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/min/04/config.toml
+++ b/tests-integration/tests/integration/basic/min/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/min/05/config.toml
+++ b/tests-integration/tests/integration/basic/min/05/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/mod/01/config.toml
+++ b/tests-integration/tests/integration/basic/mod/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/mod/02/config.toml
+++ b/tests-integration/tests/integration/basic/mod/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/mod/03/config.toml
+++ b/tests-integration/tests/integration/basic/mod/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/mod/04/config.toml
+++ b/tests-integration/tests/integration/basic/mod/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/mod/05/config.toml
+++ b/tests-integration/tests/integration/basic/mod/05/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/mod/06/config.toml
+++ b/tests-integration/tests/integration/basic/mod/06/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/neg/01-negeq/config.toml
+++ b/tests-integration/tests/integration/basic/neg/01-negeq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/neg/02-nested-neg/config.toml
+++ b/tests-integration/tests/integration/basic/neg/02-nested-neg/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/neg/03-negated-expression/config.toml
+++ b/tests-integration/tests/integration/basic/neg/03-negated-expression/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/neg/04-negated-expression-nested/config.toml
+++ b/tests-integration/tests/integration/basic/neg/04-negated-expression-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/neg/05-sum/config.toml
+++ b/tests-integration/tests/integration/basic/neg/05-sum/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/basic/neg/06-sum-nested/config.toml
+++ b/tests-integration/tests/integration/basic/neg/06-sum-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/negativeTable/01/config.toml
+++ b/tests-integration/tests/integration/basic/negativeTable/01/config.toml
@@ -31,3 +31,4 @@ solver = [
 
 # negativeTable is a Minion-specific constraint not supported by Conjure
 validate-with-conjure = false
+expected-time = 5

--- a/tests-integration/tests/integration/basic/pow/01-simple/config.toml
+++ b/tests-integration/tests/integration/basic/pow/01-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/pow/02-exponent-zero/config.toml
+++ b/tests-integration/tests/integration/basic/pow/02-exponent-zero/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/pow/03-negative-exponent/config.toml
+++ b/tests-integration/tests/integration/basic/pow/03-negative-exponent/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/pow/04-flatten/config.toml
+++ b/tests-integration/tests/integration/basic/pow/04-flatten/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/pow/05-negative-base/config.toml
+++ b/tests-integration/tests/integration/basic/pow/05-negative-base/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/product/01-simple/config.toml
+++ b/tests-integration/tests/integration/basic/product/01-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/record/01-records/config.toml
+++ b/tests-integration/tests/integration/basic/record/01-records/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/sum/01-deeply-nested/config.toml
+++ b/tests-integration/tests/integration/basic/sum/01-deeply-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/sum/02-sum-put-in-aux-var/config.toml
+++ b/tests-integration/tests/integration/basic/sum/02-sum-put-in-aux-var/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/basic/table/01/config.toml
+++ b/tests-integration/tests/integration/basic/table/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/table/02/config.toml
+++ b/tests-integration/tests/integration/basic/table/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/table/03/config.toml
+++ b/tests-integration/tests/integration/basic/table/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/toInt-flatten/config.toml
+++ b/tests-integration/tests/integration/basic/toInt-flatten/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/toInt/config.toml
+++ b/tests-integration/tests/integration/basic/toInt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/01-bool-int/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/01-bool-int/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/02-literal-indexing/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/02-literal-indexing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/03-equality/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/03-equality/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/04-inequality/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/04-inequality/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/05-equal-to-constant/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/06-letting-statement-explicit/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/06-letting-statement-explicit/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/config.toml
+++ b/tests-integration/tests/integration/basic/tuples/07-letting-statement-domain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/unary-negation/config.toml
+++ b/tests-integration/tests/integration/basic/unary-negation/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/var-in-domain/01/config.toml
+++ b/tests-integration/tests/integration/basic/var-in-domain/01/config.toml
@@ -31,3 +31,4 @@ solver = [
 
 # we must skip since decision variables in domains aren't supported in Conjure
 validate-with-conjure = false
+expected-time = 5

--- a/tests-integration/tests/integration/basic/var-in-domain/02/config.toml
+++ b/tests-integration/tests/integration/basic/var-in-domain/02/config.toml
@@ -31,3 +31,4 @@ solver = [
 
 # we must skip since decision variables in domains aren't supported in Conjure
 validate-with-conjure = false
+expected-time = 5

--- a/tests-integration/tests/integration/basic/weighted-sum/01-simple-lt/config.toml
+++ b/tests-integration/tests/integration/basic/weighted-sum/01-simple-lt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/weighted-sum/02-simple-gt/config.toml
+++ b/tests-integration/tests/integration/basic/weighted-sum/02-simple-gt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/weighted-sum/03-simple-eq/config.toml
+++ b/tests-integration/tests/integration/basic/weighted-sum/03-simple-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/weighted-sum/04-needs-normalising/config.toml
+++ b/tests-integration/tests/integration/basic/weighted-sum/04-needs-normalising/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/basic/weighted-sum/05-flattening/config.toml
+++ b/tests-integration/tests/integration/basic/weighted-sum/05-flattening/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
+++ b/tests-integration/tests/integration/bugs/domain-lettings-in-comprehensions-leak-vars-into-scope/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/config.toml
+++ b/tests-integration/tests/integration/bugs/issue-336-empty-or-should-be-false/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/bugs/sm600-non-terminating-min/config.toml
+++ b/tests-integration/tests/integration/bugs/sm600-non-terminating-min/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/bugs/treemorph-misses-node-01/config.toml
+++ b/tests-integration/tests/integration/bugs/treemorph-misses-node-01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/config.toml
+++ b/tests-integration/tests/integration/bugs/yb33-min-of-constants-parses-as-nothing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/bool-eq/config.toml
+++ b/tests-integration/tests/integration/cnf/bool-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/bool-ineq/config.toml
+++ b/tests-integration/tests/integration/cnf/bool-ineq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/cnf1/config.toml
+++ b/tests-integration/tests/integration/cnf/cnf1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/comparison/better_direct/config.toml
+++ b/tests-integration/tests/integration/cnf/comparison/better_direct/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/comparison/better_log/config.toml
+++ b/tests-integration/tests/integration/cnf/comparison/better_log/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/comparison/sparse_direct/config.toml
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_direct/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/comparison/sparse_log/config.toml
+++ b/tests-integration/tests/integration/cnf/comparison/sparse_log/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/implication1/config.toml
+++ b/tests-integration/tests/integration/cnf/implication1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/implication2/config.toml
+++ b/tests-integration/tests/integration/cnf/implication2/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/int_direct/01-eq/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/01-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/int_direct/02-eq/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/02-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/int_direct/02-neq/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/02-neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/int_direct/03-ineq/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/03-ineq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/int_direct/05-neg/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/05-neg/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/int_direct/06-add/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/06-add/config.toml
@@ -28,3 +28,4 @@ solver = [
     "smt-lia-atomic-nodiscrete",
     "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/int_direct/07-add-single-pair/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/07-add-single-pair/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/int_direct/08-add-constants/config.toml
+++ b/tests-integration/tests/integration/cnf/int_direct/08-add-constants/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/int_order/config.toml
+++ b/tests-integration/tests/integration/cnf/int_order/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/int_order_2/config.toml
+++ b/tests-integration/tests/integration/cnf/int_order_2/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/integer/01-lt/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/01-lt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/integer/02-add/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/02-add/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/integer/03-ranges/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/03-ranges/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/integer/04-complex-add/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/04-complex-add/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 90

--- a/tests-integration/tests/integration/cnf/integer/05-product/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/05-product/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/integer/07-min/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/07-min/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/integer/08-max/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/08-max/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/integer/09-abs/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/09-abs/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/integer/10-div/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/10-div/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 90

--- a/tests-integration/tests/integration/cnf/integer/11-minus/config.toml
+++ b/tests-integration/tests/integration/cnf/integer/11-minus/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/cnf/neg-div/config.toml
+++ b/tests-integration/tests/integration/cnf/neg-div/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 60

--- a/tests-integration/tests/integration/cnf/one_unbound_literal/config.toml
+++ b/tests-integration/tests/integration/cnf/one_unbound_literal/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/one_unconstrained_literal/config.toml
+++ b/tests-integration/tests/integration/cnf/one_unconstrained_literal/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/order_ineq/config.toml
+++ b/tests-integration/tests/integration/cnf/order_ineq/config.toml
@@ -28,3 +28,4 @@ solver = [
     "smt-lia-atomic-nodiscrete",
     "smt-lia-atomic",
 ]
+expected-time = 90

--- a/tests-integration/tests/integration/cnf/order_neq/config.toml
+++ b/tests-integration/tests/integration/cnf/order_neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/single_disjunction/config.toml
+++ b/tests-integration/tests/integration/cnf/single_disjunction/config.toml
@@ -29,3 +29,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/three_unconstrained_literals/config.toml
+++ b/tests-integration/tests/integration/cnf/three_unconstrained_literals/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/cnf/two_unbound_literals/config.toml
+++ b/tests-integration/tests/integration/cnf/two_unbound_literals/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/cnf/two_unconstrained_literals/config.toml
+++ b/tests-integration/tests/integration/cnf/two_unconstrained_literals/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/comprehension-dependent-domains/config.toml
+++ b/tests-integration/tests/integration/comprehension-dependent-domains/config.toml
@@ -22,3 +22,4 @@ solver = [
   # "smt-lia-atomic-nodiscrete",
   # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/comprehension-merge/01/config.toml
+++ b/tests-integration/tests/integration/comprehension-merge/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/comprehension-merge/02/config.toml
+++ b/tests-integration/tests/integration/comprehension-merge/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/dominance/int_pareto_01/config.toml
+++ b/tests-integration/tests/integration/dominance/int_pareto_01/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 120

--- a/tests-integration/tests/integration/dominance/int_pareto_direction_01/config.toml
+++ b/tests-integration/tests/integration/dominance/int_pareto_direction_01/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 90

--- a/tests-integration/tests/integration/dominance/int_pareto_list_01/config.toml
+++ b/tests-integration/tests/integration/dominance/int_pareto_list_01/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 90

--- a/tests-integration/tests/integration/dominance/sat_pareto_01/config.toml
+++ b/tests-integration/tests/integration/dominance/sat_pareto_01/config.toml
@@ -31,3 +31,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 180

--- a/tests-integration/tests/integration/dominance/sat_pareto_02/config.toml
+++ b/tests-integration/tests/integration/dominance/sat_pareto_02/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 270

--- a/tests-integration/tests/integration/dominance/sat_pareto_03/config.toml
+++ b/tests-integration/tests/integration/dominance/sat_pareto_03/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 420

--- a/tests-integration/tests/integration/dominance/subset_pareto_01/config.toml
+++ b/tests-integration/tests/integration/dominance/subset_pareto_01/config.toml
@@ -33,3 +33,4 @@ solver = [
 ]
 
 validate-with-conjure = false
+expected-time = 360

--- a/tests-integration/tests/integration/eprime-minion/bool/literals-to-wlit-1/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/bool/literals-to-wlit-1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/eprime-minion/nqueens-4/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/nqueens-4/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/eprime-minion/partial-eval-01-add/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/partial-eval-01-add/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 60

--- a/tests-integration/tests/integration/eprime-minion/partial-eval-02-or-and/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/partial-eval-02-or-and/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/eprime-minion/partial-eval-03/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/partial-eval-03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/eprime-minion/xyz/config.toml
+++ b/tests-integration/tests/integration/eprime-minion/xyz/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/exists/01/config.toml
+++ b/tests-integration/tests/integration/exists/01/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/exists/02/config.toml
+++ b/tests-integration/tests/integration/exists/02/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/exists/03/config.toml
+++ b/tests-integration/tests/integration/exists/03/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/exists/04/config.toml
+++ b/tests-integration/tests/integration/exists/04/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/experiment/works/max2/config.toml
+++ b/tests-integration/tests/integration/experiment/works/max2/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/experiment/works/min/config.toml
+++ b/tests-integration/tests/integration/experiment/works/min/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/hakank_eprime/schur_small/config.toml
+++ b/tests-integration/tests/integration/hakank_eprime/schur_small/config.toml
@@ -24,3 +24,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/hakank_eprime/xkcd/config.toml
+++ b/tests-integration/tests/integration/hakank_eprime/xkcd/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/diseq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/diseq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-01-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-02-zero/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-02-zero/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-03-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-04-nested-neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/div_undefzero-05-nested-noteq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/minion_constraints/eq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/ineq-01-strict-less-than/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-01-strict-less-than/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/ineq-02-leq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-02-leq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/ineq-03-leq-plus-k/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-03-leq-plus-k/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/ineq-04-strict-greater-than/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-04-strict-greater-than/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-05-geq-plus-k-wrong-order/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/ineq-06-leq-plus-k-wrong-order/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/minion_constraints/modulo_undefzero-01-simple/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/modulo_undefzero-01-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/modulo_undefzero-02-zero/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/modulo_undefzero-02-zero/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/modulo_undefzero-03-nested/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/modulo_undefzero-03-nested/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/modulo_undefzero-04-nested-neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/modulo_undefzero-05-nested-noteq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/minion_constraints/sumgeq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/sumgeq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/minion_constraints/sumleq/config.toml
+++ b/tests-integration/tests/integration/minion_constraints/sumleq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/pythagorean-triples/config.toml
+++ b/tests-integration/tests/integration/pythagorean-triples/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/savilerow/divide-mod-novar/config.toml
+++ b/tests-integration/tests/integration/savilerow/divide-mod-novar/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/savilerow/divide-mod/config.toml
+++ b/tests-integration/tests/integration/savilerow/divide-mod/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/savilerow/langford/config.toml
+++ b/tests-integration/tests/integration/savilerow/langford/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/savilerow/nqueens-8/config.toml
+++ b/tests-integration/tests/integration/savilerow/nqueens-8/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/savilerow/test-power/config.toml
+++ b/tests-integration/tests/integration/savilerow/test-power/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/sets/concat/config.toml
+++ b/tests-integration/tests/integration/sets/concat/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/In/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/In/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Intersect/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/SubSet/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/SubSet/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/SubSetEq/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/SubSetEq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/SupSet/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/SupSet/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/SupSetEq/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/SupSetEq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/config.toml
+++ b/tests-integration/tests/integration/sets/constant_eval_set_tests/Union/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/equals1/config.toml
+++ b/tests-integration/tests/integration/sets/equals1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/sets/in/config.toml
+++ b/tests-integration/tests/integration/sets/in/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/intersect1/config.toml
+++ b/tests-integration/tests/integration/sets/intersect1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/sets/parsing/config.toml
+++ b/tests-integration/tests/integration/sets/parsing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/subset/config.toml
+++ b/tests-integration/tests/integration/sets/subset/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/sets/subsetEq1/config.toml
+++ b/tests-integration/tests/integration/sets/subsetEq1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/sets/supset/config.toml
+++ b/tests-integration/tests/integration/sets/supset/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/supsetEq/config.toml
+++ b/tests-integration/tests/integration/sets/supsetEq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/sets/union1/config.toml
+++ b/tests-integration/tests/integration/sets/union1/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/union2/config.toml
+++ b/tests-integration/tests/integration/sets/union2/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/sets/union_comprehension/config.toml
+++ b/tests-integration/tests/integration/sets/union_comprehension/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 1

--- a/tests-integration/tests/integration/smt/bool/and-eq/config.toml
+++ b/tests-integration/tests/integration/smt/bool/and-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/empty/config.toml
+++ b/tests-integration/tests/integration/smt/bool/empty/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/implies/config.toml
+++ b/tests-integration/tests/integration/smt/bool/implies/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/neq/config.toml
+++ b/tests-integration/tests/integration/smt/bool/neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/not-and/config.toml
+++ b/tests-integration/tests/integration/smt/bool/not-and/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/simple-and/config.toml
+++ b/tests-integration/tests/integration/smt/bool/simple-and/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/bool/simple-or/config.toml
+++ b/tests-integration/tests/integration/smt/bool/simple-or/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/int/floor-div/config.toml
+++ b/tests-integration/tests/integration/smt/int/floor-div/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/int/int-domain/config.toml
+++ b/tests-integration/tests/integration/smt/int/int-domain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/int/min-and-max/config.toml
+++ b/tests-integration/tests/integration/smt/int/min-and-max/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/int/simple-div/config.toml
+++ b/tests-integration/tests/integration/smt/int/simple-div/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/int/simple-negative-add/config.toml
+++ b/tests-integration/tests/integration/smt/int/simple-negative-add/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/int/simple-sub/config.toml
+++ b/tests-integration/tests/integration/smt/int/simple-sub/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/int/simple-sum/config.toml
+++ b/tests-integration/tests/integration/smt/int/simple-sum/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/int/simple_negative_mult/config.toml
+++ b/tests-integration/tests/integration/smt/int/simple_negative_mult/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/int/to-int/config.toml
+++ b/tests-integration/tests/integration/smt/int/to-int/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/1d-alldiff/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/1d-alldiff/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/2d-eq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/2d-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/2d-indexing/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/2d-indexing/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/2d-slicing-alldiff/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/2d-slicing-alldiff/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/bibd/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/bibd/config.toml
@@ -28,3 +28,4 @@ solver = [
   # "smt-lia-atomic-nodiscrete",
   # "smt-lia-atomic",
 ]
+expected-time = 90

--- a/tests-integration/tests/integration/smt/matrix/bool-indexing-of-bool/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/bool-indexing-of-bool/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/bool-indexing-of-int/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/bool-indexing-of-int/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/bool-indexing-simple/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/bool-indexing-simple/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/flatten-no-depth/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/flatten-no-depth/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/holey-domain/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/holey-domain/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/indexing-addition/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/indexing-addition/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/int-indexing-of-bool/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/int-indexing-of-bool/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/int-indexing-of-int/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/int-indexing-of-int/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/lex-eq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/lex-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/lex-geq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/lex-geq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/lex-gt/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/lex-gt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/lex-leq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/lex-leq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/lex-lt/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/lex-lt/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/magic-square-flatten/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/magic-square-flatten/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/nqueens-4/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/nqueens-4/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/overlapping-eq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/overlapping-eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/overlapping-neq-wrapped/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/overlapping-neq-wrapped/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/overlapping-neq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/overlapping-neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/matrix/scalar-neq/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/scalar-neq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/undefined-index-var/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/undefined-index-var/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 30

--- a/tests-integration/tests/integration/smt/matrix/undefined-index/config.toml
+++ b/tests-integration/tests/integration/smt/matrix/undefined-index/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/set/eq/config.toml
+++ b/tests-integration/tests/integration/smt/set/eq/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/set/eq_overlap/config.toml
+++ b/tests-integration/tests/integration/smt/set/eq_overlap/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 10

--- a/tests-integration/tests/integration/smt/set/subset-sum/config.toml
+++ b/tests-integration/tests/integration/smt/set/subset-sum/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration/xyz/config.toml
+++ b/tests-integration/tests/integration/xyz/config.toml
@@ -28,3 +28,4 @@ solver = [
     # "smt-lia-atomic-nodiscrete",
     # "smt-lia-atomic",
 ]
+expected-time = 5

--- a/tests-integration/tests/integration_tests.rs
+++ b/tests-integration/tests/integration_tests.rs
@@ -4,16 +4,16 @@ use git_version as _;
 use conjure_cp::defaults::DEFAULT_RULE_SETS;
 use conjure_cp::parse::tree_sitter::parse_essence_file_native;
 use conjure_cp::rule_engine::{rewrite_morph, rewrite_naive};
-use conjure_cp::solver::Solver;
 use conjure_cp::solver::adaptors::*;
+use conjure_cp::solver::Solver;
 use conjure_cp_cli::utils::testing::{normalize_solutions_for_comparison, read_default_rule_trace};
 use std::collections::{BTreeMap, BTreeSet};
-use std::env;
 use std::error::Error;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
-use tracing_subscriber::{Layer, filter::EnvFilter, filter::FilterFn, fmt, layer::SubscriberExt};
+use std::time::Instant;
+use tracing_subscriber::{filter::EnvFilter, filter::FilterFn, fmt, layer::SubscriberExt, Layer};
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -23,10 +23,10 @@ use conjure_cp::context::Context;
 use conjure_cp::parse::tree_sitter::parse_essence_file;
 use conjure_cp::rule_engine::resolve_rule_sets;
 use conjure_cp::settings::{
-    Parser, QuantifiedExpander, Rewriter, SolverFamily, set_comprehension_expander,
-    set_current_parser, set_current_rewriter, set_current_solver_family,
-    set_default_rule_trace_enabled, set_minion_discrete_threshold,
+    set_comprehension_expander, set_current_parser, set_current_rewriter,
+    set_current_solver_family, set_default_rule_trace_enabled, set_minion_discrete_threshold,
     set_rule_trace_aggregates_enabled, set_rule_trace_enabled, set_rule_trace_verbose_enabled,
+    Parser, QuantifiedExpander, Rewriter, SolverFamily,
 };
 use conjure_cp_cli::utils::conjure::solutions_to_json;
 use conjure_cp_cli::utils::conjure::{get_solutions, get_solutions_from_conjure};
@@ -35,8 +35,10 @@ use conjure_cp_cli::utils::testing::{read_solutions_json, save_solutions_json};
 #[allow(clippy::single_component_path_imports, unused_imports)]
 use conjure_cp_rules;
 use pretty_assertions::assert_eq;
-use tests_integration::TestConfig;
 use tests_integration::golden_files::assert_no_redundant_expected_files;
+use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
+use tests_integration::AcceptMode;
+use tests_integration::TestConfig;
 
 #[derive(Clone, Copy, Debug)]
 struct RunCase<'a> {
@@ -63,7 +65,9 @@ fn run_case_label(
 }
 
 fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(), Box<dyn Error>> {
-    let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
+    let accept_mode = AcceptMode::from_env();
+    let accept = accept_mode.accepts_outputs();
+    let started_at = Instant::now();
 
     if accept {
         clean_test_dir_for_accept(path, essence_base, extension)?;
@@ -174,6 +178,12 @@ fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(
 
     assert_no_redundant_expected_files(Path::new(path), &allowed_expected_files, None)?;
 
+    if accept_mode.records_expected_time() {
+        let expected_time = round_expected_time(started_at.elapsed());
+        let config_path = Path::new(path).join("config.toml");
+        upsert_expected_time_config(&config_path, expected_time)?;
+    }
+
     Ok(())
 }
 
@@ -276,7 +286,7 @@ fn integration_test_inner(
         solved
     };
 
-    // Stage 3b: Check solutions against Conjure when ACCEPT=true and validation is enabled.
+    // Stage 3b: Check solutions against Conjure when accept mode is enabled and validation is enabled.
     if accept && conjure_solutions.is_some() {
         let conjure_solutions = conjure_solutions
             .as_deref()
@@ -297,7 +307,7 @@ fn integration_test_inner(
         );
     }
 
-    // When ACCEPT=true, copy all generated files to expected
+    // When accept mode is enabled, copy all generated files to expected
     if accept {
         // Always overwrite these ones. Unlike the rest, we don't need to selectively do these
         // based on the test results, so they don't get done later.

--- a/tests-integration/tests/integration_tests.rs
+++ b/tests-integration/tests/integration_tests.rs
@@ -4,8 +4,8 @@ use git_version as _;
 use conjure_cp::defaults::DEFAULT_RULE_SETS;
 use conjure_cp::parse::tree_sitter::parse_essence_file_native;
 use conjure_cp::rule_engine::{rewrite_morph, rewrite_naive};
-use conjure_cp::solver::adaptors::*;
 use conjure_cp::solver::Solver;
+use conjure_cp::solver::adaptors::*;
 use conjure_cp_cli::utils::testing::{normalize_solutions_for_comparison, read_default_rule_trace};
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -13,7 +13,7 @@ use std::fs;
 use std::fs::File;
 use std::path::Path;
 use std::time::Instant;
-use tracing_subscriber::{filter::EnvFilter, filter::FilterFn, fmt, layer::SubscriberExt, Layer};
+use tracing_subscriber::{Layer, filter::EnvFilter, filter::FilterFn, fmt, layer::SubscriberExt};
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -23,10 +23,10 @@ use conjure_cp::context::Context;
 use conjure_cp::parse::tree_sitter::parse_essence_file;
 use conjure_cp::rule_engine::resolve_rule_sets;
 use conjure_cp::settings::{
-    set_comprehension_expander, set_current_parser, set_current_rewriter,
-    set_current_solver_family, set_default_rule_trace_enabled, set_minion_discrete_threshold,
+    Parser, QuantifiedExpander, Rewriter, SolverFamily, set_comprehension_expander,
+    set_current_parser, set_current_rewriter, set_current_solver_family,
+    set_default_rule_trace_enabled, set_minion_discrete_threshold,
     set_rule_trace_aggregates_enabled, set_rule_trace_enabled, set_rule_trace_verbose_enabled,
-    Parser, QuantifiedExpander, Rewriter, SolverFamily,
 };
 use conjure_cp_cli::utils::conjure::solutions_to_json;
 use conjure_cp_cli::utils::conjure::{get_solutions, get_solutions_from_conjure};
@@ -35,10 +35,10 @@ use conjure_cp_cli::utils::testing::{read_solutions_json, save_solutions_json};
 #[allow(clippy::single_component_path_imports, unused_imports)]
 use conjure_cp_rules;
 use pretty_assertions::assert_eq;
-use tests_integration::golden_files::assert_no_redundant_expected_files;
-use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
 use tests_integration::AcceptMode;
 use tests_integration::TestConfig;
+use tests_integration::golden_files::assert_no_redundant_expected_files;
+use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
 
 #[derive(Clone, Copy, Debug)]
 struct RunCase<'a> {

--- a/tests-integration/tests/roundtrip_tests.rs
+++ b/tests-integration/tests/roundtrip_tests.rs
@@ -1,3 +1,4 @@
+use conjure_cp::Model;
 use conjure_cp::ast::SerdeModel;
 use conjure_cp::context::Context;
 use conjure_cp::instantiate::instantiate_model;
@@ -5,7 +6,6 @@ use conjure_cp::parse::tree_sitter::errors::InstantiateModelError;
 use conjure_cp::parse::tree_sitter::errors::ParseErrorCollection;
 use conjure_cp::parse::tree_sitter::{parse_essence_file, parse_essence_file_native};
 use conjure_cp::settings::Parser;
-use conjure_cp::Model;
 use conjure_cp_cli::utils::testing::serialize_model;
 use std::collections::BTreeSet;
 use std::error::Error;
@@ -13,9 +13,9 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
-use tests_integration::golden_files::assert_no_redundant_expected_files;
 use tests_integration::AcceptMode;
 use tests_integration::TestConfig;
+use tests_integration::golden_files::assert_no_redundant_expected_files;
 
 use std::io::Write;
 

--- a/tests-integration/tests/roundtrip_tests.rs
+++ b/tests-integration/tests/roundtrip_tests.rs
@@ -13,9 +13,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::time::Instant;
 use tests_integration::golden_files::assert_no_redundant_expected_files;
-use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
 use tests_integration::AcceptMode;
 use tests_integration::TestConfig;
 
@@ -26,9 +24,7 @@ type ParseFn = fn(&str, Arc<RwLock<Context<'static>>>) -> Result<Model, Box<Pars
 
 /// Runs a roundtrip parse test for one input model using the parsers configured in `config.toml`.
 fn roundtrip_test(path: &str, filename: &str, extension: &str) -> Result<(), Box<dyn Error>> {
-    let accept_mode = AcceptMode::from_env();
-    let accept = accept_mode.accepts_outputs();
-    let started_at = Instant::now();
+    let accept = AcceptMode::from_env().accepts_outputs();
 
     let file_config: TestConfig =
         if let Ok(config_contents) = fs::read_to_string(format!("{path}/config.toml")) {
@@ -70,12 +66,6 @@ fn roundtrip_test(path: &str, filename: &str, extension: &str) -> Result<(), Box
     }
 
     assert_no_redundant_expected_files(Path::new(path), &allowed_expected_files, None)?;
-
-    if accept_mode.records_expected_time() {
-        let expected_time = round_expected_time(started_at.elapsed());
-        let config_path = Path::new(path).join("config.toml");
-        upsert_expected_time_config(&config_path, expected_time)?;
-    }
 
     Ok(())
 }

--- a/tests-integration/tests/roundtrip_tests.rs
+++ b/tests-integration/tests/roundtrip_tests.rs
@@ -1,4 +1,3 @@
-use conjure_cp::Model;
 use conjure_cp::ast::SerdeModel;
 use conjure_cp::context::Context;
 use conjure_cp::instantiate::instantiate_model;
@@ -6,16 +5,19 @@ use conjure_cp::parse::tree_sitter::errors::InstantiateModelError;
 use conjure_cp::parse::tree_sitter::errors::ParseErrorCollection;
 use conjure_cp::parse::tree_sitter::{parse_essence_file, parse_essence_file_native};
 use conjure_cp::settings::Parser;
+use conjure_cp::Model;
 use conjure_cp_cli::utils::testing::serialize_model;
 use std::collections::BTreeSet;
-use std::env;
 use std::error::Error;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
-use tests_integration::TestConfig;
+use std::time::Instant;
 use tests_integration::golden_files::assert_no_redundant_expected_files;
+use tests_integration::test_config::{round_expected_time, upsert_expected_time_config};
+use tests_integration::AcceptMode;
+use tests_integration::TestConfig;
 
 use std::io::Write;
 
@@ -24,7 +26,9 @@ type ParseFn = fn(&str, Arc<RwLock<Context<'static>>>) -> Result<Model, Box<Pars
 
 /// Runs a roundtrip parse test for one input model using the parsers configured in `config.toml`.
 fn roundtrip_test(path: &str, filename: &str, extension: &str) -> Result<(), Box<dyn Error>> {
-    let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
+    let accept_mode = AcceptMode::from_env();
+    let accept = accept_mode.accepts_outputs();
+    let started_at = Instant::now();
 
     let file_config: TestConfig =
         if let Ok(config_contents) = fs::read_to_string(format!("{path}/config.toml")) {
@@ -66,10 +70,17 @@ fn roundtrip_test(path: &str, filename: &str, extension: &str) -> Result<(), Box
     }
 
     assert_no_redundant_expected_files(Path::new(path), &allowed_expected_files, None)?;
+
+    if accept_mode.records_expected_time() {
+        let expected_time = round_expected_time(started_at.elapsed());
+        let config_path = Path::new(path).join("config.toml");
+        upsert_expected_time_config(&config_path, expected_time)?;
+    }
+
     Ok(())
 }
 
-/// Removes generated and expected artefacts for a roundtrip test directory when `ACCEPT=true`.
+/// Removes generated and expected artefacts for a roundtrip test directory when accept mode is enabled.
 ///
 /// Keeps source model files (`.essence`, `.param`) and `config.toml`. Nested directories are not removed,
 /// because each nested test directory performs its own cleanup when executed.
@@ -112,13 +123,13 @@ fn clean_test_dir_for_accept(path: &str) -> Result<(), std::io::Error> {
 /// 1. Parse the input model file.
 /// 2. If parsing succeeds:
 /// 3. Save generated model JSON and generated Essence output.
-/// 4. If `ACCEPT=true`, copy generated outputs to expected outputs.
+/// 4. If accept mode is enabled, copy generated outputs to expected outputs.
 /// 5. Load and compare generated vs expected model JSON.
 /// 6. Load and compare generated vs expected Essence output.
 /// 7. Parse generated Essence again, re-emit Essence, and assert roundtrip stability.
 /// 8. If parsing fails:
 /// 9. Save generated parse error output.
-/// 10. If `ACCEPT=true`, copy generated error output to expected error output.
+/// 10. If accept mode is enabled, copy generated error output to expected error output.
 /// 11. Load and compare generated vs expected error output.
 fn roundtrip_test_inner(
     path: &str,
@@ -128,7 +139,7 @@ fn roundtrip_test_inner(
     parse: ParseFn,
     param_file: Option<&str>,
 ) -> Result<BTreeSet<String>, Box<dyn Error>> {
-    let accept = env::var("ACCEPT").unwrap_or("false".to_string()) == "true";
+    let accept = AcceptMode::from_env().accepts_outputs();
 
     let file_path = format!("{path}/{input_filename}.{extension}");
     let context: Arc<RwLock<Context<'static>>> = Default::default();
@@ -177,7 +188,10 @@ fn roundtrip_test_inner(
             {
                 return Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
-                    "Expected output file not found: Run with ACCEPT=true".to_string(),
+                    format!(
+                        "Expected output file not found: {}",
+                        AcceptMode::refresh_hint()
+                    ),
                 )));
             }
 
@@ -218,7 +232,10 @@ fn roundtrip_test_inner(
             if !accept && !Path::new(&roundtrip_error_path(path, case_name, "expected")).exists() {
                 return Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
-                    "Expected output file not found: Run with ACCEPT=true".to_string(),
+                    format!(
+                        "Expected output file not found: {}",
+                        AcceptMode::refresh_hint()
+                    ),
                 )));
             }
 


### PR DESCRIPTION
## Description

- Add a skip field to custom tests
- Add expected-time fields to integration and custom tests
- `ACCEPT=with-times` updates the expected-time entries in the config.toml files
- `make test-accept-times` runs all tests with `ACCEPT=with-times`
- `MAX_EXPECTED_TIME` environment variables can be used to filter tests. If set to `N`, only tests that (declare themselves to) take up to `N` seconds are run

Of course, I realise a wall clock time isn't something reliable, especially across computers. But this is better than nothing. To reduce the churn, I made the time itself quite coarse, it can take one of the following values: 1, 5, 10, 30, 60, (or other multiples of 30).