### PR TITLE
docs(source-map): add documentation for source map

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,6 +53,7 @@
     - [LSP]()
         - [General Structure](developers-guide/architecture/lsp/general-structure.md)
         - [Diagnostics API](developers-guide/architecture/lsp/diagnostics-api.md)
+        - [Source Map](developers-guide/architecture/lsp/source-map.md)
         - [Syntax Errors](developers-guide/architecture/lsp/syntax-errors.md)
         - [Error Detection]()
             - [Error Classification](developers-guide/architecture/lsp/error-detection/error-classification.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,6 +54,7 @@
         - [General Structure](developers-guide/architecture/lsp/general-structure.md)
         - [Diagnostics API](developers-guide/architecture/lsp/diagnostics-api.md)
         - [Syntax Errors](developers-guide/architecture/lsp/syntax-errors.md)
+        - [Semantic Highlighting](developers-guide/architecture/lsp/semantic-highlighting.md)
         - [Error Detection]()
             - [Error Classification](developers-guide/architecture/lsp/error-detection/error-classification.md)
             - [Semantic Errors](developers-guide/architecture/lsp/error-detection/semantic-errors.md)

--- a/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
+++ b/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
@@ -1,0 +1,57 @@
+[//]: # (Author: Yi Xin Chong)
+[//]: # (Last Updated: 13/5/2026)
+
+# Semantic Highlighting for the LSP Server
+
+## Overview
+
+Semantic highlighting is an LSP feature that provides context-aware token styling. Unlike syntax highlighting, which relies solely on TextMate grammar patterns, semantic highlighting understands the meaning and usage of tokens within the program.
+
+This implementation extends the existing TextMate-based syntax highlighting and falls back to syntax highlighting whenever a semantic style is not defined by the active theme. Semantic tokens are generated based on prior declarations, allowing variables to be styled differently depending on how they were declared and used throughout the source file.
+
+## Structure
+
+```bash
+conjure-oxide
+└─ crates/
+  └─ conjure-cp-essence-parser/src/diagnostics/
+    └─ semantic_tokens.rs          # Encodes SourceMap tokens into semantic tokens based on SymbolKind
+  └─ conjure-cp-lsp/src/
+    ├─ server.rs                   # Registers semantic token handlers with the LSP server
+    └─ handlers/
+        └─ semantic_highlighting.rs # Handles semantic token requests from the client
+└─ package.json                      # Defines fallback TextMate scopes and semantic styling
+```
+
+## Key Functions
+
+### Token Encoding
+
+Semantic tokens are encoded using the `encode_semantic_tokens()` function in `semantic_tokens.rs`. The function processes each token in the `SourceMap` and converts it into a semantic token by calling `token_encoding()`. This helper maps each `SymbolKind` to a corresponding `TokenEncoding`.
+
+Most editor themes do not provide dedicated styles for Essence variables. To visually distinguish variables by declaration type, Essence declarations are mapped onto standard semantic token classifications commonly used in other languages but otherwise unused in Essence.
+
+The current mappings are shown below:
+
+| Declaration kind(s)                                    | Symbol kind | Semantic token classifier | Fallback TextMate grammar          |
+| ------------------------------------------------------ | ----------- | ------------------------- | ---------------------------------- |
+| Find                                                   | FindVar     | property                  | variable.other.property.findVar    |
+| ValueLetting<br>TemporaryValueLetting<br>DomainLetting | LettingVar  | variable                  | variable.other.constant.lettingVar |
+| Given                                                  | GivenVar    | string                    | string.other.givenVar              |
+
+Additionally, `find` variables are visually emphasised because they represent the variables the solver is attempting to solve for. An underline style is therefore hardcoded in `package.json` for tokens classified as `FindVar`.
+
+### LSP Semantic Highlighting Handler
+
+The semantic highlighting handler retrieves the `SourceMap` from cache and passes it to `encode_semantic_tokens()` to generate semantic tokens. These encoded tokens are then returned to the LSP server, which forwards them to the client. The client uses the semantic token classifications together with the active theme to determine how each token should be rendered.
+
+## Semantic Highlighting Customisation (VSCode)
+To customise semantic highlighting styles, open up `settings.json` in VSCode, and add the following code snippet if it does not exist in the file:
+
+```bash
+"editor.semanticTokenColorCustomizations": {
+  "rules": {
+    "{token_name}": "{styles}",
+  }
+}
+```

--- a/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
+++ b/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
@@ -39,7 +39,7 @@ The current mappings are shown below:
 | ValueLetting<br>TemporaryValueLetting<br>DomainLetting | LettingVar  | variable                  | variable.other.constant.lettingVar |
 | Given                                                  | GivenVar    | string                    | string.other.givenVar              |
 
-Additionally, `find` variables are visually emphasised because they represent the variables the solver is attempting to solve for. An underline style is therefore hardcoded in `package.json` for tokens classified as `FindVar`.
+Additionally, `find` variables are visually emphasised because they represent the variables the solver is attempting to solve for. An underline style is therefore hard-coded in `package.json` for tokens classified as `FindVar`.
 
 ### LSP Semantic Highlighting Handler
 

--- a/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
+++ b/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
@@ -48,12 +48,12 @@ Additionally, `find` variables are visually emphasised because they represent th
 The semantic highlighting handler retrieves the `SourceMap` from cache and passes it to `encode_semantic_tokens()` to generate semantic tokens. These encoded tokens are then returned to the LSP server, which forwards them to the client. The client uses the semantic token classifications together with the active theme to determine how each token should be rendered.
 
 ## Expanding Semantic Highlighting
-To expand on the currrent semantic highlighting available, the files that will need to be changed are: `crates/conjure-cp-essence-parser/src/diagnostics/diagnostics_api.rs`, `crates/conjure-cp-essence-parser/src/diagnostics/semantic-tokens.rs`, `crates/conjure-cp-lsp/src/server.rs`, and `package.json`
+To expand on the current semantic highlighting available, the files that will need to be changed are: `crates/conjure-cp-essence-parser/src/diagnostics/diagnostics_api.rs`, `crates/conjure-cp-essence-parser/src/diagnostics/semantic-tokens.rs`, `crates/conjure-cp-lsp/src/server.rs`, and `package.json`
 
 1. In `diagnostics_api.rs`, add the new symbol kind to the `SymbolKind` enum.
 2. In `semantic_token.rs`, add a new constant variable for the new symbol kind and create a mapping from the symbol kind to a token in the `token_encoding()` function.
 3. In `server.rs`, add the new symbol kind to the server's `semantic_toke_provider`.
-4. In `package.json`, add the new symbol kind to the semantic token scopes to specify its styling in Textmate, and if it is a custom token, add a new field for it in the semantic token types
+4. In `package.json`, add the new symbol kind to the semantic token scopes to specify its styling in TextMate, and if it is a custom token, add a new field for it in the semantic token types
 
 ## Semantic Highlighting Customisation (VSCode)
 To customise semantic highlighting styles, open up `settings.json` in VSCode, and add the following code snippet if it does not exist in the file:

--- a/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
+++ b/docs/src/developers-guide/architecture/lsp/semantic-highlighting.md
@@ -9,23 +9,25 @@ Semantic highlighting is an LSP feature that provides context-aware token stylin
 
 This implementation extends the existing TextMate-based syntax highlighting and falls back to syntax highlighting whenever a semantic style is not defined by the active theme. Semantic tokens are generated based on prior declarations, allowing variables to be styled differently depending on how they were declared and used throughout the source file.
 
-## Structure
-
-```bash
-conjure-oxide
-└─ crates/
-  └─ conjure-cp-essence-parser/src/diagnostics/
-    └─ semantic_tokens.rs          # Encodes SourceMap tokens into semantic tokens based on SymbolKind
-  └─ conjure-cp-lsp/src/
-    ├─ server.rs                   # Registers semantic token handlers with the LSP server
-    └─ handlers/
-        └─ semantic_highlighting.rs # Handles semantic token requests from the client
-└─ package.json                      # Defines fallback TextMate scopes and semantic styling
-```
-
 ## Key Functions
 
 ### Token Encoding
+
+During parsing, the semantic meaning of each token is stored in the `HoverInfo` of the `SourceMap` as a `SymbolKind` (see list below). Specifically when parsing variables, they are assigned a `DeclarationKind` during the initial declaration of the variable, which is stored in the symbol table. When used in expressions, the `DeclarationKind` is then mapped to either a `FindVar`, `LettingVar`, or `GivenVar` and stored in the `SourceMap`, which allows different styling of the variable based on its declaration type.
+
+List of available `SymbolKinds` in `diagnostics_api.rs`:
+- Integer
+- Decimal
+- Function
+- Letting
+- Find
+- Variable
+- Constant
+- Domain
+- FindVar 
+- LettingVar
+- Given
+- GivenVar
 
 Semantic tokens are encoded using the `encode_semantic_tokens()` function in `semantic_tokens.rs`. The function processes each token in the `SourceMap` and converts it into a semantic token by calling `token_encoding()`. This helper maps each `SymbolKind` to a corresponding `TokenEncoding`.
 
@@ -44,6 +46,14 @@ Additionally, `find` variables are visually emphasised because they represent th
 ### LSP Semantic Highlighting Handler
 
 The semantic highlighting handler retrieves the `SourceMap` from cache and passes it to `encode_semantic_tokens()` to generate semantic tokens. These encoded tokens are then returned to the LSP server, which forwards them to the client. The client uses the semantic token classifications together with the active theme to determine how each token should be rendered.
+
+## Expanding Semantic Highlighting
+To expand on the currrent semantic highlighting available, the files that will need to be changed are: `crates/conjure-cp-essence-parser/src/diagnostics/diagnostics_api.rs`, `crates/conjure-cp-essence-parser/src/diagnostics/semantic-tokens.rs`, `crates/conjure-cp-lsp/src/server.rs`, and `package.json`
+
+1. In `diagnostics_api.rs`, add the new symbol kind to the `SymbolKind` enum.
+2. In `semantic_token.rs`, add a new constant variable for the new symbol kind and create a mapping from the symbol kind to a token in the `token_encoding()` function.
+3. In `server.rs`, add the new symbol kind to the server's `semantic_toke_provider`.
+4. In `package.json`, add the new symbol kind to the semantic token scopes to specify its styling in Textmate, and if it is a custom token, add a new field for it in the semantic token types
 
 ## Semantic Highlighting Customisation (VSCode)
 To customise semantic highlighting styles, open up `settings.json` in VSCode, and add the following code snippet if it does not exist in the file:

--- a/docs/src/developers-guide/architecture/lsp/source-map.md
+++ b/docs/src/developers-guide/architecture/lsp/source-map.md
@@ -1,0 +1,173 @@
+[//]: # "Author: Anastasia Martinson"
+[//]: # "Last Updated: 22/05/2026"
+
+# Source Map
+
+The source map connects locations in an Essence source file to metadata discovered while parsing that file.
+
+## Overview
+
+The LSP uses the source map for position-based editor features:
+
+- hover information (e.g., description of the keword at that position)
+- declaration site and reference metadata
+  - i.e., if we're referencing an already declared variable, we want to know where in the file it was declared (to then have the ability to visit the definition), and what type it is (to be able to highlight different types of variables differently throughout the code).
+- semantic token generation (more in semantic_tokens.md)
+  - used for semantic highlighting
+- keeping hover and highlighting available even when the full AST cannot be built (more in recoverable_parsing.md)
+
+The source map is built during CST-to-AST parsing in `parse_essence_with_context_and_map`, to retrieve the relevant semantic information: symbol table entries, declaration sites, domains, expression types, documentation keys, and symbol kinds.
+
+## Implementation Locations
+
+Source map is implemented in:
+
+```bash
+crates/conjure-cp-essence-parser/src/diagnostics/
+└─ source_map.rs
+```
+
+Parser modules that populate source map spans include:
+
+```text
+crates/conjure-cp-essence-parser/src/parser/
+├─ find.rs
+├─ letting.rs
+├─ domain.rs
+├─ atom.rs
+└─ expression.rs
+```
+
+## Data Structures
+
+`SourceMap` owns all spans and keeps a range index for lookup by byte offset:
+
+```rust
+pub struct SourceMap {
+    pub spans: Vec<SourceSpan>,            // stores records
+    pub by_byte: RangeMap<usize, SpanId>,  // maps ranges to spanID (index into spans)
+```
+
+}
+
+Each span records both byte offsets and Tree-sitter points:
+
+```rust
+pub struct SourceSpan {
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_point: Position,
+    pub end_point: Position,
+    pub hover_info: Option<HoverInfo>,
+}
+```
+
+`HoverInfo` stores the editor-facing metadata attached to a span:
+
+```rust
+pub struct HoverInfo {
+    pub description: String,       // on-hover text
+    pub doc_key: Option<String>,   // optional key into Conjure's docs/bits documentation
+    pub kind: Option<SymbolKind>,  // optional semantic category, such as 'Find'
+    pub ty: Option<String>,        // optional type/domain string, for example 'int(1..3)'
+    pub decl_span: Option<SpanId>, // optional SpanId pointing back to the declaration span
+}
+```
+
+## Populating The Map
+
+Parser code usually adds spans with:
+
+```rust
+span_with_hover(node, source, map, hover_info)
+```
+
+This wraps `alloc_span(...)`, records the node range, stores the hover metadata, and inserts the byte range into the `RangeMap`.
+
+For documentation-backed hovers, parser code can use:
+
+```rust
+ctx.add_span_and_doc_hover(node, doc_key, kind, ty, decl_span)
+```
+
+That stores a normalised `doc_key` in `HoverInfo`. The LSP only fetches the full documentation text when the user actually hovers that span.
+
+Examples of current source map population:
+
+- `find.rs` adds spans for `find`/`given` keywords and declaration variables.
+- `letting.rs` adds spans for `letting` declarations.
+- `domain.rs` adds spans for domain keywords and domain operators.
+- `atom.rs` adds spans for variable references and constants.
+- `expression.rs` adds spans for operators and function-like expressions.
+
+For variable references, the parser looks up the declaration in the current symbol table and uses that declaration kind to set the semantic kind. This is why later occurrences of a `find` variable can be highlighted as `FindVar`, not just as a generic identifier.
+
+## Parser Integration
+
+The parse entry point is:
+
+```rust
+parse_essence_with_context_and_map(
+    src,
+    context,
+    errors,
+    tree,
+) -> Result<(Option<Model>, SourceMap), FatalParseError>
+```
+
+The `SourceMap` is returned even when parse errors occur. This is intentional: editor features should still work for the parts of the file that were parsed successfully, even if another part of the file has a syntax or semantic error.
+
+## Recoverable Parsing
+
+When the CST contains Tree-sitter errors, the parser:
+
+- records syntactic diagnostics with `detect_syntactic_errors(...)`
+- suppresses following semantic errors to avoid noise and duplicate error flagging
+- still walks the CST where possible
+- still builds source map spans for valid subtrees
+- returns `Ok((None, source_map))` if recoverable errors exist
+
+Fatal parser errors still exist for cases where parsing cannot safely continue at all.
+
+## LSP Cache Integration
+
+The LSP stores the source map in its per-document cache:
+
+```rust
+pub struct CacheCont {
+    pub sourcemap: Option<SourceMap>,  // here
+    pub ast: Option<Model>,
+    pub errors: Vec<RecoverableParseError>,
+    pub cst: Option<Tree>,
+    pub contents: String,
+    pub version: i32,
+}
+```
+
+## Accessing the Source Map
+
+The source map lookup is:
+
+```rust
+source_map.hover_info_at_byte(hover_byte)
+```
+
+This resolves a byte offset to a `SpanId` through `by_byte`, then returns the hover metadata attached to that span.
+
+## Byte Offsets And LSP Positions
+
+Tree-sitter nodes use byte offsets and byte columns. Rust string slicing also uses byte offsets. The source map therefore uses bytes as its canonical internal representation.
+
+LSP positions use line plus UTF-16 character offsets. Any LSP request must be converted before querying the map:
+
+```text
+LSP Position -> byte offset -> SourceMap lookup
+```
+
+Semantic token responses need the reverse shape:
+
+```text
+SourceMap byte range -> LSP UTF-16 line/column/length
+```
+
+This distinction matters for non-ASCII text. Byte length and LSP character length are not the same.

--- a/docs/src/developers-guide/architecture/lsp/source-map.md
+++ b/docs/src/developers-guide/architecture/lsp/source-map.md
@@ -12,7 +12,7 @@ The LSP uses the source map for position-based editor features:
 - hover information (e.g., description of the keword at that position)
 - declaration site and reference metadata
   - i.e., if we're referencing an already declared variable, we want to know where in the file it was declared (to then have the ability to visit the definition), and what type it is (to be able to highlight different types of variables differently throughout the code).
-- semantic token generation (more in semantic_tokens.md)
+- semantic token generation (more in [Semantic_Highlighting](semantic-highlighting.md))
   - used for semantic highlighting
 - keeping hover and highlighting available even when the full AST cannot be built (more in recoverable_parsing.md)
 

--- a/docs/src/developers-guide/architecture/lsp/source-map.md
+++ b/docs/src/developers-guide/architecture/lsp/source-map.md
@@ -12,9 +12,9 @@ The LSP uses the source map for position-based editor features:
 - hover information (e.g., description of the keword at that position)
 - declaration site and reference metadata
   - i.e., if we're referencing an already declared variable, we want to know where in the file it was declared (to then have the ability to visit the definition), and what type it is (to be able to highlight different types of variables differently throughout the code).
-- semantic token generation (more in [Semantic_Highlighting](semantic-highlighting.md))
+- semantic token generation (more in [Semantic Highlighting](semantic-highlighting.md))
   - used for semantic highlighting
-- keeping hover and highlighting available even when the full AST cannot be built (more in recoverable_parsing.md)
+- keeping hover and highlighting available even when the full AST cannot be built
 
 The source map is built during CST-to-AST parsing in `parse_essence_with_context_and_map`, to retrieve the relevant semantic information: symbol table entries, declaration sites, domains, expression types, documentation keys, and symbol kinds.
 

--- a/docs/src/developers-guide/architecture/lsp/source-map.md
+++ b/docs/src/developers-guide/architecture/lsp/source-map.md
@@ -9,7 +9,7 @@ The source map connects locations in an Essence source file to metadata discover
 
 The LSP uses the source map for position-based editor features:
 
-- hover information (e.g., description of the keword at that position)
+- hover information (e.g., description of the keyword at that position)
 - declaration site and reference metadata
   - i.e., if we're referencing an already declared variable, we want to know where in the file it was declared (to then have the ability to visit the definition), and what type it is (to be able to highlight different types of variables differently throughout the code).
 - semantic token generation (more in [Semantic Highlighting](semantic-highlighting.md))


### PR DESCRIPTION
## Description
Adding docs for sourcemap.
<!-- what does this PR do? a quick summary of changes. -->

## Related issues
Closes #1843 
<!-- e.g. Closes #12 or Fixes #45 -->

## Key changes

- add `docs/src/developers-guide/architecture/lsp/source-map.md`

## How to test/review

- read the docs
<!-- instructions to make the reviewer's life easier-->

## PR Ladder
This PR is based off of another documentation PR (it references the file created in that pr). After the parent PR has been merged, the cild PR will automatically rebase onto main. Please review the parent PR first.

- #1821 
     - #1831 <- this PR 
