### PR TITLE
fix: fix record printing

### DIFF
--- a/crates/conjure-cp-core/src/ast/domains/ground.rs
+++ b/crates/conjure-cp-core/src/ast/domains/ground.rs
@@ -1049,13 +1049,11 @@ impl Display for GroundDomain {
             GroundDomain::Record(entries) => {
                 write!(
                     f,
-                    "record of ({})",
-                    pretty_vec(
-                        &entries
-                            .iter()
-                            .map(|entry| format!("{}: {}", entry.name, entry.domain))
-                            .collect_vec()
-                    )
+                    "record {{{}}}",
+                    entries
+                        .iter()
+                        .map(|entry| format!("{}: {}", entry.name, entry.domain))
+                        .join(", ")
                 )
             }
             GroundDomain::Function(attribute, domain, codomain) => {

--- a/crates/conjure-cp-core/src/ast/domains/unresolved.rs
+++ b/crates/conjure-cp-core/src/ast/domains/unresolved.rs
@@ -583,13 +583,11 @@ impl Display for UnresolvedDomain {
             UnresolvedDomain::Record(entries) => {
                 write!(
                     f,
-                    "record of ({})",
-                    pretty_vec(
-                        &entries
-                            .iter()
-                            .map(|entry| format!("{}: {}", entry.name, entry.domain))
-                            .collect_vec()
-                    )
+                    "record {{{}}}",
+                    entries
+                        .iter()
+                        .map(|entry| format!("{}: {}", entry.name, entry.domain))
+                        .join(", ")
                 )
             }
             UnresolvedDomain::Function(attribute, domain, codomain) => {

--- a/crates/conjure-cp-core/src/ast/literals.rs
+++ b/crates/conjure-cp-core/src/ast/literals.rs
@@ -344,9 +344,9 @@ where
             AbstractLiteral::Record(entries) => {
                 let entries_str: String = entries
                     .iter()
-                    .map(|entry| format!("{}: {}", entry.name, entry.value))
+                    .map(|entry| format!("{} = {}", entry.name, entry.value))
                     .join(",");
-                write!(f, "{{{entries_str}}}")
+                write!(f, "record {{{entries_str}}}")
             }
             AbstractLiteral::Function(entries) => {
                 let entries_str: String = entries

--- a/tests-integration/tests/integration/basic/record/01-records/tree-sitter-morph-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/tree-sitter-morph-via-solver-ac-minion-expected-rule-trace.txt
@@ -2,7 +2,7 @@ Model before rewriting:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R
@@ -11,7 +11,7 @@ such that
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -20,7 +20,7 @@ Final model:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R

--- a/tests-integration/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -2,7 +2,7 @@ Model before rewriting:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R
@@ -11,19 +11,19 @@ such that
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -45,12 +45,12 @@ x#record_to_atom[a],
 
 ({SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SafeIndex(x#record_to_atom,[1]) = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -69,12 +69,12 @@ x#record_to_atom[b],
 
 (SafeIndex(x#record_to_atom,[1]) = true),
 ({SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SafeIndex(x#record_to_atom,[1]) = true),
 (SafeIndex(x#record_to_atom,[2]) = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -121,15 +121,15 @@ x#record_to_atom_2
 
 --
 
-(y#record_to_atom = {a: false,b: 4}), 
+(y#record_to_atom = record {a = false,b = 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex({a: false,b: 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex({a: false,b: 4},[2]));int(1..)])
+and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)])
 
 --
 
 Reify(true, x#record_to_atom_1),
 (x#record_to_atom_2 = 3),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex({a: false,b: 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex({a: false,b: 4},[2]));int(1..)]),
+and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
 Reify(true, x#record_to_atom_1),
@@ -213,7 +213,7 @@ Final model:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R

--- a/tests-integration/tests/integration/basic/record/01-records/via-conjure-morph-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/via-conjure-morph-via-solver-ac-minion-expected-rule-trace.txt
@@ -2,7 +2,7 @@ Model before rewriting:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R
@@ -11,7 +11,7 @@ such that
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -20,7 +20,7 @@ Final model:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R

--- a/tests-integration/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/tests-integration/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -2,7 +2,7 @@ Model before rewriting:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R
@@ -11,19 +11,19 @@ such that
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
 
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (x[a] = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -45,12 +45,12 @@ x#record_to_atom[a],
 
 ({SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SafeIndex(x#record_to_atom,[1]) = true),
 (x[b] = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -69,12 +69,12 @@ x#record_to_atom[b],
 
 (SafeIndex(x#record_to_atom,[1]) = true),
 ({SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z), 
    ~~> constant_evaluator ([("Constant", 9001)])
 (SafeIndex(x#record_to_atom,[1]) = true),
 (SafeIndex(x#record_to_atom,[2]) = 3),
-(y = {a: false,b: 4}),
+(y = record {a = false,b = 4}),
 (y = z)
 
 --
@@ -121,15 +121,15 @@ x#record_to_atom_2
 
 --
 
-(y#record_to_atom = {a: false,b: 4}), 
+(y#record_to_atom = record {a = false,b = 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex({a: false,b: 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex({a: false,b: 4},[2]));int(1..)])
+and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)])
 
 --
 
 Reify(true, x#record_to_atom_1),
 (x#record_to_atom_2 = 3),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex({a: false,b: 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex({a: false,b: 4},[2]));int(1..)]),
+and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
 Reify(true, x#record_to_atom_1),
@@ -213,7 +213,7 @@ Final model:
 
 
 
-letting R be domain record of ([a: bool, b: int(0..9)])
+letting R be domain record {a: bool, b: int(0..9)}
 find x: R
 find y: R
 find z: R

--- a/tests-integration/tests/roundtrip/records/explicit/config.toml
+++ b/tests-integration/tests/roundtrip/records/explicit/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/records/explicit/input.essence
+++ b/tests-integration/tests/roundtrip/records/explicit/input.essence
@@ -1,0 +1,1 @@
+letting x be record {y = 2, z = false}

--- a/tests-integration/tests/roundtrip/records/explicit/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/records/explicit/via-conjure.expected.essence
@@ -1,0 +1,1 @@
+letting x be record {y = 2,z = false}

--- a/tests-integration/tests/roundtrip/records/explicit/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/records/explicit/via-conjure.expected.serialised.json
@@ -1,0 +1,87 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      []
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "ValueLetting": [
+              {
+                "AbstractLiteral": [
+                  {
+                    "etype": null
+                  },
+                  {
+                    "Record": [
+                      {
+                        "name": {
+                          "User": "y"
+                        },
+                        "value": {
+                          "Atomic": [
+                            {
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Int": 2
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "name": {
+                          "User": "z"
+                        },
+                        "value": {
+                          "Atomic": [
+                            {
+                              "etype": null
+                            },
+                            {
+                              "Literal": {
+                                "Bool": false
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              null
+            ]
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/tests-integration/tests/roundtrip/records/ground/config.toml
+++ b/tests-integration/tests/roundtrip/records/ground/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/records/ground/input.essence
+++ b/tests-integration/tests/roundtrip/records/ground/input.essence
@@ -1,0 +1,1 @@
+find x : record {y:int(1..5), z:bool}

--- a/tests-integration/tests/roundtrip/records/ground/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/records/ground/via-conjure.expected.essence
@@ -1,0 +1,3 @@
+
+
+find x: record {y: int(1..5), z: bool}

--- a/tests-integration/tests/roundtrip/records/ground/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/records/ground/via-conjure.expected.serialised.json
@@ -1,0 +1,115 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      []
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "y"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "RecordField": {
+              "Ground": {
+                "Int": [
+                  {
+                    "Bounded": [
+                      1,
+                      5
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "User": "y"
+          }
+        }
+      ],
+      [
+        {
+          "User": "z"
+        },
+        {
+          "id": {
+            "object_id": 2,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "RecordField": {
+              "Ground": "Bool"
+            }
+          },
+          "name": {
+            "User": "z"
+          }
+        }
+      ],
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 3,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Ground": {
+                  "Record": [
+                    {
+                      "domain": {
+                        "Int": [
+                          {
+                            "Bounded": [
+                              1,
+                              5
+                            ]
+                          }
+                        ]
+                      },
+                      "name": {
+                        "User": "y"
+                      }
+                    },
+                    {
+                      "domain": "Bool",
+                      "name": {
+                        "User": "z"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/tests-integration/tests/roundtrip/records/unresovled/config.toml
+++ b/tests-integration/tests/roundtrip/records/unresovled/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/records/unresovled/input.essence
+++ b/tests-integration/tests/roundtrip/records/unresovled/input.essence
@@ -1,0 +1,2 @@
+letting a be 5
+find x : record {y:int(1..a), z:bool}

--- a/tests-integration/tests/roundtrip/records/unresovled/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/records/unresovled/via-conjure.expected.essence
@@ -1,0 +1,4 @@
+letting a be 5
+
+
+find x: record {y: int(1..a), z: bool}

--- a/tests-integration/tests/roundtrip/records/unresovled/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/records/unresovled/via-conjure.expected.serialised.json
@@ -1,0 +1,168 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      []
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "a"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "ValueLetting": [
+              {
+                "Atomic": [
+                  {
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 5
+                    }
+                  }
+                ]
+              },
+              null
+            ]
+          },
+          "name": {
+            "User": "a"
+          }
+        }
+      ],
+      [
+        {
+          "User": "y"
+        },
+        {
+          "id": {
+            "object_id": 2,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "RecordField": {
+              "Unresolved": {
+                "Int": [
+                  {
+                    "Bounded": [
+                      {
+                        "Const": 1
+                      },
+                      {
+                        "Reference": {
+                          "ptr": {
+                            "object_id": 1,
+                            "type_name": "DeclarationPtrInner"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "name": {
+            "User": "y"
+          }
+        }
+      ],
+      [
+        {
+          "User": "z"
+        },
+        {
+          "id": {
+            "object_id": 3,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "RecordField": {
+              "Ground": "Bool"
+            }
+          },
+          "name": {
+            "User": "z"
+          }
+        }
+      ],
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 4,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Unresolved": {
+                  "Record": [
+                    {
+                      "domain": {
+                        "Unresolved": {
+                          "Int": [
+                            {
+                              "Bounded": [
+                                {
+                                  "Const": 1
+                                },
+                                {
+                                  "Reference": {
+                                    "ptr": {
+                                      "object_id": 1,
+                                      "type_name": "DeclarationPtrInner"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "name": {
+                        "User": "y"
+                      }
+                    },
+                    {
+                      "domain": {
+                        "Ground": "Bool"
+                      },
+                      "name": {
+                        "User": "z"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/tests-integration/tests/roundtrip/tuples/explicit/config.toml
+++ b/tests-integration/tests/roundtrip/tuples/explicit/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/tuples/explicit/input.essence
+++ b/tests-integration/tests/roundtrip/tuples/explicit/input.essence
@@ -1,0 +1,4 @@
+letting x be (1,2)
+letting y be tuple (1,2)
+
+such that x = y

--- a/tests-integration/tests/roundtrip/tuples/explicit/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/tuples/explicit/via-conjure.expected.essence
@@ -1,0 +1,6 @@
+letting x be (1,2)
+letting y be (1,2)
+
+such that
+
+(x = y)

--- a/tests-integration/tests/roundtrip/tuples/explicit/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/tuples/explicit/via-conjure.expected.serialised.json
@@ -1,0 +1,169 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      [
+        {
+          "Eq": [
+            {
+              "etype": null
+            },
+            {
+              "Atomic": [
+                {
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "ptr": {
+                      "object_id": 1,
+                      "type_name": "DeclarationPtrInner"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "Atomic": [
+                {
+                  "etype": null
+                },
+                {
+                  "Reference": {
+                    "ptr": {
+                      "object_id": 2,
+                      "type_name": "DeclarationPtrInner"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "ValueLetting": [
+              {
+                "AbstractLiteral": [
+                  {
+                    "etype": null
+                  },
+                  {
+                    "Tuple": [
+                      {
+                        "Atomic": [
+                          {
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              null
+            ]
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ],
+      [
+        {
+          "User": "y"
+        },
+        {
+          "id": {
+            "object_id": 2,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "ValueLetting": [
+              {
+                "AbstractLiteral": [
+                  {
+                    "etype": null
+                  },
+                  {
+                    "Tuple": [
+                      {
+                        "Atomic": [
+                          {
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "Atomic": [
+                          {
+                            "etype": null
+                          },
+                          {
+                            "Literal": {
+                              "Int": 2
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              null
+            ]
+          },
+          "name": {
+            "User": "y"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/tests-integration/tests/roundtrip/tuples/ground/config.toml
+++ b/tests-integration/tests/roundtrip/tuples/ground/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/tuples/ground/input.essence
+++ b/tests-integration/tests/roundtrip/tuples/ground/input.essence
@@ -1,0 +1,2 @@
+find x : tuple (int(1..5), int(0..2))
+find y : (int(1..5), int(0..2))

--- a/tests-integration/tests/roundtrip/tuples/ground/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/tuples/ground/via-conjure.expected.essence
@@ -1,0 +1,2 @@
+find x: tuple (int(1..5), int(0..2))
+find y: tuple (int(1..5), int(0..2))

--- a/tests-integration/tests/roundtrip/tuples/ground/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/tuples/ground/via-conjure.expected.serialised.json
@@ -1,0 +1,111 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      []
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Ground": {
+                  "Tuple": [
+                    {
+                      "Int": [
+                        {
+                          "Bounded": [
+                            1,
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Int": [
+                        {
+                          "Bounded": [
+                            0,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ],
+      [
+        {
+          "User": "y"
+        },
+        {
+          "id": {
+            "object_id": 2,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Ground": {
+                  "Tuple": [
+                    {
+                      "Int": [
+                        {
+                          "Bounded": [
+                            1,
+                            5
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Int": [
+                        {
+                          "Bounded": [
+                            0,
+                            2
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "y"
+          }
+        }
+      ]
+    ]
+  }
+}

--- a/tests-integration/tests/roundtrip/tuples/unresovled/config.toml
+++ b/tests-integration/tests/roundtrip/tuples/unresovled/config.toml
@@ -1,0 +1,4 @@
+parser = [
+    # "tree-sitter",
+    "via-conjure",
+]

--- a/tests-integration/tests/roundtrip/tuples/unresovled/input.essence
+++ b/tests-integration/tests/roundtrip/tuples/unresovled/input.essence
@@ -1,0 +1,3 @@
+letting a be 5
+find x : tuple (int(1..a), int(0..2))
+find y : (int(1..a), int(0..2))

--- a/tests-integration/tests/roundtrip/tuples/unresovled/via-conjure.expected.essence
+++ b/tests-integration/tests/roundtrip/tuples/unresovled/via-conjure.expected.essence
@@ -1,0 +1,3 @@
+letting a be 5
+find x: tuple (int(1..a),int(0..2))
+find y: tuple (int(1..a),int(0..2))

--- a/tests-integration/tests/roundtrip/tuples/unresovled/via-conjure.expected.serialised.json
+++ b/tests-integration/tests/roundtrip/tuples/unresovled/via-conjure.expected.serialised.json
@@ -1,0 +1,168 @@
+{
+  "cnf_clauses": [],
+  "constraints": {
+    "Root": [
+      {
+        "etype": null
+      },
+      []
+    ]
+  },
+  "dominance": null,
+  "search_order": null,
+  "symbols": {
+    "id": {
+      "object_id": 0,
+      "type_name": "SymbolTable"
+    },
+    "next_machine_name": 0,
+    "parent": null,
+    "table": [
+      [
+        {
+          "User": "a"
+        },
+        {
+          "id": {
+            "object_id": 1,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "ValueLetting": [
+              {
+                "Atomic": [
+                  {
+                    "etype": null
+                  },
+                  {
+                    "Literal": {
+                      "Int": 5
+                    }
+                  }
+                ]
+              },
+              null
+            ]
+          },
+          "name": {
+            "User": "a"
+          }
+        }
+      ],
+      [
+        {
+          "User": "x"
+        },
+        {
+          "id": {
+            "object_id": 2,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Unresolved": {
+                  "Tuple": [
+                    {
+                      "Unresolved": {
+                        "Int": [
+                          {
+                            "Bounded": [
+                              {
+                                "Const": 1
+                              },
+                              {
+                                "Reference": {
+                                  "ptr": {
+                                    "object_id": 1,
+                                    "type_name": "DeclarationPtrInner"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "Ground": {
+                        "Int": [
+                          {
+                            "Bounded": [
+                              0,
+                              2
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "x"
+          }
+        }
+      ],
+      [
+        {
+          "User": "y"
+        },
+        {
+          "id": {
+            "object_id": 3,
+            "type_name": "DeclarationPtrInner"
+          },
+          "kind": {
+            "Find": {
+              "domain": {
+                "Unresolved": {
+                  "Tuple": [
+                    {
+                      "Unresolved": {
+                        "Int": [
+                          {
+                            "Bounded": [
+                              {
+                                "Const": 1
+                              },
+                              {
+                                "Reference": {
+                                  "ptr": {
+                                    "object_id": 1,
+                                    "type_name": "DeclarationPtrInner"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "Ground": {
+                        "Int": [
+                          {
+                            "Bounded": [
+                              0,
+                              2
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "name": {
+            "User": "y"
+          }
+        }
+      ]
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Changes the string printing (fmt) for record types to ensure that it is valid Essence. This allows it to roundtrip.
The changes for tuple printing syntax were actually added already as part of #1772.

Added roundtrip tests for displaying tuples and records, that are ground, unresolved, and an abstractLiteral.

## Related issues

Closes #1783

## Key changes

- Fixed record printing syntax
- Roundtrip tests for records
- Roundtrip tests for tuples

## How to test/review

Review the roundtrip tests with 'cargo test tests_roundtrip_records', and 'cargo test tests_roundtrip_tuples'.