### PR TITLE
DONOTMERGE: benchmarking framework early proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "conjure-cp-bench"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "conjure-cp",
+ "derivative",
+ "glob",
+ "serde_json",
+ "thiserror",
+ "versions",
+ "walkdir",
+]
+
+[[package]]
 name = "conjure-cp-cli"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,20 @@ resolver = "2"
 default-members = ["crates/conjure-cp", "tests-integration", "crates/conjure-cp-cli"]
 
 members = [
-    "crates/conjure-cp-cli",
     "crates/conjure-cp",
+    "crates/conjure-cp-bench",
+    "crates/conjure-cp-cli",
     "crates/conjure-cp-core",
-    "crates/conjure-cp-rules",
-    "crates/conjure-cp-essence-parser",
-    "crates/conjure-cp-essence-macros",
     "crates/conjure-cp-enum-compatibility-macro",
+    "crates/conjure-cp-essence-macros",
+    "crates/conjure-cp-essence-parser",
+    "crates/conjure-cp-lsp",
     "crates/conjure-cp-rule-macros",
+    "crates/conjure-cp-rules",
     "crates/minion-sys",
-    "crates/tree-sitter-essence",
     "crates/tree-morph",
     "crates/tree-morph-macros",
-    "crates/conjure-cp-lsp",
+    "crates/tree-sitter-essence",
 
   # internal crates, not to be pushed to crates io
   "tests-integration"

--- a/crates/conjure-cp-bench/Cargo.toml
+++ b/crates/conjure-cp-bench/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "conjure-cp-bench"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+conjure-cp = { version = "0.1.0", path = "../conjure-cp" }
+derivative.workspace = true
+glob.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+versions.workspace = true
+walkdir.workspace = true
+
+[lints]
+workspace = true
+
+
+[[example]]
+name = "conjure_solve_time"
+
+[dev-dependencies]
+clap.workspace = true

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens.eprime
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens.eprime
@@ -1,0 +1,17 @@
+language ESSENCE' 1.0
+given      n : int(1..)
+letting    AMOUNT_QUEENS be domain int(0..n-1)
+find       q1: matrix indexed by [ AMOUNT_QUEENS ] of int(0..n-1)
+find       q2: matrix indexed by [ AMOUNT_QUEENS ] of int(-(n-1)..n-1)
+find       q3: matrix indexed by [ AMOUNT_QUEENS ] of int(0..(n-1)*2)
+
+such that  allDiff(q1), 
+           allDiff(q2), 
+           allDiff(q3),
+           
+         $ diagonals
+           forAll i : AMOUNT_QUEENS . (
+               (q2[i]=q1[i]-i)  /\
+               (q3[i]=q1[i]+i)
+           )
+           

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_16.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_16.param
@@ -1,0 +1,3 @@
+language ESSENCE' 1.0
+letting n be 16
+

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_24.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_24.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 24

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_8.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/n_queens/n_queens_8.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 8

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens.eprime
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens.eprime
@@ -1,0 +1,87 @@
+$ Peaceable Army of queens
+$
+$ Place 2 equally-sized armies of queens (white and black)
+$ on a chess board without attacking each other
+$ Maximise the size of the armies.
+$
+$ 'occurrence' representation 
+$
+
+
+language ESSENCE' 1.0
+
+
+
+$ board width
+given        n : int
+letting      N be domain int(1..n)
+
+
+$ 0: empty field, 1:white queen, 2: black queen
+find        board : matrix indexed by [N,N] of int(0..2)
+find        amountOfQueens : int(1..(n*n)/2)     
+
+
+maximising   amountOfQueens
+
+
+such that
+
+   
+   $ we have the same amount of white as black queens
+   (sum row : N .
+       (sum col : N .
+          (board[row,col] = 1))) = amountOfQueens,
+
+   (sum row : N .
+       (sum col : N . 
+           (board[row,col] = 2))) = amountOfQueens,
+
+
+  $ for all rows
+  forAll row,col1,col2 : N .
+     (col1 < col2) -> 
+       (board[row,col1] + board[row,col2] != 3),
+
+
+  $ for all cols
+  forAll col, row1, row2 : N .
+     (row1 < row2) -> 
+       (board[row1,col] + board[row2,col] != 3),
+
+ $ for all diagonals 
+   forAll i,col1,col2,row1,row2 : N .
+
+      $ South-West diagonal
+     (((row1 + i <= n) /\ (col1 + i <= n)) ->
+             (((row1 + i = row2) /\ (col1 + i = col2)) ->  
+                   (board[row1,col1] + board[row2,col2] != 3)  
+             ))
+ 
+     /\
+      
+      $ South-East diagonal
+     (((row1 + i <= n) /\ (col1 - i > 0)) ->
+             (((row1 + i = row2) /\ (col1 - i = col2)) ->  
+                   (board[row1,col1] + board[row2,col2] != 3)  
+              ))
+
+     /\
+
+      $ North-East diagonal
+     (((row1 - i > 0) /\ (col1 - i > 0)) ->
+             (((row1 - i = row2) /\ (col1 - i = col2)) ->  
+                   (board[row1,col1] + board[row2,col2] != 3)  
+              ))
+
+     /\
+
+      $ North-West diagonal
+     (((row1 - i > 0) /\ (col1 + i <= n)) ->
+             (((row1 - i = row2) /\ (col1 + i = col2)) ->  
+                   (board[row1,col1] + board[row2,col2] != 3)  
+              ))
+
+    
+
+

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens4.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens4.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 4

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens5.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens5.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 5

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens6.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens6.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 6

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens7.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens7.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 7

--- a/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens8.param
+++ b/crates/conjure-cp-bench/example_models/eprime_models_with_params/peaceableArmyQueens8.param
@@ -1,0 +1,2 @@
+language ESSENCE' 1.0
+letting n be 8

--- a/crates/conjure-cp-bench/example_models/xkcd.essence
+++ b/crates/conjure-cp-bench/example_models/xkcd.essence
@@ -1,0 +1,9 @@
+language ESSENCE' 1.0
+
+letting n be 6
+letting price be [215, 275, 335, 355, 420, 580]
+letting total_ be 1505
+find x : matrix indexed by [int(1..n)] of int(0..100000)
+such that
+(total_=(sum i : int(1..n) . (price[i] * x[i])))
+

--- a/crates/conjure-cp-bench/examples/conjure_solve_time.rs
+++ b/crates/conjure-cp-bench/examples/conjure_solve_time.rs
@@ -1,0 +1,63 @@
+//! This is a small example showing how to use this library to report solver stats from conjure.
+
+use conjure_cp_bench::{
+    executor::conjure::{ConjureExecutor, ConjureExecutorBuilder},
+    mode::{BenchmarkingMode, FixedIterationsMode, ModeOutputKey},
+    model_sources::models_from_directory_tree,
+};
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    conjure_executable: PathBuf,
+    models_directory: PathBuf,
+    i: usize,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    // an instance of conjure to run the benchmarks on
+    let executor: ConjureExecutor = ConjureExecutorBuilder::new(cli.conjure_executable)
+        .add_flag("--solver=minion".to_owned())
+        .build();
+
+    let benchmark_mode = FixedIterationsMode::new(cli.i);
+
+    // convert models_directory to absolute path before passing down the line, otherwise things
+    // break.
+    let models_directory = std::fs::canonicalize(&cli.models_directory).unwrap();
+    let models_and_params = models_from_directory_tree(&models_directory).unwrap();
+
+    let results = benchmark_mode.run(&models_and_params, &executor).unwrap();
+    println!("{0: <20.20} {1: <20.20} mean", "instance", "counterName");
+    for (
+        ModeOutputKey {
+            model,
+            param,
+            counter_name,
+        },
+        v,
+    ) in results.counters.into_iter()
+    {
+        let v_mean: Option<f64> = v
+            .iter()
+            .copied()
+            .flatten()
+            .enumerate()
+            .reduce(|(_, x_acc), (i, x)| (i, (x_acc + x)))
+            .map(|(v_size, v_sum)| v_sum / (v_size as f64));
+
+        let v_mean_string = match v_mean {
+            Some(v) => format!("{v:.02}"),
+            None => String::from("N/A"),
+        };
+
+        let instance_string = param.unwrap_or_else(|| model);
+
+        println!("{instance_string: <20.20} {counter_name: <20.20}  {v_mean_string}");
+    }
+}

--- a/crates/conjure-cp-bench/src/executor.rs
+++ b/crates/conjure-cp-bench/src/executor.rs
@@ -1,0 +1,49 @@
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::{Model, ParamFile};
+
+pub mod conjure;
+
+pub trait Executor {
+    fn run(
+        &self,
+        model: &Model,
+        param_file: Option<&ParamFile>,
+    ) -> Result<ExecutorOutput, ExecutorError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct ExecutorOutput {
+    pub metadata: HashMap<String, String>,
+    pub counters: HashMap<String, Option<f64>>,
+}
+
+impl Default for ExecutorOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExecutorOutput {
+    pub fn new() -> Self {
+        ExecutorOutput {
+            metadata: HashMap::new(),
+            counters: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn set_metadata(&mut self, key: &str, value: String) {
+        self.metadata.insert(key.to_string(), value);
+    }
+
+    pub(crate) fn set_counter(&mut self, key: &str, value: Option<f64>) {
+        self.counters.insert(key.to_string(), value);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ExecutorError {}

--- a/crates/conjure-cp-bench/src/executor/conjure.rs
+++ b/crates/conjure-cp-bench/src/executor/conjure.rs
@@ -1,0 +1,307 @@
+use std::{
+    fs::File,
+    path::PathBuf,
+    process::{Command, Stdio},
+    time::Instant,
+};
+use versions::Versioning;
+
+use crate::{FileSource, Model, ParamFile, executor::Executor};
+
+use super::{ExecutorError, ExecutorOutput};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConjureExecutorBuilder {
+    executable: PathBuf,
+    extra_flags: Vec<String>,
+}
+
+// TODO: add option to get executable from path.
+
+impl ConjureExecutorBuilder {
+    /// Creates a new ConjureExecutorBuilder.
+    ///
+    /// # Panics
+    ///
+    /// - If conjure_executable does not exist, is not executable, or is not conjure.
+    pub fn new(conjure_executable: PathBuf) -> ConjureExecutorBuilder {
+        assert_executable_exists_and_is_conjure(&conjure_executable);
+        ConjureExecutorBuilder {
+            executable: conjure_executable,
+            extra_flags: vec![],
+        }
+    }
+
+    // TODO: do not allow the passing of arbitrary flags, make well-typed builder methods for all
+    // options.
+    pub fn add_flag(mut self, flag: String) -> ConjureExecutorBuilder {
+        self.extra_flags.push(flag);
+        self
+    }
+
+    pub fn add_flags(mut self, flags: &[String]) -> ConjureExecutorBuilder {
+        self.extra_flags.extend(flags.iter().cloned());
+        self
+    }
+
+    /// Changes the Conjure executable to use.
+    ///
+    /// # Panics
+    ///
+    /// - If conjure_executable does not exist, is not executable, or is not conjure.
+    pub fn conjure_executable(mut self, conjure_executable: PathBuf) -> ConjureExecutorBuilder {
+        assert_executable_exists_and_is_conjure(&conjure_executable);
+        self.executable = conjure_executable;
+        self
+    }
+
+    pub fn build(self) -> ConjureExecutor {
+        let temp_dir = std::env::temp_dir();
+        ConjureExecutor {
+            executable: self.executable,
+            extra_flags: self.extra_flags,
+            temp_dir,
+        }
+    }
+}
+
+const CONJURE_MIN_VERSION: &str = "2.6.0";
+const CORRECT_FIRST_LINE: &str = "Conjure: The Automated Constraint Modelling Tool";
+
+// adapted from conjure-cp-cli
+fn assert_executable_exists_and_is_conjure(executable: &PathBuf) {
+    let mut cmd = std::process::Command::new(executable);
+    let output = cmd
+        .arg("--version")
+        .output()
+        .expect("Failed conjure executable check: expect conjure --version to succeed");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    if !stderr.is_empty() {
+        panic!(
+            "Failed Conjure executable check: running conjure results in error: {}",
+            &stderr
+        );
+    }
+
+    let first = stdout
+        .lines()
+        .next()
+        .expect("Failed Conjure executable check: could not read stddout.");
+
+    if first != CORRECT_FIRST_LINE {
+        panic!(
+            "Failed Conjure executable check: first line is incorrect when using --version. Expected {CORRECT_FIRST_LINE}, got {first}."
+        );
+    }
+
+    let version_line = stdout
+        .lines()
+        .nth(1)
+        .expect("Failed conjure executable check: could not read stdout");
+
+    let version_and_repo = version_line.strip_prefix("Conjure v").unwrap_or_else(|| panic!("Failed Conjure executable check: could not read conjure's version from: {version_line}"));
+
+    let (version, _) = version_and_repo.split_once(" (Repository version ").unwrap_or_else(|| panic!("Failed Conjure executable check: could not read Conjure's version from: {version_line}"));
+
+    if Versioning::new(version) < Versioning::new(CONJURE_MIN_VERSION) {
+        panic!(
+            "failed Conjure executable check: conjure version is too old (< {CONJURE_MIN_VERSION}): {version}"
+        );
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConjureExecutor {
+    pub executable: PathBuf,
+    pub extra_flags: Vec<String>,
+    temp_dir: PathBuf,
+}
+
+impl Executor for ConjureExecutor {
+    fn run(
+        &self,
+        model: &Model,
+        param_file: Option<&ParamFile>,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        let model_file_path: String = match &model.source {
+            FileSource::File(path_buf) => {
+                if !path_buf.exists() {
+                    let model_path_str = path_buf.to_str().unwrap();
+                    panic!("Model {model_path_str} does not exist");
+                }
+
+                if !path_buf.is_absolute() {
+                    let model_path_str = path_buf.to_str().unwrap();
+                    panic!("Model {model_path_str} is not an absolute path.");
+                }
+
+                String::from(path_buf.to_string_lossy())
+            }
+            FileSource::Text(src) => {
+                let path = &self.temp_dir.join(format!("{}.essence", &model.name));
+                std::fs::write(path, src).unwrap();
+                String::from(path.to_string_lossy())
+            }
+        };
+
+        let param_file_path: String = match &param_file.map(|x| &x.source) {
+            Some(FileSource::File(path_buf)) => {
+                if !path_buf.exists() {
+                    let param_path_str = path_buf.to_str().unwrap();
+                    panic!("Param file {param_path_str} does not exist");
+                }
+
+                if !path_buf.is_absolute() {
+                    let param_path_str = path_buf.to_str().unwrap();
+                    panic!("Param file {param_path_str} is not an absolute path");
+                }
+                String::from(path_buf.to_string_lossy())
+            }
+            Some(FileSource::Text(src)) => {
+                let path = &self.temp_dir.join(format!("{}.essence", &model.name));
+                std::fs::write(path, src).unwrap();
+                String::from(path.to_string_lossy())
+            }
+            None => String::from(""),
+        };
+
+        let mut output = ExecutorOutput::new();
+
+        let mut command = Command::new(&self.executable);
+        let command = command
+            .current_dir(&self.temp_dir)
+            .arg("solve")
+            .arg(model_file_path)
+            .arg(param_file_path)
+            .args(&self.extra_flags)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut command_as_string: Vec<String> =
+            vec![String::from(command.get_program().to_string_lossy())];
+
+        command_as_string.extend(
+            command
+                .get_args()
+                .map(|x| String::from(x.to_string_lossy())),
+        );
+
+        let command_as_string = command_as_string.join(" ");
+        output.set_metadata("command", command_as_string);
+
+        // clear conjure cache, ignoring errors that arise if conjure-output does not exist yet
+        let _ = std::fs::remove_dir_all(self.temp_dir.join("conjure-output"));
+
+        // run and time conjure
+        let now = Instant::now();
+        let p_handle = command.spawn().expect("conjure failed to start");
+        let conjure_output = p_handle
+            .wait_with_output()
+            .expect("TODO: return error upwards instead of panicing");
+
+        // TODO: on linux, call getrusage syscall on this process to see peak memory usage, cpu time, swap, etc.
+
+        let elapsed_wall_time = now.elapsed();
+
+        output.set_counter("wall_time_s", Some(elapsed_wall_time.as_secs_f64()));
+        output.set_counter(
+            "exit_status",
+            conjure_output.status.code().map(|x| x as f64),
+        );
+
+        output.set_metadata("stdout", String::from_utf8(conjure_output.stdout).unwrap());
+        output.set_metadata("stderr", String::from_utf8(conjure_output.stderr).unwrap());
+
+        process_stats_json(&self.temp_dir, param_file.map(|x| &x.name), &mut output);
+
+        Ok(output)
+    }
+}
+
+macro_rules! _counter_from_json {
+    ($json: expr, $out: expr, $counter_name: expr, $pointer_name: expr) => {
+        $out.set_counter($counter_name, f64_from_stats_json(&$json, $pointer_name));
+    };
+
+    ($json: expr, $out: expr, $counter_name: expr) => {
+        $out.set_counter(
+            $counter_name,
+            f64_from_stats_json(&$json, "/" + $counter_name),
+        );
+    };
+}
+
+macro_rules! _meta_from_json {
+    ($json: expr, $out: expr, $counter_name: expr, $pointer_name: expr) => {
+        $out.set_metadata($counter_name, str_from_stats_json(&$json, $pointer_name));
+    };
+
+    ($json: expr, $out: expr, $counter_name: expr) => {
+        $out.set_metadata(
+            $counter_name,
+            str_from_stats_json(&$json, format!("/{}", $counter_name).as_str()),
+        );
+    };
+}
+
+// Add counters and metadata from stats.json to the output, if stats.json exists.
+fn process_stats_json(
+    temp_dir: &PathBuf,
+    param_file_name: Option<&String>,
+    out: &mut ExecutorOutput,
+) {
+    // called model000001.stats.json without param file,
+    // model000001-{param_file_name}.stats.json with param file
+    let stats_json_path = match param_file_name {
+        Some(p) => temp_dir.join(format!("conjure-output/model000001-{p}.stats.json")),
+        None => temp_dir.join("conjure-output/model000001.stats.json"),
+    };
+
+    if !stats_json_path.exists() {
+        return;
+    }
+    let file = File::open(stats_json_path).unwrap();
+    let json: serde_json::Value =
+        serde_json::from_reader(file).expect("conjure stats.json to be valid json");
+
+    _counter_from_json!(
+        json,
+        out,
+        "SavileRowTotalTime",
+        "/savilerowInfo/SavileRowTotalTime"
+    );
+    _counter_from_json!(json, out, "SolverNodes", "/savilerowInfo/SolverNodes");
+    _counter_from_json!(
+        json,
+        out,
+        "SolverSolveTime",
+        "/savilerowInfo/SolverSolveTime"
+    );
+    _counter_from_json!(
+        json,
+        out,
+        "SolverSetupTime",
+        "/savilerowInfo/SolverSetupTime"
+    );
+
+    _meta_from_json!(json, out, "conjureVersion");
+    _meta_from_json!(json, out, "savileRowVersion");
+    _meta_from_json!(json, out, "solver");
+    _meta_from_json!(json, out, "solverOptions");
+    _meta_from_json!(json, out, "conjureTimestamp");
+}
+
+fn f64_from_stats_json(json: &serde_json::Value, pointer: &str) -> Option<f64> {
+    json.pointer(pointer)
+        .and_then(|x| x.as_str())
+        .and_then(|x| x.parse().ok())
+}
+
+fn str_from_stats_json(json: &serde_json::Value, pointer: &str) -> String {
+    json.pointer(pointer)
+        .map(|x| x.to_string())
+        .unwrap_or_default()
+}

--- a/crates/conjure-cp-bench/src/lib.rs
+++ b/crates/conjure-cp-bench/src/lib.rs
@@ -1,0 +1,74 @@
+use std::path::PathBuf;
+
+pub mod executor;
+pub mod mode;
+pub mod model_sources;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Model {
+    pub name: String,
+    pub source: FileSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelAndParams {
+    pub model: Model,
+    pub params: Option<Vec<ParamFile>>,
+}
+
+impl ModelAndParams {
+    /// Constructs an iterator of (model,param) combinations.
+    ///
+    /// If this model does not require parameter files, a single iteration (model,None) is returned.
+    pub fn iter(&self) -> impl Iterator<Item = (&Model, Option<&ParamFile>)> {
+        ModelAndParamsIter::new(&self.model, &self.params)
+    }
+}
+
+struct ModelAndParamsIter<'a> {
+    model: &'a Model,
+    params: &'a [ParamFile],
+    i: usize,
+    no_params: bool,
+}
+
+impl<'a> ModelAndParamsIter<'a> {
+    fn new(model: &'a Model, params: &'a Option<Vec<ParamFile>>) -> ModelAndParamsIter<'a> {
+        ModelAndParamsIter {
+            model,
+            params: params.as_deref().unwrap_or_default(),
+            i: 0,
+            no_params: params.is_none(),
+        }
+    }
+}
+
+impl<'a> Iterator for ModelAndParamsIter<'a> {
+    type Item = (&'a Model, Option<&'a ParamFile>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_params = self.params.get(self.i);
+
+        // if no params and first run, return (model,None).
+        if self.i == 0 && self.no_params {
+            self.i += 1;
+            Some((self.model, None))
+        } else {
+            self.i += 1;
+            next_params.map(|p| (self.model, Some(p)))
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParamFile {
+    pub name: String,
+    pub source: FileSource,
+}
+
+/// The source of an essence file.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileSource {
+    Text(String),
+    File(PathBuf),
+}

--- a/crates/conjure-cp-bench/src/mode.rs
+++ b/crates/conjure-cp-bench/src/mode.rs
@@ -1,0 +1,56 @@
+//! Benchmarking modes.
+//!
+//! A benchmarking mode provides a strategy for running an executor on a set of models and parameter
+//! files, possibly for multiple replications.
+use crate::{ModelAndParams, executor::Executor};
+use std::collections::HashMap;
+use thiserror::Error;
+
+mod fixed_iterations;
+pub use fixed_iterations::*;
+/// A benchmarking mode provides a strategy for running an executor on a set of models and parameter
+/// files, possibly for multiple replications.
+pub trait BenchmarkingMode {
+    fn run(
+        &self,
+        models_and_params: &[ModelAndParams],
+        executor: &dyn Executor,
+    ) -> Result<ModeOutput, ModeError>;
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+/// Results obtained out of a [benchmarking mode](BenchmarkingMode).
+pub struct ModeOutput {
+    /// Metadata for the scheduler.
+    pub mode_metadata: HashMap<String, String>,
+
+    /// Metadata for each iteration of the program under test, group by model, param file, and
+    /// metadata field name.
+    pub executor_metadata: HashMap<ModeOutputKey, Vec<Option<String>>>,
+
+    /// Counter values for each iteration of the program under test, grouped by model, param file,
+    /// and counter name.
+    pub counters: HashMap<ModeOutputKey, Vec<Option<f64>>>,
+}
+
+impl ModeOutput {
+    pub(crate) fn new() -> ModeOutput {
+        ModeOutput {
+            mode_metadata: HashMap::new(),
+            executor_metadata: HashMap::new(),
+            counters: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModeOutputKey {
+    pub model: String,
+    pub param: Option<String>,
+    pub counter_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ModeError {}

--- a/crates/conjure-cp-bench/src/mode/fixed_iterations.rs
+++ b/crates/conjure-cp-bench/src/mode/fixed_iterations.rs
@@ -1,0 +1,100 @@
+//! A benchmarking mode that loops over each (model,param) combination, running a fixed number of
+//! iterations for each.
+
+use std::collections::hash_map::Entry;
+
+use crate::{
+    Model, ModelAndParams, ParamFile,
+    executor::{Executor, ExecutorOutput},
+    mode::{BenchmarkingMode, ModeOutputKey},
+};
+
+use super::{ModeError, ModeOutput};
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FixedIterationsMode {
+    iterations: usize,
+}
+
+impl FixedIterationsMode {
+    pub fn new(iterations: usize) -> FixedIterationsMode {
+        FixedIterationsMode { iterations }
+    }
+}
+
+impl BenchmarkingMode for FixedIterationsMode {
+    fn run(
+        &self,
+        model_and_params: &[ModelAndParams],
+        executor: &dyn Executor,
+    ) -> Result<ModeOutput, ModeError> {
+        let mut output = ModeOutput::new();
+        for (model, param_file) in model_and_params.iter().flat_map(|x| x.iter()) {
+            for i in 0..self.iterations {
+                run_once(&mut output, executor, model, param_file, i, self.iterations)?
+            }
+        }
+
+        Ok(output)
+    }
+}
+
+fn run_once(
+    output: &mut ModeOutput,
+    executor: &dyn Executor,
+    model: &Model,
+    param_file: Option<&ParamFile>,
+    i: usize,
+    iterations: usize,
+) -> Result<(), ModeError> {
+    let executor_result = executor.run(model, param_file);
+    let Ok(ExecutorOutput { metadata, counters }) = executor_result else {
+        panic!("Todo: propogate executor error")
+    };
+
+    // update output.metadata
+    for (key, value) in metadata.into_iter() {
+        let key = ModeOutputKey {
+            model: model.name.clone(),
+            param: param_file.map(|x| x.name.clone()),
+            counter_name: key,
+        };
+
+        match output.executor_metadata.entry(key) {
+            Entry::Occupied(mut occupied_entry) => {
+                let entry_val = occupied_entry.get_mut();
+                entry_val[i] = Some(value);
+            }
+            Entry::Vacant(vacant_entry) => {
+                // when we see a counter we havent seen yet, create a vector of size
+                // iterations, so xs[i] = counter value for ith run.
+                let entry_val = vacant_entry.insert(vec![None; iterations]);
+                entry_val[i] = Some(value);
+            }
+        };
+    }
+
+    // update output.counters
+    for (key, value) in counters.into_iter() {
+        let key = ModeOutputKey {
+            model: model.name.clone(),
+            param: param_file.map(|x| x.name.clone()),
+            counter_name: key,
+        };
+
+        match output.counters.entry(key) {
+            Entry::Occupied(mut occupied_entry) => {
+                let entry_val = occupied_entry.get_mut();
+                entry_val[i] = value;
+            }
+            Entry::Vacant(vacant_entry) => {
+                // when we see a counter we havent seen yet, create a vector of size
+                // iterations, so xs[i] = counter value for ith run.
+                let entry_val = vacant_entry.insert(vec![None; iterations]);
+                entry_val[i] = value;
+            }
+        };
+    }
+
+    Ok(())
+}

--- a/crates/conjure-cp-bench/src/model_sources.rs
+++ b/crates/conjure-cp-bench/src/model_sources.rs
@@ -1,0 +1,94 @@
+//! Utility functions to collect Essence models.
+
+use std::path::PathBuf;
+
+use walkdir::WalkDir;
+
+use crate::{FileSource, Model, ModelAndParams, ParamFile};
+
+use glob::glob;
+
+/// Sources models and param files from `dir` and all immediate subdirectories.
+///
+/// - Only models with the extensions .eprime and .essence are included.
+///
+/// - Parameter files for ame>.essence should begin with <name>, and have the extension .param.
+///   They also must be in the same directory as the model.
+///
+///
+/// # Returns
+///
+/// - If dir does not exist or is a file that is not a model, an empty vector is returned.
+pub fn models_from_directory_tree(dir: &PathBuf) -> Result<Vec<ModelAndParams>, walkdir::Error> {
+    let mut output = vec![];
+
+    // only use walkdir to traverse directories not files inside of them. This is necessary to look
+    // at all the files in a specific directory at the same time and match models to param files only
+    // if they are in the same directory.
+    for entry in WalkDir::new(dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_entry(|x| x.file_type().is_dir())
+    {
+        let entry = entry?;
+        let path = entry.path();
+        let path_str = path.to_str().unwrap();
+
+        let models = glob(format!("{path_str}/*.eprime").as_str())
+            .unwrap()
+            .chain(glob(format!("{path_str}/*.essence").as_str()).unwrap());
+
+        for model_path in models {
+            let model_path = model_path.unwrap();
+            if !model_path.is_file() {
+                continue;
+            }
+
+            let model_name = model_path
+                .file_stem()
+                .expect("path to have a file stem as it is an ordinary file")
+                .to_str()
+                .unwrap();
+
+            let model = Model {
+                name: String::from(model_name),
+                source: FileSource::File(model_path.clone()),
+            };
+
+            // find param files for this model
+            let param_file_paths =
+                glob(format!("{path_str}/{model_name}*.param").as_str()).unwrap();
+            let mut params = Vec::<ParamFile>::new();
+
+            for param_file_path in param_file_paths {
+                let param_file_path = param_file_path.unwrap();
+                if !param_file_path.is_file() {
+                    continue;
+                }
+
+                let param_file_name = param_file_path
+                    .file_stem()
+                    .expect("path to have a file stem as it is an ordinary file")
+                    .to_str()
+                    .unwrap();
+
+                params.push(ParamFile {
+                    name: String::from(param_file_name),
+                    source: FileSource::File(param_file_path.clone()),
+                });
+            }
+
+            // convert param_files from Vec<ParamFile> to an Option<Vec<ParamFile>>, as required
+            // for ModelAndParams. --> If no param files were found, set to None.
+            let params: Option<Vec<ParamFile>> = if params.is_empty() {
+                None
+            } else {
+                Some(params)
+            };
+
+            output.push(ModelAndParams { model, params })
+        }
+    }
+
+    Ok(output)
+}


### PR DESCRIPTION
This PR contains an early proof of concept of a benchmarking framework for evaluating the performance of Conjure and Conjure-Oxide. It is by no means complete; I am uploading as is to early feedback on the general approach, and as I do not have time for a more extensive POC in the immediate future. 

This design is based on my previous comments in #1822. The main aim is to build reusable modular building blocks for building any benchmarking tool on Conjure, without pre-supposing what workload we are measuring, or the counters we are interested in. 

*  Executors define how to run a compiler with some configuration once on a model, returning the counters measured for that run. Benchmark modes run executors on a set of models for a number of repetitions.

* Executors are fully interchangeable; allowing the same models to be ran on different compilers and compiler configurations in the same way just by changing the executor passed to the benchmarking mode.

* I store results in a map of "counters", which map counter names to f64 values. This contrasts to other approaches (e.g. conjure-cp/benchmarking) which use a struct of well-typed values. The latter makes serialisation easier; however it makes adding new counters harder, as all uses of the struct within the benchmarking library have to be updated. Adding new counters to a struct may also break user-code. Using a map of counters means that metrics can be added in the executor, and no change to any other code inside the library or users of it.

  Furthermore, using a map allows statistical functions such as the mean to be applied generically to all recorded values of all counters, without knowing what counters exist and how they are organised within a struct. 

An example program, which prints a list of counters and their average scores can be found in examples/conjure_solve_time.rs. 

This is still a bit of a toy example:  main limitations include only conjure support not oxide support, no methods for pretty printing, json output, only a few counters supported, etc. These would be key features of a final version of this.

---

The biggest difference between this vs conjure-cp/benchmarking is the use of a map of counters vs well-typed structs of counters -- this is the key point I would like to raise for discussion. I think the latter is really key to making the benchmarking framework truely generic and workload agnostic. It also makes comparing conjure vs conjure-oxide easier, as we can just make the counters have the same names. RFC @ozgurakgun 