### PR TITLE
feat(source map): more population for hover info

### DIFF
--- a/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
@@ -1,5 +1,5 @@
-use crate::diagnostics::diagnostics_api::SymbolKind;
 use crate::RecoverableParseError;
+use crate::diagnostics::diagnostics_api::SymbolKind;
 use crate::errors::FatalParseError;
 use crate::expression::parse_expression;
 use crate::field;

--- a/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
@@ -1,3 +1,5 @@
+use crate::diagnostics::diagnostics_api::SymbolKind;
+use crate::diagnostics::source_map::{HoverInfo, span_with_hover};
 use crate::RecoverableParseError;
 use crate::errors::FatalParseError;
 use crate::expression::parse_expression;
@@ -224,6 +226,27 @@ pub fn parse_quantifier_or_aggregate_expr(
             return Ok(None);
         }
     };
+
+    let description = match operator_str {
+        "forAll" => "Universal quantifier keyword",
+        "exists" => "Existential quantifier keyword",
+        "sum" => "Aggregate keyword: sum",
+        "min" => "Aggregate keyword: min",
+        "max" => "Aggregate keyword: max",
+        _ => "Quantifier/aggregate keyword",
+    };
+    span_with_hover(
+        &operator_node,
+        ctx.source_code,
+        ctx.source_map,
+        HoverInfo {
+            description: description.to_string(),
+            doc_key: None,
+            kind: Some(SymbolKind::Function),
+            ty: None,
+            decl_span: None,
+        },
+    );
 
     // Add variables as generators
     if let Some(dom) = domain {

--- a/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/comprehension.rs
@@ -1,5 +1,4 @@
 use crate::diagnostics::diagnostics_api::SymbolKind;
-use crate::diagnostics::source_map::{HoverInfo, span_with_hover};
 use crate::RecoverableParseError;
 use crate::errors::FatalParseError;
 use crate::expression::parse_expression;
@@ -227,26 +226,13 @@ pub fn parse_quantifier_or_aggregate_expr(
         }
     };
 
-    let description = match operator_str {
-        "forAll" => "Universal quantifier keyword",
-        "exists" => "Existential quantifier keyword",
-        "sum" => "Aggregate keyword: sum",
-        "min" => "Aggregate keyword: min",
-        "max" => "Aggregate keyword: max",
-        _ => "Quantifier/aggregate keyword",
-    };
-    span_with_hover(
-        &operator_node,
-        ctx.source_code,
-        ctx.source_map,
-        HoverInfo {
-            description: description.to_string(),
-            doc_key: None,
-            kind: Some(SymbolKind::Function),
-            ty: None,
-            decl_span: None,
-        },
-    );
+    if let Some(doc_key) = match operator_str {
+        "min" => Some("min"),
+        "max" => Some("max"),
+        _ => None,
+    } {
+        ctx.add_span_and_doc_hover(&operator_node, doc_key, SymbolKind::Function, None, None);
+    }
 
     // Add variables as generators
     if let Some(dom) = domain {

--- a/crates/conjure-cp-essence-parser/src/parser/domain.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/domain.rs
@@ -133,19 +133,6 @@ fn parse_int_domain(
                     return Ok(None);
                 };
 
-                span_with_hover(
-                    &domain_component,
-                    ctx.source_code,
-                    ctx.source_map,
-                    HoverInfo {
-                        description: "Single integer domain value".to_string(),
-                        doc_key: None,
-                        kind: Some(SymbolKind::Domain),
-                        ty: None,
-                        decl_span: None,
-                    },
-                );
-
                 if !matches!(int_val, IntVal::Const(_)) {
                     all_resolved = false;
                 }
@@ -187,54 +174,18 @@ fn parse_int_domain(
                         } else {
                             all_resolved = false;
                         }
-                        span_with_hover(
-                            &domain_component,
-                            ctx.source_code,
-                            ctx.source_map,
-                            HoverInfo {
-                                description: "Bounded integer range".to_string(),
-                                doc_key: None,
-                                kind: Some(SymbolKind::Domain),
-                                ty: None,
-                                decl_span: None,
-                            },
-                        );
                         ranges_unresolved.push(Range::Bounded(lower, upper));
                     }
                     (Some(lower), None) => {
                         if !matches!(lower, IntVal::Const(_)) {
                             all_resolved = false;
                         }
-                        span_with_hover(
-                            &domain_component,
-                            ctx.source_code,
-                            ctx.source_map,
-                            HoverInfo {
-                                description: "Lower-bounded integer range".to_string(),
-                                doc_key: None,
-                                kind: Some(SymbolKind::Domain),
-                                ty: None,
-                                decl_span: None,
-                            },
-                        );
                         ranges_unresolved.push(Range::UnboundedR(lower));
                     }
                     (None, Some(upper)) => {
                         if !matches!(upper, IntVal::Const(_)) {
                             all_resolved = false;
                         }
-                        span_with_hover(
-                            &domain_component,
-                            ctx.source_code,
-                            ctx.source_map,
-                            HoverInfo {
-                                description: "Upper-bounded integer range".to_string(),
-                                doc_key: None,
-                                kind: Some(SymbolKind::Domain),
-                                ty: None,
-                                decl_span: None,
-                            },
-                        );
                         ranges_unresolved.push(Range::UnboundedL(upper));
                     }
                     _ => {
@@ -246,6 +197,7 @@ fn parse_int_domain(
                         return Ok(None);
                     }
                 }
+                ctx.add_span_and_doc_hover(&domain_component, "range", SymbolKind::Domain, None, None);
 
                 for i in 0..domain_component.child_count() {
                     let Some(i_u32) = u32::try_from(i).ok() else {
@@ -255,18 +207,7 @@ fn parse_int_domain(
                         continue;
                     };
                     if child.kind() == ".." {
-                        span_with_hover(
-                            &child,
-                            ctx.source_code,
-                            ctx.source_map,
-                            HoverInfo {
-                                description: "Integer range separator".to_string(),
-                                doc_key: None,
-                                kind: Some(SymbolKind::Domain),
-                                ty: None,
-                                decl_span: None,
-                            },
-                        );
+                        ctx.add_span_and_doc_hover(&child, "range", SymbolKind::Domain, None, None);
                         break;
                     }
                 }
@@ -316,18 +257,6 @@ fn parse_int_val(ctx: &mut ParseContext, node: Node) -> Result<Option<IntVal>, F
     if node.kind() == "atom" {
         let text = &ctx.source_code[node.start_byte()..node.end_byte()];
         if let Ok(integer) = text.parse::<i32>() {
-            span_with_hover(
-                &node,
-                ctx.source_code,
-                ctx.source_map,
-                HoverInfo {
-                    description: format!("Integer domain bound: {integer}"),
-                    doc_key: None,
-                    kind: Some(SymbolKind::Integer),
-                    ty: None,
-                    decl_span: None,
-                },
-            );
             return Ok(Some(IntVal::Const(integer)));
         }
         // Otherwise, check if it's an identifier reference
@@ -370,17 +299,12 @@ fn parse_tuple_domain(
             None,
         );
     } else {
-        span_with_hover(
+        ctx.add_span_and_doc_hover(
             &tuple_domain,
-            ctx.source_code,
-            ctx.source_map,
-            HoverInfo {
-                description: "Tuple domain".to_string(),
-                doc_key: None,
-                kind: Some(SymbolKind::Domain),
-                ty: Some(format!("arity: {}", domains.len())),
-                decl_span: None,
-            },
+            "L_tuple",
+            SymbolKind::Domain,
+            Some(format!("arity: {}", domains.len())),
+            None,
         );
     }
 
@@ -421,30 +345,6 @@ fn parse_matrix_domain(
         )),
         None,
     );
-    span_with_hover(
-        &index_domain_list,
-        ctx.source_code,
-        ctx.source_map,
-        HoverInfo {
-            description: "Matrix index domain list".to_string(),
-            doc_key: None,
-            kind: Some(SymbolKind::Domain),
-            ty: Some(format!("dimensions: {}", domains.len())),
-            decl_span: None,
-        },
-    );
-    span_with_hover(
-        &value_domain_node,
-        ctx.source_code,
-        ctx.source_map,
-        HoverInfo {
-            description: "Matrix value domain".to_string(),
-            doc_key: None,
-            kind: Some(SymbolKind::Domain),
-            ty: Some(value_domain.to_string()),
-            decl_span: None,
-        },
-    );
     Ok(Some(Domain::matrix(value_domain, domains)))
 }
 
@@ -458,18 +358,6 @@ fn parse_record_domain(
             return Ok(None);
         };
         let name = Name::user(&ctx.source_code[name_node.start_byte()..name_node.end_byte()]);
-        span_with_hover(
-            &name_node,
-            ctx.source_code,
-            ctx.source_map,
-            HoverInfo {
-                description: format!("Record field: {}", name),
-                doc_key: None,
-                kind: Some(SymbolKind::Variable),
-                ty: None,
-                decl_span: None,
-            },
-        );
         let Some(domain_node) = field!(recover, ctx, record_entry, "domain") else {
             return Ok(None);
         };
@@ -543,21 +431,23 @@ pub fn parse_set_domain(
                     set_attribute = Some(SetAttr::new_max_size(max_val));
                 }
 
-                span_with_hover(
-                    &child,
-                    ctx.source_code,
-                    ctx.source_map,
-                    HoverInfo {
-                        description: "Set domain attributes".to_string(),
-                        doc_key: None,
-                        kind: Some(SymbolKind::Domain),
-                        ty: set_attribute.as_ref().and_then(|attr| {
-                            let txt = attr.to_string();
-                            if txt.is_empty() { None } else { Some(txt) }
-                        }),
-                        decl_span: None,
-                    },
-                );
+                for i in 0..child.child_count() {
+                    let Some(i_u32) = u32::try_from(i).ok() else {
+                        continue;
+                    };
+                    let Some(attr_node) = child.child(i_u32) else {
+                        continue;
+                    };
+                    let Some(doc_key) = (match attr_node.kind() {
+                        "size" => Some("L_size"),
+                        "minSize" => Some("L_minSize"),
+                        "maxSize" => Some("L_maxSize"),
+                        _ => None,
+                    }) else {
+                        continue;
+                    };
+                    ctx.add_span_and_doc_hover(&attr_node, doc_key, SymbolKind::Domain, None, None);
+                }
             }
             "domain" => {
                 let Some(parsed_domain) = parse_domain(ctx, child)? else {
@@ -576,23 +466,6 @@ pub fn parse_set_domain(
     }
 
     if let Some(domain) = value_domain {
-        // Adding set to the source map with hover info from documentation
-        let set_keyword_node = child!(set_domain, 0, "set");
-        // No documentation available for set domain, using fallback description
-        let set_attr = set_attribute.clone().unwrap_or_default();
-        let set_attr_txt = set_attr.to_string();
-        let details = if set_attr_txt.is_empty() {
-            format!("value domain: {}", domain)
-        } else {
-            format!("attributes: {set_attr_txt}; value domain: {}", domain)
-        };
-        ctx.add_span_and_doc_hover(
-            &set_keyword_node,
-            "set",
-            SymbolKind::Domain,
-            Some(details),
-            None,
-        );
         Ok(Some(Domain::set(set_attribute.unwrap_or_default(), domain)))
     } else {
         ctx.record_error(RecoverableParseError::new(

--- a/crates/conjure-cp-essence-parser/src/parser/domain.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/domain.rs
@@ -133,6 +133,19 @@ fn parse_int_domain(
                     return Ok(None);
                 };
 
+                span_with_hover(
+                    &domain_component,
+                    ctx.source_code,
+                    ctx.source_map,
+                    HoverInfo {
+                        description: "Single integer domain value".to_string(),
+                        doc_key: None,
+                        kind: Some(SymbolKind::Domain),
+                        ty: None,
+                        decl_span: None,
+                    },
+                );
+
                 if !matches!(int_val, IntVal::Const(_)) {
                     all_resolved = false;
                 }
@@ -174,18 +187,54 @@ fn parse_int_domain(
                         } else {
                             all_resolved = false;
                         }
+                        span_with_hover(
+                            &domain_component,
+                            ctx.source_code,
+                            ctx.source_map,
+                            HoverInfo {
+                                description: "Bounded integer range".to_string(),
+                                doc_key: None,
+                                kind: Some(SymbolKind::Domain),
+                                ty: None,
+                                decl_span: None,
+                            },
+                        );
                         ranges_unresolved.push(Range::Bounded(lower, upper));
                     }
                     (Some(lower), None) => {
                         if !matches!(lower, IntVal::Const(_)) {
                             all_resolved = false;
                         }
+                        span_with_hover(
+                            &domain_component,
+                            ctx.source_code,
+                            ctx.source_map,
+                            HoverInfo {
+                                description: "Lower-bounded integer range".to_string(),
+                                doc_key: None,
+                                kind: Some(SymbolKind::Domain),
+                                ty: None,
+                                decl_span: None,
+                            },
+                        );
                         ranges_unresolved.push(Range::UnboundedR(lower));
                     }
                     (None, Some(upper)) => {
                         if !matches!(upper, IntVal::Const(_)) {
                             all_resolved = false;
                         }
+                        span_with_hover(
+                            &domain_component,
+                            ctx.source_code,
+                            ctx.source_map,
+                            HoverInfo {
+                                description: "Upper-bounded integer range".to_string(),
+                                doc_key: None,
+                                kind: Some(SymbolKind::Domain),
+                                ty: None,
+                                decl_span: None,
+                            },
+                        );
                         ranges_unresolved.push(Range::UnboundedL(upper));
                     }
                     _ => {
@@ -195,6 +244,27 @@ fn parse_int_domain(
                             Some(domain_component.range()),
                         ));
                         return Ok(None);
+                    }
+                }
+
+                for i in 0..domain_component.child_count() {
+                    let Some(child) = domain_component.child(i) else {
+                        continue;
+                    };
+                    if child.kind() == ".." {
+                        span_with_hover(
+                            &child,
+                            ctx.source_code,
+                            ctx.source_map,
+                            HoverInfo {
+                                description: "Integer range separator".to_string(),
+                                doc_key: None,
+                                kind: Some(SymbolKind::Domain),
+                                ty: None,
+                                decl_span: None,
+                            },
+                        );
+                        break;
                     }
                 }
             }
@@ -243,6 +313,18 @@ fn parse_int_val(ctx: &mut ParseContext, node: Node) -> Result<Option<IntVal>, F
     if node.kind() == "atom" {
         let text = &ctx.source_code[node.start_byte()..node.end_byte()];
         if let Ok(integer) = text.parse::<i32>() {
+            span_with_hover(
+                &node,
+                ctx.source_code,
+                ctx.source_map,
+                HoverInfo {
+                    description: format!("Integer domain bound: {integer}"),
+                    doc_key: None,
+                    kind: Some(SymbolKind::Integer),
+                    ty: None,
+                    decl_span: None,
+                },
+            );
             return Ok(Some(IntVal::Const(integer)));
         }
         // Otherwise, check if it's an identifier reference
@@ -277,7 +359,26 @@ fn parse_tuple_domain(
         && first.kind() == "tuple"
     {
         // Adding tuple to the source map with hover info from documentation
-        ctx.add_span_and_doc_hover(&first, "L_tuple", SymbolKind::Domain, None, None);
+        ctx.add_span_and_doc_hover(
+            &first,
+            "L_tuple",
+            SymbolKind::Domain,
+            Some(format!("arity: {}", domains.len())),
+            None,
+        );
+    } else {
+        span_with_hover(
+            &tuple_domain,
+            ctx.source_code,
+            ctx.source_map,
+            HoverInfo {
+                description: "Tuple domain".to_string(),
+                doc_key: None,
+                kind: Some(SymbolKind::Domain),
+                ty: Some(format!("arity: {}", domains.len())),
+                decl_span: None,
+            },
+        );
     }
 
     Ok(Some(Domain::tuple(domains)))
@@ -310,8 +411,36 @@ fn parse_matrix_domain(
         &matrix_keyword_node,
         "matrix",
         SymbolKind::Domain,
+        Some(format!(
+            "index domains: {}, value domain: {}",
+            domains.len(),
+            value_domain
+        )),
         None,
-        None,
+    );
+    span_with_hover(
+        &index_domain_list,
+        ctx.source_code,
+        ctx.source_map,
+        HoverInfo {
+            description: "Matrix index domain list".to_string(),
+            doc_key: None,
+            kind: Some(SymbolKind::Domain),
+            ty: Some(format!("dimensions: {}", domains.len())),
+            decl_span: None,
+        },
+    );
+    span_with_hover(
+        &value_domain_node,
+        ctx.source_code,
+        ctx.source_map,
+        HoverInfo {
+            description: "Matrix value domain".to_string(),
+            doc_key: None,
+            kind: Some(SymbolKind::Domain),
+            ty: Some(value_domain.to_string()),
+            decl_span: None,
+        },
     );
     Ok(Some(Domain::matrix(value_domain, domains)))
 }
@@ -326,6 +455,18 @@ fn parse_record_domain(
             return Ok(None);
         };
         let name = Name::user(&ctx.source_code[name_node.start_byte()..name_node.end_byte()]);
+        span_with_hover(
+            &name_node,
+            ctx.source_code,
+            ctx.source_map,
+            HoverInfo {
+                description: format!("Record field: {}", name),
+                doc_key: None,
+                kind: Some(SymbolKind::Variable),
+                ty: None,
+                decl_span: None,
+            },
+        );
         let Some(domain_node) = field!(recover, ctx, record_entry, "domain") else {
             return Ok(None);
         };
@@ -341,7 +482,14 @@ fn parse_record_domain(
         &record_keyword_node,
         "L_record",
         SymbolKind::Domain,
-        None,
+        Some(format!(
+            "fields: {}",
+            record_entries
+                .iter()
+                .map(|entry| entry.name.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
         None,
     );
     Ok(Some(Domain::record(record_entries)))
@@ -391,6 +539,22 @@ pub fn parse_set_domain(
                     };
                     set_attribute = Some(SetAttr::new_max_size(max_val));
                 }
+
+                span_with_hover(
+                    &child,
+                    ctx.source_code,
+                    ctx.source_map,
+                    HoverInfo {
+                        description: "Set domain attributes".to_string(),
+                        doc_key: None,
+                        kind: Some(SymbolKind::Domain),
+                        ty: set_attribute.as_ref().and_then(|attr| {
+                            let txt = attr.to_string();
+                            if txt.is_empty() { None } else { Some(txt) }
+                        }),
+                        decl_span: None,
+                    },
+                );
             }
             "domain" => {
                 let Some(parsed_domain) = parse_domain(ctx, child)? else {
@@ -412,7 +576,20 @@ pub fn parse_set_domain(
         // Adding set to the source map with hover info from documentation
         let set_keyword_node = child!(set_domain, 0, "set");
         // No documentation available for set domain, using fallback description
-        ctx.add_span_and_doc_hover(&set_keyword_node, "set", SymbolKind::Domain, None, None);
+        let set_attr = set_attribute.clone().unwrap_or_default();
+        let set_attr_txt = set_attr.to_string();
+        let details = if set_attr_txt.is_empty() {
+            format!("value domain: {}", domain)
+        } else {
+            format!("attributes: {set_attr_txt}; value domain: {}", domain)
+        };
+        ctx.add_span_and_doc_hover(
+            &set_keyword_node,
+            "set",
+            SymbolKind::Domain,
+            Some(details),
+            None,
+        );
         Ok(Some(Domain::set(set_attribute.unwrap_or_default(), domain)))
     } else {
         ctx.record_error(RecoverableParseError::new(

--- a/crates/conjure-cp-essence-parser/src/parser/domain.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/domain.rs
@@ -197,7 +197,13 @@ fn parse_int_domain(
                         return Ok(None);
                     }
                 }
-                ctx.add_span_and_doc_hover(&domain_component, "range", SymbolKind::Domain, None, None);
+                ctx.add_span_and_doc_hover(
+                    &domain_component,
+                    "range",
+                    SymbolKind::Domain,
+                    None,
+                    None,
+                );
 
                 for i in 0..domain_component.child_count() {
                     let Some(i_u32) = u32::try_from(i).ok() else {

--- a/crates/conjure-cp-essence-parser/src/parser/domain.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/domain.rs
@@ -248,7 +248,10 @@ fn parse_int_domain(
                 }
 
                 for i in 0..domain_component.child_count() {
-                    let Some(child) = domain_component.child(i) else {
+                    let Some(i_u32) = u32::try_from(i).ok() else {
+                        continue;
+                    };
+                    let Some(child) = domain_component.child(i_u32) else {
                         continue;
                     };
                     if child.kind() == ".." {

--- a/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
@@ -14,13 +14,12 @@ use super::dominance::parse_dominance_relation;
 use super::find::{parse_find_statement, parse_given_statement};
 use super::letting::parse_letting_statement;
 use super::util::{TypecheckingContext, get_tree};
-use crate::diagnostics::diagnostics_api::SymbolKind;
-use crate::diagnostics::source_map::{HoverInfo, SourceMap, span_with_hover};
+use crate::diagnostics::source_map::SourceMap;
 use crate::errors::{FatalParseError, ParseErrorCollection, RecoverableParseError};
 use crate::expression::parse_expression;
 use crate::parser::keyword_checks::keyword_as_identifier;
 use crate::syntax_errors::detect_syntactic_errors;
-use tree_sitter::{Node, Tree};
+use tree_sitter::Tree;
 
 /// Parse an Essence file into a Model using the tree-sitter parser.
 pub fn parse_essence_file_native(
@@ -149,7 +148,6 @@ pub fn parse_essence_with_context_and_map(
                 }
             }
             "bool_expr" | "atom" | "comparison_expr" => {
-                maybe_add_such_that_hover(&mut ctx, &statement);
                 ctx.typechecking_context = TypecheckingContext::Boolean;
                 let Some(expr) = parse_expression(&mut ctx, statement)? else {
                     continue;
@@ -192,31 +190,6 @@ pub fn parse_essence_with_context_and_map(
     }
     // otherwise return the model
     Ok((Some(model), source_map))
-}
-
-fn maybe_add_such_that_hover(ctx: &mut ParseContext, statement: &Node) {
-    let mut prev = statement.prev_sibling();
-    while let Some(node) = prev {
-        match node.kind() {
-            "," => prev = node.prev_sibling(),
-            "such that" => {
-                span_with_hover(
-                    &node,
-                    ctx.source_code,
-                    ctx.source_map,
-                    HoverInfo {
-                        description: "Constraint block keyword: such that".to_string(),
-                        doc_key: None,
-                        kind: Some(SymbolKind::Function),
-                        ty: None,
-                        decl_span: None,
-                    },
-                );
-                return;
-            }
-            _ => return,
-        }
-    }
 }
 
 pub fn parse_essence(src: &str) -> Result<(Model, SourceMap), Box<ParseErrorCollection>> {

--- a/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/parse_model.rs
@@ -14,12 +14,13 @@ use super::dominance::parse_dominance_relation;
 use super::find::{parse_find_statement, parse_given_statement};
 use super::letting::parse_letting_statement;
 use super::util::{TypecheckingContext, get_tree};
-use crate::diagnostics::source_map::SourceMap;
+use crate::diagnostics::diagnostics_api::SymbolKind;
+use crate::diagnostics::source_map::{HoverInfo, SourceMap, span_with_hover};
 use crate::errors::{FatalParseError, ParseErrorCollection, RecoverableParseError};
 use crate::expression::parse_expression;
 use crate::parser::keyword_checks::keyword_as_identifier;
 use crate::syntax_errors::detect_syntactic_errors;
-use tree_sitter::Tree;
+use tree_sitter::{Node, Tree};
 
 /// Parse an Essence file into a Model using the tree-sitter parser.
 pub fn parse_essence_file_native(
@@ -148,6 +149,7 @@ pub fn parse_essence_with_context_and_map(
                 }
             }
             "bool_expr" | "atom" | "comparison_expr" => {
+                maybe_add_such_that_hover(&mut ctx, &statement);
                 ctx.typechecking_context = TypecheckingContext::Boolean;
                 let Some(expr) = parse_expression(&mut ctx, statement)? else {
                     continue;
@@ -190,6 +192,31 @@ pub fn parse_essence_with_context_and_map(
     }
     // otherwise return the model
     Ok((Some(model), source_map))
+}
+
+fn maybe_add_such_that_hover(ctx: &mut ParseContext, statement: &Node) {
+    let mut prev = statement.prev_sibling();
+    while let Some(node) = prev {
+        match node.kind() {
+            "," => prev = node.prev_sibling(),
+            "such that" => {
+                span_with_hover(
+                    &node,
+                    ctx.source_code,
+                    ctx.source_map,
+                    HoverInfo {
+                        description: "Constraint block keyword: such that".to_string(),
+                        doc_key: None,
+                        kind: Some(SymbolKind::Function),
+                        ty: None,
+                        decl_span: None,
+                    },
+                );
+                return;
+            }
+            _ => return,
+        }
+    }
 }
 
 pub fn parse_essence(src: &str) -> Result<(Model, SourceMap), Box<ParseErrorCollection>> {


### PR DESCRIPTION
## Description
This PR fills in missing hover population in the parser SourceMap for docs-backed keywords.
- domain substructure details (`tuple`, `matrix`, `record`, `set`)
- quantifier/aggregate keywords (`forAll`, `exists`, `sum`, `min`, `max`)

<!-- what does this PR do? a quick summary of changes. -->

## Related issues
Closes Issue #1585
<!-- e.g. Closes #12 or Fixes #45 -->

## Key changes

- `parser/domain.rs`
  - Integer range hover now uses documented key:
    - `int_range` nodes -> `range`
    - `..` separator token -> `range`
  - Tuple domain hover now consistently uses docs key `L_tuple` (including parenthesised tuple form), while retaining arity metadata.
  - keyword hover for `matrix` (docs-backed).
  - Added docs-backed hover for set attribute keywords:
    - `size` -> `L_size`
    - `minSize` -> `L_minSize`
    - `maxSize` -> `L_maxSize`

- `parser/comprehension.rs`
  - Added docs-backed operator hover only where docs exist:
    - `min` -> `min`
    - `max` -> `max`
  - No hover is added for undocumented operator keys (`forAll`, `exists`, `sum`).
  
- `parser/domain.rs` cleanup
  -`u32` conversion before `Node::child(...)` index access.

## How to test/review
- run `extension.ts`
- test on essence files, hover on keywords mentioned above 

<img width="841" height="346" alt="Screenshot 2026-05-25 at 16 38 30" src="https://github.com/user-attachments/assets/65770b26-846a-45da-86f9-ca314fb69529" />
<img width="775" height="256" alt="Screenshot 2026-05-25 at 17 42 34" src="https://github.com/user-attachments/assets/ea131807-9dff-49b8-8315-21667f7ffb51" />


   
<!-- instructions to make the reviewer's life easier-->
