### PR TITLE
refactor(parser): integrate keyword checks

### DIFF
--- a/crates/conjure-cp-essence-parser/src/parser/find.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/find.rs
@@ -10,6 +10,7 @@ use super::util::named_children;
 use crate::diagnostics::diagnostics_api::SymbolKind;
 use crate::diagnostics::source_map::{HoverInfo, span_with_hover};
 use crate::errors::{FatalParseError, RecoverableParseError};
+use crate::parser::keyword_checks::is_keyword_identifier;
 use conjure_cp_core::ast::{DomainPtr, Name};
 
 pub fn parse_find_statement(
@@ -89,6 +90,14 @@ pub fn parse_declaration_statement(
         }
         let variable_name = &ctx.source_code[start..end];
         let name = Name::user(variable_name);
+
+        if is_keyword_identifier(variable_name) {
+            ctx.errors.push(RecoverableParseError::new(
+                format!("Keyword '{variable_name}' used as identifier"),
+                Some(variable.range()),
+            ));
+            continue;
+        }
 
         // Check for duplicate within the same statement
         if vars.contains_key(&name) {

--- a/crates/conjure-cp-essence-parser/src/parser/find.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/find.rs
@@ -96,7 +96,7 @@ pub fn parse_declaration_statement(
                 format!("Keyword '{variable_name}' used as identifier"),
                 Some(variable.range()),
             ));
-            continue;
+            // still add variable to symbol table to avoid follow-up errors
         }
 
         // Check for duplicate within the same statement

--- a/crates/conjure-cp-essence-parser/src/parser/keyword_checks.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/keyword_checks.rs
@@ -1,6 +1,3 @@
-use crate::errors::RecoverableParseError;
-use crate::parser::syntax_errors::is_malformed_line_error;
-
 const KEYWORDS: [&str; 24] = [
     "forall",
     "exists",
@@ -28,39 +25,6 @@ const KEYWORDS: [&str; 24] = [
     "maximising",
 ];
 
-pub fn keyword_as_identifier(
-    root: tree_sitter::Node,
-    source: &str,
-    errors: &mut Vec<RecoverableParseError>,
-) {
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        if node.is_error() && is_malformed_line_error(&node, source) {
-            return;
-        }
-        if (node.kind() == "variable" || node.kind() == "identifier" || node.kind() == "parameter")
-            && let Ok(text) = node.utf8_text(source.as_bytes())
-        {
-            let ident = text.trim();
-            if KEYWORDS.contains(&ident) {
-                let start_point = node.start_position();
-                let end_point = node.end_position();
-                errors.push(RecoverableParseError::new(
-                    format!("Keyword '{ident}' used as identifier"),
-                    Some(tree_sitter::Range {
-                        start_byte: node.start_byte(),
-                        end_byte: node.end_byte(),
-                        start_point,
-                        end_point,
-                    }),
-                ));
-            }
-        }
-
-        for i in 0..node.child_count() {
-            if let Some(child) = u32::try_from(i).ok().and_then(|i| node.child(i)) {
-                stack.push(child);
-            }
-        }
-    }
+pub fn is_keyword_identifier(identifier: &str) -> bool {
+    KEYWORDS.contains(&identifier)
 }

--- a/crates/conjure-cp-essence-parser/src/parser/letting.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/letting.rs
@@ -5,6 +5,7 @@ use tree_sitter::Node;
 
 use super::ParseContext;
 use super::domain::parse_domain;
+use super::keyword_checks::is_keyword_identifier;
 use super::util::named_children;
 use crate::diagnostics::diagnostics_api::SymbolKind;
 use crate::diagnostics::source_map::{HoverInfo, span_with_hover};
@@ -44,6 +45,14 @@ pub fn parse_letting_statement(
         };
         for variable in named_children(&variable_list) {
             let variable_name = &ctx.source_code[variable.start_byte()..variable.end_byte()];
+
+            if is_keyword_identifier(variable_name) {
+                ctx.errors.push(RecoverableParseError::new(
+                    format!("Keyword '{variable_name}' used as identifier"),
+                    Some(variable.range()),
+                ));
+                continue;
+            }
 
             // Check for duplicate within the same statement
             if temp_symbols.contains(variable_name) {

--- a/crates/conjure-cp-essence-parser/src/parser/letting.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/letting.rs
@@ -51,7 +51,7 @@ pub fn parse_letting_statement(
                     format!("Keyword '{variable_name}' used as identifier"),
                     Some(variable.range()),
                 ));
-                continue;
+                // still add variable to symbol table to avoid follow-up errors
             }
 
             // Check for duplicate within the same statement

--- a/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
@@ -17,7 +17,6 @@ use super::util::{TypecheckingContext, get_tree};
 use crate::diagnostics::source_map::SourceMap;
 use crate::errors::{FatalParseError, ParseErrorCollection, RecoverableParseError};
 use crate::expression::parse_expression;
-use crate::parser::keyword_checks::keyword_as_identifier;
 use crate::syntax_errors::detect_syntactic_errors;
 use tree_sitter::Tree;
 
@@ -101,8 +100,6 @@ pub fn parse_essence_with_context_and_map(
     } else {
         errors
     };
-
-    keyword_as_identifier(tree.root_node(), src, semantic_errors);
 
     let mut model = Model::new(context);
     let mut source_map = SourceMap::default();

--- a/tests-integration/tests/roundtrip/invalid/semantic/keyword_as_identifier/01/tree-sitter.expected-error.txt
+++ b/tests-integration/tests/roundtrip/invalid/semantic/keyword_as_identifier/01/tree-sitter.expected-error.txt
@@ -3,9 +3,3 @@ tests/roundtrip/invalid/semantic/keyword_as_identifier/01/keyword_as_identifier.
 1 | find find : int(1..10)
   |      ^
 Keyword 'find' used as identifier
-
-tests/roundtrip/invalid/semantic/keyword_as_identifier/01/keyword_as_identifier.essence:2:11:
-  |
-2 | such that find > 5
-  |           ^
-The identifier 'find' is not defined

--- a/tests-integration/tests/roundtrip/invalid/semantic/keyword_as_identifier/01/tree-sitter.expected-error.txt
+++ b/tests-integration/tests/roundtrip/invalid/semantic/keyword_as_identifier/01/tree-sitter.expected-error.txt
@@ -8,4 +8,4 @@ tests/roundtrip/invalid/semantic/keyword_as_identifier/01/keyword_as_identifier.
   |
 2 | such that find > 5
   |           ^
-Keyword 'find' used as identifier
+The identifier 'find' is not defined


### PR DESCRIPTION
## Description
While writing docs, I realized there's no reason to continue to have the separate pass of the CST to look for keywords used as identifiers. It is cleaner to just check the identifiers when they appear, like we do for duplicate identifiers. The keywords file still exists to house the keyword list.

Variables with keyword identifiers are not added to the symbol table so if referenced later, the error says the variable doesn't exist. This could be changed if we'd prefer to have just one error per keyword identifier (when it is declared) and then no related errors after that.

## Related issues
n/a

## Key changes
- modify keyword file to house keyword list only, remove separate pass function
- add checks in find.rs and letting.rs to check for keywords as identifiers

## How to test/review
checks already exist for keywords as identifiers and they all still pass, with the changes described above.
