### PR TITLE
test(minion-sys): add raw FFI reproducer for mid-search reify/newvar segfault(draft)

### DIFF
--- a/crates/minion-sys/src/ffi.rs
+++ b/crates/minion-sys/src/ffi.rs
@@ -17,6 +17,8 @@ mod tests {
     static Z_VAL: AtomicI32 = AtomicI32::new(0);
     const MIDSEARCH_SCENARIO_ENV: &str = "MINION_MIDSEARCH_SCENARIO";
     const MIDSEARCH_CHILD_TEST: &str = "ffi::tests::midsearch_child_runner";
+    const ISSUE_SCENARIO_ENV: &str = "MINION_ISSUE_MIDSEARCH_REIFY_NEWVAR";
+    const ISSUE_CHILD_TEST: &str = "ffi::tests::midsearch_reify_newvar_issue_child_runner";
 
     #[derive(Clone, Copy, Debug)]
     enum MidsearchScenario {
@@ -60,6 +62,22 @@ mod tests {
         added_var_ok: bool,
         looked_up_new_var_ok: bool,
         add_constraint_result: Option<MinionResult>,
+    }
+
+    #[derive(Debug)]
+    struct IssueState {
+        instance: *mut ProbSpec_CSPInstance,
+        callback_count: u32,
+        add_var_results: Vec<MinionResult>,
+        add_constraint_results: Vec<MinionResult>,
+    }
+
+    #[derive(Debug)]
+    struct IssueOutcome {
+        run_code: MinionResult,
+        callback_count: u32,
+        add_var_results: Vec<MinionResult>,
+        add_constraint_results: Vec<MinionResult>,
     }
 
     #[derive(Default, Debug)]
@@ -138,6 +156,154 @@ mod tests {
         instance_addSearchOrder(instance, search_order);
     }
 
+    unsafe fn build_issue_instance(instance: *mut ProbSpec_CSPInstance) {
+        let x_name = b"x\0";
+        let y_name = b"y\0";
+
+        assert_eq!(
+            minion_newVar(
+                instance,
+                x_name.as_ptr() as *mut c_char,
+                VariableType_VAR_BOUND,
+                0,
+                3
+            ),
+            MinionResult_MINION_OK
+        );
+        assert_eq!(
+            minion_newVar(
+                instance,
+                y_name.as_ptr() as *mut c_char,
+                VariableType_VAR_BOUND,
+                0,
+                3
+            ),
+            MinionResult_MINION_OK
+        );
+
+        let x = minion_getVarByName(instance, x_name.as_ptr() as *mut c_char);
+        let y = minion_getVarByName(instance, y_name.as_ptr() as *mut c_char);
+        assert_eq!(x.result, MinionResult_MINION_OK);
+        assert_eq!(y.result, MinionResult_MINION_OK);
+
+        printMatrix_addVar(instance, x.var);
+        printMatrix_addVar(instance, y.var);
+
+        let search_vars = vec_var_new();
+        vec_var_push_back(search_vars, x.var);
+        vec_var_push_back(search_vars, y.var);
+        let search_order = searchOrder_new(search_vars, VarOrderEnum_ORDER_STATIC, false);
+        instance_addSearchOrder(instance, search_order);
+
+        // sumgeq([x, y], 2)
+        let geq = constraint_new(ConstraintType_CT_GEQSUM);
+        let lhs = vec_var_new();
+        vec_var_push_back(lhs, x.var);
+        vec_var_push_back(lhs, y.var);
+        let rhs = vec_var_new();
+        vec_var_push_back(rhs, constantAsVar(2));
+        constraint_addList(geq, lhs);
+        constraint_addList(geq, rhs);
+        instance_addConstraint(instance, geq);
+    }
+
+    unsafe fn add_issue_dominance_like_reify(
+        ctx: *mut MinionContext,
+        instance: *mut ProbSpec_CSPInstance,
+        y_value: i32,
+        aux_name: &str,
+    ) -> (MinionResult, MinionResult) {
+        let aux_name_c = CString::new(aux_name).expect("bad aux name");
+        let add_var = minion_newVarMidsearch(
+            ctx,
+            instance,
+            aux_name_c.as_ptr() as *mut c_char,
+            VariableType_VAR_BOOL,
+            0,
+            1,
+        );
+        if add_var != MinionResult_MINION_OK {
+            return (add_var, add_var);
+        }
+
+        let x_res = minion_getVarByName(instance, b"x\0".as_ptr() as *mut c_char);
+        let y_res = minion_getVarByName(instance, b"y\0".as_ptr() as *mut c_char);
+        let aux_res = minion_getVarByName(instance, aux_name_c.as_ptr() as *mut c_char);
+        if x_res.result != MinionResult_MINION_OK
+            || y_res.result != MinionResult_MINION_OK
+            || aux_res.result != MinionResult_MINION_OK
+        {
+            return (add_var, MinionResult_MINION_INVALID_INSTANCE);
+        }
+
+        let mut x = x_res.var;
+        let mut y = y_res.var;
+        let mut aux = aux_res.var;
+
+        // w-literal(aux, 0)
+        let wlit = constraint_new(ConstraintType_CT_WATCHED_LIT);
+        constraint_addVar(wlit, &mut aux);
+        constraint_addConstant(wlit, 0);
+        let add_wlit = minion_addConstraintMidsearch(ctx, instance, wlit);
+        if add_wlit != MinionResult_MINION_OK {
+            return (add_var, add_wlit);
+        }
+
+        // ineq(0, x, 0)
+        let ineq_x = constraint_new(ConstraintType_CT_INEQ);
+        let mut c0 = constantAsVar(0);
+        constraint_addVar(ineq_x, &mut c0);
+        constraint_addVar(ineq_x, &mut x);
+        constraint_addConstant(ineq_x, 0);
+
+        // ineq(y_value, y, 0)
+        let ineq_y = constraint_new(ConstraintType_CT_INEQ);
+        let mut cy = constantAsVar(y_value);
+        constraint_addVar(ineq_y, &mut cy);
+        constraint_addVar(ineq_y, &mut y);
+        constraint_addConstant(ineq_y, 0);
+
+        let and_inner = constraint_new(ConstraintType_CT_WATCHED_NEW_AND);
+        constraint_addConstraint(and_inner, ineq_x);
+        constraint_addConstraint(and_inner, ineq_y);
+
+        // sumgeq([-1, x], 0)
+        let sum_x = constraint_new(ConstraintType_CT_GEQSUM);
+        let sx_lhs = vec_var_new();
+        vec_var_push_back(sx_lhs, constantAsVar(-1));
+        vec_var_push_back(sx_lhs, x);
+        let sx_rhs = vec_var_new();
+        vec_var_push_back(sx_rhs, constantAsVar(0));
+        constraint_addList(sum_x, sx_lhs);
+        constraint_addList(sum_x, sx_rhs);
+
+        // sumgeq([-1, y], y_value)
+        let sum_y = constraint_new(ConstraintType_CT_GEQSUM);
+        let sy_lhs = vec_var_new();
+        vec_var_push_back(sy_lhs, constantAsVar(-1));
+        vec_var_push_back(sy_lhs, y);
+        let sy_rhs = vec_var_new();
+        vec_var_push_back(sy_rhs, constantAsVar(y_value));
+        constraint_addList(sum_y, sy_lhs);
+        constraint_addList(sum_y, sy_rhs);
+
+        let or_inner = constraint_new(ConstraintType_CT_WATCHED_NEW_OR);
+        constraint_addConstraint(or_inner, sum_x);
+        constraint_addConstraint(or_inner, sum_y);
+
+        let and_outer = constraint_new(ConstraintType_CT_WATCHED_NEW_AND);
+        constraint_addConstraint(and_outer, and_inner);
+        constraint_addConstraint(and_outer, or_inner);
+
+        // reify(and_outer, aux)
+        let reify = constraint_new(ConstraintType_CT_REIFY);
+        constraint_addConstraint(reify, and_outer);
+        constraint_addVar(reify, &mut aux);
+
+        let add_reify = minion_addConstraintMidsearch(ctx, instance, reify);
+        (add_var, add_reify)
+    }
+
     unsafe extern "C" fn midsearch_mutation_callback(
         ctx: *mut MinionContext,
         userdata: *mut c_void,
@@ -184,6 +350,42 @@ mod tests {
         false
     }
 
+    unsafe extern "C" fn issue_midsearch_callback(
+        ctx: *mut MinionContext,
+        userdata: *mut c_void,
+    ) -> bool {
+        let state = &mut *(userdata as *mut IssueState);
+        state.callback_count += 1;
+
+        if state.callback_count == 1 {
+            let (add_var, add_reify) =
+                add_issue_dominance_like_reify(ctx, state.instance, 2, "dyn_aux_0");
+            state.add_var_results.push(add_var);
+            state.add_constraint_results.push(add_reify);
+            return true;
+        }
+
+        if state.callback_count == 2 {
+            let add_unused = minion_newVarMidsearch(
+                ctx,
+                state.instance,
+                b"dyn_aux_1_unused\0".as_ptr() as *mut c_char,
+                VariableType_VAR_BOOL,
+                0,
+                1,
+            );
+            state.add_var_results.push(add_unused);
+
+            let (add_var, add_reify) =
+                add_issue_dominance_like_reify(ctx, state.instance, 3, "dyn_aux_2");
+            state.add_var_results.push(add_var);
+            state.add_constraint_results.push(add_reify);
+            return true;
+        }
+
+        false
+    }
+
     unsafe fn run_midsearch_scenario_once(scenario: MidsearchScenario) -> MidsearchOutcome {
         let ctx = minion_newContext();
         let options = searchOptions_new();
@@ -224,6 +426,43 @@ mod tests {
         }
     }
 
+    unsafe fn run_issue_scenario_once() -> IssueOutcome {
+        let ctx = minion_newContext();
+        let options = searchOptions_new();
+        let args = searchMethod_new();
+        let instance = instance_new();
+
+        (*options).silent = true;
+        (*options).print_solution = false;
+
+        build_issue_instance(instance);
+
+        let mut state = IssueState {
+            instance,
+            callback_count: 0,
+            add_var_results: vec![],
+            add_constraint_results: vec![],
+        };
+
+        let run_code = runMinion(
+            ctx,
+            options,
+            args,
+            instance,
+            Some(issue_midsearch_callback),
+            (&mut state as *mut IssueState).cast::<c_void>(),
+        );
+
+        minion_freeContext(ctx);
+
+        IssueOutcome {
+            run_code,
+            callback_count: state.callback_count,
+            add_var_results: state.add_var_results,
+            add_constraint_results: state.add_constraint_results,
+        }
+    }
+
     fn run_midsearch_child(scenario: MidsearchScenario) -> ExitStatus {
         let current_test_binary =
             std::env::current_exe().expect("could not find current test binary");
@@ -235,6 +474,19 @@ mod tests {
             .env(MIDSEARCH_SCENARIO_ENV, scenario.as_env_value())
             .status()
             .expect("could not execute child test")
+    }
+
+    fn run_issue_child() -> ExitStatus {
+        let current_test_binary =
+            std::env::current_exe().expect("could not find current test binary");
+
+        Command::new(current_test_binary)
+            .arg("--exact")
+            .arg(ISSUE_CHILD_TEST)
+            .arg("--nocapture")
+            .env(ISSUE_SCENARIO_ENV, "1")
+            .status()
+            .expect("could not execute issue child test")
     }
 
     pub extern "C" fn hello_from_rust(ctx: *mut MinionContext, _userdata: *mut c_void) -> bool {
@@ -420,6 +672,44 @@ mod tests {
         assert!(
             !any_failures,
             "at least one subprocess crashed/failed in mid-search variable-addition stress run"
+        );
+    }
+
+    #[test]
+    fn midsearch_reify_newvar_issue_child_runner() {
+        let Ok(flag) = std::env::var(ISSUE_SCENARIO_ENV) else {
+            return;
+        };
+        assert_eq!(flag, "1", "invalid issue child env value");
+
+        let outcome = unsafe { run_issue_scenario_once() };
+
+        assert_eq!(
+            outcome.run_code, MinionResult_MINION_OK,
+            "runMinion failed unexpectedly in issue child with outcome={outcome:#?}"
+        );
+        assert!(
+            outcome.callback_count >= 1,
+            "issue callback was never called; outcome={outcome:#?}"
+        );
+    }
+
+    #[test]
+    #[ignore = "diagnostic reproducer for Minion segfault with mid-search reify on freshly-added bool vars"]
+    fn midsearch_reify_newvar_issue_reproducer() {
+        let status = run_issue_child();
+
+        #[cfg(unix)]
+        assert_eq!(
+            status_signal(&status),
+            Some(11),
+            "expected SIGSEGV from issue reproducer child, got status={status:?}"
+        );
+
+        #[cfg(not(unix))]
+        assert!(
+            !status.success(),
+            "expected child failure on issue reproducer, got status={status:?}"
         );
     }
 }


### PR DESCRIPTION
## Description

This PR adds a focused raw-FFI reproducer for a Minion crash when mutating the model mid-search.

It captures the pattern:

1. minion_newVarMidsearch(... VAR_BOOL ...)
2. minion_addConstraintMidsearch(w-literal(aux, 0))
3. minion_addConstraintMidsearch(reify(watched-and(...), aux))

Reproducer runs this in a child process so Conjure Oxide doesn't crash when Minion does

## Related issues

#1780 

## Key changes

- Added ffi::tests::midsearch_reify_newvar_issue_child_runner in crates/minion-sys/src/ffi.rs
- Added ignored diagnostic test ffi::tests::midsearch_reify_newvar_issue_reproducer that asserts child exits with SIGSEGV on Unix
- Added minimal raw-FFI construction of the dominance-like w-literal + reify(watched-and(...)) injection pattern

## How to test/review
```
# Runs the reproducer harness (passes because it expects child SIGSEGV)
cargo test -p minion-sys --lib ffi::tests::midsearch_reify_newvar_issue_reproducer -- --ignored --exact --nocapture

# Optional: run child directly to observe raw crash behavior
MINION_ISSUE_MIDSEARCH_REIFY_NEWVAR=1 \
cargo test -p minion-sys --lib ffi::tests::midsearch_reify_newvar_issue_child_runner -- --exact --nocapture
```