### PR TITLE
refactor(rules): centralise uniplate child rewrites

### DIFF
--- a/crates/conjure-cp-rules/src/bubble.rs
+++ b/crates/conjure-cp-rules/src/bubble.rs
@@ -9,9 +9,9 @@ use conjure_cp::{
         ApplicationResult, Reduction, register_rule, register_rule_set,
     },
 };
-use uniplate::{Biplate, Uniplate};
+use uniplate::Biplate;
 
-use super::utils::is_all_constant;
+use super::utils::{is_all_constant, rewrite_children};
 
 register_rule_set!("Bubble", ("Base"));
 
@@ -64,24 +64,22 @@ fn bubble_up(expr: &Expression, syms: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     };
 
-    let mut sub = expr.children();
     let mut bubbled_conditions = vec![];
-    for e in sub.iter_mut() {
-        if let Expression::Bubble(_, a, b) = e
-            && a.return_type() != ReturnType::Bool
-        {
-            let a = Moo::unwrap_or_clone(Moo::clone(a));
-            let b = Moo::unwrap_or_clone(Moo::clone(b));
+    let (new_inner, num_changed) = rewrite_children(expr, |child| match child {
+        Expression::Bubble(_, a, b) if a.return_type() != ReturnType::Bool => {
+            let a = Moo::unwrap_or_clone(a);
+            let b = Moo::unwrap_or_clone(b);
             bubbled_conditions.push(b);
-            *e = a;
+            (a, true)
         }
-    }
-    if bubbled_conditions.is_empty() {
+        child => (child, false),
+    });
+    if num_changed == 0 {
         Err(ApplicationError::RuleNotApplicable)
     } else if bubbled_conditions.len() == 1 {
         let new_expr = Expression::Bubble(
             Metadata::new(),
-            Moo::new(expr.with_children(sub)),
+            Moo::new(new_inner),
             Moo::new(bubbled_conditions[0].clone()),
         );
 
@@ -89,7 +87,7 @@ fn bubble_up(expr: &Expression, syms: &SymbolTable) -> ApplicationResult {
     } else {
         Ok(Reduction::pure(Expression::Bubble(
             Metadata::new(),
-            Moo::new(expr.with_children(sub)),
+            Moo::new(new_inner),
             Moo::new(Expression::And(
                 Metadata::new(),
                 Moo::new(into_matrix_expr![bubbled_conditions]),

--- a/crates/conjure-cp-rules/src/comprehensions/expansion.rs
+++ b/crates/conjure-cp-rules/src/comprehensions/expansion.rs
@@ -153,13 +153,17 @@ fn expand_comprehension_via_solver_ac(expr: &Expr, symbols: &SymbolTable) -> App
     // Is this an ac expression?
     let ac_operator_kind = expr.to_ac_operator_kind().ok_or(RuleNotApplicable)?;
 
+    let children = expr.children();
     debug_assert_eq!(
-        expr.children().len(),
+        children.len(),
         1,
         "AC expressions should have exactly one child."
     );
 
-    let comprehension = as_single_comprehension(&expr.children()[0]).ok_or(RuleNotApplicable)?;
+    let comprehension = children
+        .front()
+        .and_then(as_single_comprehension)
+        .ok_or(RuleNotApplicable)?;
 
     for qual in &comprehension.qualifiers {
         if let ComprehensionQualifier::ExpressionGenerator { .. } = qual {

--- a/crates/conjure-cp-rules/src/matrix/matrix_to_list.rs
+++ b/crates/conjure-cp-rules/src/matrix/matrix_to_list.rs
@@ -1,11 +1,9 @@
-use std::collections::VecDeque;
-
+use crate::utils::rewrite_children;
 use conjure_cp::ast::{Domain, Expression as Expr, IntVal, Range, SymbolTable};
 use conjure_cp::into_matrix_expr;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
-use uniplate::Uniplate;
 
 /// Converts a matrix to a list if possible.
 ///
@@ -48,40 +46,33 @@ fn matrix_to_list(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     }
 
-    let mut new_children = VecDeque::new();
-    let mut any_changes = false;
-    for child in expr.children() {
+    let (new_expr, num_changed) = rewrite_children(expr, |child| {
         // already a list => no change
         if child.clone().unwrap_list().is_some() {
-            new_children.push_back(child);
-            continue;
+            return (child, false);
         }
 
         // not a matrix => no change
         let Some((elems, domain)) = child.clone().unwrap_matrix_unchecked() else {
-            new_children.push_back(child);
-            continue;
+            return (child, false);
         };
 
         let Some(ranges) = domain.as_int() else {
-            new_children.push_back(child);
-            continue;
+            return (child, false);
         };
 
         // must be domain int(1..n)
         let [Range::Bounded(IntVal::Const(1), _)] = ranges[..] else {
-            new_children.push_back(child);
-            continue;
+            return (child, false);
         };
 
-        any_changes = true;
-        new_children
-            .push_back(into_matrix_expr![elems;Domain::int_ground(vec![Range::UnboundedR(1)])]);
-    }
+        (
+            into_matrix_expr![elems;Domain::int_ground(vec![Range::UnboundedR(1)])],
+            true,
+        )
+    });
 
-    let new_expr = expr.with_children(new_children);
-
-    if any_changes {
+    if num_changed != 0 {
         Ok(Reduction::pure(new_expr))
     } else {
         Err(RuleNotApplicable)

--- a/crates/conjure-cp-rules/src/matrix/matrix_to_list.rs
+++ b/crates/conjure-cp-rules/src/matrix/matrix_to_list.rs
@@ -48,7 +48,7 @@ fn matrix_to_list(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
 
     let (new_expr, num_changed) = rewrite_children(expr, |child| {
         // already a list => no change
-        if child.clone().unwrap_list().is_some() {
+        if child.unwrap_list().is_some() {
             return (child, false);
         }
 

--- a/crates/conjure-cp-rules/src/minion.rs
+++ b/crates/conjure-cp-rules/src/minion.rs
@@ -2,12 +2,11 @@
 /*        Rules for translating to Minion-supported constraints         */
 /************************************************************************/
 
-use std::collections::VecDeque;
 use std::{collections::HashMap, convert::TryInto};
 
 use crate::{
     extra_check,
-    utils::{is_flat, to_aux_var},
+    utils::{is_flat, rewrite_children, to_aux_var},
 };
 use conjure_cp::ast::Moo;
 use conjure_cp::ast::categories::Category;
@@ -24,10 +23,8 @@ use conjure_cp::{
     settings::SolverFamily,
 };
 
-use itertools::Itertools;
-use uniplate::Uniplate;
-
 use ApplicationError::RuleNotApplicable;
+use itertools::Itertools;
 
 register_rule_set!("Minion", ("Base"), |f: &SolverFamily| {
     matches!(f, SolverFamily::Minion)
@@ -577,9 +574,11 @@ fn introduce_diveq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     }
 
-    let children: VecDeque<Expr> = div.as_ref().children();
-    let a: &Atom = (&children[0]).try_into().or(Err(RuleNotApplicable))?;
-    let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
+    let Expr::SafeDiv(_, a, b) = div.as_ref() else {
+        return Err(RuleNotApplicable);
+    };
+    let a: &Atom = a.as_ref().try_into().or(Err(RuleNotApplicable))?;
+    let b: &Atom = b.as_ref().try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(Expr::MinionDivEqUndefZero(
         meta,
@@ -628,9 +627,11 @@ fn introduce_modeq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     }
 
-    let children: VecDeque<Expr> = div.as_ref().children();
-    let a: &Atom = (&children[0]).try_into().or(Err(RuleNotApplicable))?;
-    let b: &Atom = (&children[1]).try_into().or(Err(RuleNotApplicable))?;
+    let Expr::SafeMod(_, a, b) = div.as_ref() else {
+        return Err(RuleNotApplicable);
+    };
+    let a: &Atom = a.as_ref().try_into().or(Err(RuleNotApplicable))?;
+    let b: &Atom = b.as_ref().try_into().or(Err(RuleNotApplicable))?;
 
     Ok(Reduction::pure(Expr::MinionModuloEqUndefZero(
         meta,
@@ -1001,26 +1002,22 @@ fn flatten_generic(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     }
 
-    let mut children = expr.children();
-
     let mut symbols = symbols.clone();
-    let mut num_changed = 0;
     let mut new_tops: Vec<Expr> = vec![];
 
-    for child in children.iter_mut() {
-        if let Some(aux_var_info) = to_aux_var(child, &symbols) {
+    let (expr, num_changed) = rewrite_children(expr, |child| {
+        if let Some(aux_var_info) = to_aux_var(&child, &symbols) {
             symbols = aux_var_info.symbols();
             new_tops.push(aux_var_info.top_level_expr());
-            *child = aux_var_info.as_expr();
-            num_changed += 1;
+            (aux_var_info.as_expr(), true)
+        } else {
+            (child, false)
         }
-    }
+    });
 
     if num_changed == 0 {
         return Err(RuleNotApplicable);
     }
-
-    let expr = expr.with_children(children);
 
     Ok(Reduction::new(expr, new_tops, symbols))
 }
@@ -1031,29 +1028,23 @@ fn flatten_eq(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     }
 
-    let children = expr.children();
-    debug_assert_eq!(children.len(), 2);
-
-    let mut new_children = VecDeque::new();
     let mut symbols = symbols.clone();
-    let mut num_changed = 0;
     let mut new_tops: Vec<Expr> = vec![];
 
-    for child in children {
+    let (expr, num_changed) = rewrite_children(expr, |child| {
         if let Some(aux_var_info) = to_aux_var(&child, &symbols) {
             symbols = aux_var_info.symbols();
             new_tops.push(aux_var_info.top_level_expr());
-            new_children.push_back(aux_var_info.as_expr());
-            num_changed += 1;
+            (aux_var_info.as_expr(), true)
+        } else {
+            (child, false)
         }
-    }
+    });
 
     // eq: both sides have to be non flat for the rule to be applicable!
     if num_changed != 2 {
         return Err(RuleNotApplicable);
     }
-
-    let expr = expr.with_children(new_children);
 
     Ok(Reduction::new(expr, new_tops, symbols))
 }
@@ -1139,14 +1130,11 @@ fn flatten_matrix_literal(expr: &Expr, symtab: &SymbolTable) -> ApplicationResul
         return Err(RuleNotApplicable);
     }
 
-    // flatten any children that are matrix literals
-    let mut children = expr.children();
-
-    let mut has_changed = false;
     let mut symbols = symtab.clone();
     let mut top_level_exprs = vec![];
 
-    for child in children.iter_mut() {
+    // flatten any children that are matrix literals
+    let (expr, num_changed) = rewrite_children(expr, |child| {
         // is this a matrix literal?
         //
         // as we arn't changing the number of arguments in the matrix, we can apply this to all
@@ -1155,8 +1143,10 @@ fn flatten_matrix_literal(expr: &Expr, symtab: &SymbolTable) -> ApplicationResul
         // this also means that this rule works with n-d matrices -- the inner dimensions of n-d
         // matrices cant be turned into lists, as described the docstring for matrix_to_list.
         let Some((mut es, index_domain)) = child.clone().unwrap_matrix_unchecked() else {
-            continue;
+            return (child, false);
         };
+
+        let mut child_changed = false;
 
         // flatten expressions
         for e in es.iter_mut() {
@@ -1164,7 +1154,7 @@ fn flatten_matrix_literal(expr: &Expr, symtab: &SymbolTable) -> ApplicationResul
                 *e = aux_info.as_expr();
                 top_level_exprs.push(aux_info.top_level_expr());
                 symbols = aux_info.symbols();
-                has_changed = true;
+                child_changed = true;
             } else if let Expr::SafeIndex(_, subject, _) = e
                 && !matches!(**subject, Expr::Atomic(_, Atom::Reference(_)))
             {
@@ -1205,19 +1195,15 @@ fn flatten_matrix_literal(expr: &Expr, symtab: &SymbolTable) -> ApplicationResul
 
                 *e = Expr::Atomic(Metadata::new(), Atom::Reference(Reference::new(decl)));
 
-                has_changed = true;
+                child_changed = true;
             }
         }
 
-        *child = into_matrix_expr!(es;index_domain);
-    }
+        (into_matrix_expr!(es;index_domain), child_changed)
+    });
 
-    if has_changed {
-        Ok(Reduction::new(
-            expr.with_children(children),
-            top_level_exprs,
-            symbols,
-        ))
+    if num_changed != 0 {
+        Ok(Reduction::new(expr, top_level_exprs, symbols))
     } else {
         Err(RuleNotApplicable)
     }

--- a/crates/conjure-cp-rules/src/normalisers/associative_commutative.rs
+++ b/crates/conjure-cp-rules/src/normalisers/associative_commutative.rs
@@ -1,13 +1,12 @@
 //! Generic normalising rules for associative-commutative operators.
 
-use std::collections::VecDeque;
 use std::mem::Discriminant;
 
+use crate::utils::{single_vec_child, with_single_vec_child};
 use conjure_cp::ast::{Expression as Expr, SymbolTable};
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
-use uniplate::Biplate;
 
 /// Normalises associative_commutative operations.
 ///
@@ -34,15 +33,9 @@ fn normalise_associative_commutative(expr: &Expr, _: &SymbolTable) -> Applicatio
             return vec![expr];
         }
 
-        let child_vecs: VecDeque<Vec<Expr>> = expr.children_bi();
-
-        // empty expression
-        if child_vecs.is_empty() {
+        let Some(children) = single_vec_child(&expr) else {
             return vec![expr];
-        }
-
-        // go deeper
-        let children = child_vecs[0].clone();
+        };
         let old_len = children.len();
 
         let new_children = children
@@ -56,8 +49,7 @@ fn normalise_associative_commutative(expr: &Expr, _: &SymbolTable) -> Applicatio
         new_children
     }
 
-    let child_vecs: VecDeque<Vec<Expr>> = expr.children_bi();
-    if child_vecs.is_empty() {
+    if single_vec_child(expr).is_none() {
         return Err(RuleNotApplicable);
     }
 
@@ -68,7 +60,7 @@ fn normalise_associative_commutative(expr: &Expr, _: &SymbolTable) -> Applicatio
         return Err(RuleNotApplicable);
     }
 
-    let new_expr = expr.with_children_bi(vec![new_children].into());
+    let new_expr = with_single_vec_child(expr, new_children);
 
     Ok(Reduction::pure(new_expr))
 }

--- a/crates/conjure-cp-rules/src/normalisers/neg_minus.rs
+++ b/crates/conjure-cp-rules/src/normalisers/neg_minus.rs
@@ -26,6 +26,7 @@
 //!    weightedsumgeq and weightedsumleq constraints. A negated number is just a number
 //!    with a coefficient of -1.
 
+use crate::utils::{single_vec_child, with_single_vec_child};
 use conjure_cp::essence_expr;
 use conjure_cp::{
     ast::Metadata,
@@ -35,8 +36,6 @@ use conjure_cp::{
         ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
     },
 };
-use std::collections::VecDeque;
-use uniplate::{Biplate, Uniplate as _};
 
 /// Eliminates double negation
 ///
@@ -46,10 +45,10 @@ use uniplate::{Biplate, Uniplate as _};
 #[register_rule("Base", 8400, [Neg])]
 fn elmininate_double_negation(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     match expr {
-        Expr::Neg(_, a) if matches!(**a, Expr::Neg(_, _)) => {
-            let first_child: Expr = a.as_ref().children()[0].clone();
-            Ok(Reduction::pure(first_child))
-        }
+        Expr::Neg(_, a) => match a.as_ref() {
+            Expr::Neg(_, inner) => Ok(Reduction::pure(Moo::unwrap_or_clone(inner.clone()))),
+            _ => Err(RuleNotApplicable),
+        },
         _ => Err(RuleNotApplicable),
     }
 }
@@ -66,18 +65,14 @@ fn distribute_negation_over_sum(expr: &Expr, _: &SymbolTable) -> ApplicationResu
         _ => Err(RuleNotApplicable),
     }?;
 
-    let mut child_vecs: VecDeque<Vec<Expr>> = inner_expr.children_bi();
-
-    if child_vecs.is_empty() {
-        return Err(RuleNotApplicable);
-    }
-
-    for child in child_vecs[0].iter_mut() {
+    let mut children = single_vec_child(inner_expr.as_ref()).ok_or(RuleNotApplicable)?;
+    for child in children.iter_mut() {
         *child = essence_expr!(-&child);
     }
 
-    Ok(Reduction::pure(Moo::unwrap_or_clone(
-        inner_expr.with_children_bi(child_vecs),
+    Ok(Reduction::pure(with_single_vec_child(
+        inner_expr.as_ref(),
+        children,
     )))
 }
 

--- a/crates/conjure-cp-rules/src/utils.rs
+++ b/crates/conjure-cp-rules/src/utils.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use conjure_cp::ast::{
     AbstractLiteral, Atom, DeclarationPtr, Expression as Expr, Literal, Metadata, Moo, Name,
     SymbolTable,
@@ -24,12 +26,45 @@ pub fn is_literal(expr: &Expr) -> bool {
 
 /// True if `expr` is flat; i.e. it only contains atoms.
 pub fn is_flat(expr: &Expr) -> bool {
-    for e in expr.children() {
-        if !is_atom(&e) {
-            return false;
-        }
+    expr.children().iter().all(is_atom)
+}
+
+/// Rewrites the direct expression children of `expr`, preserving the number of children.
+///
+/// Returns the rebuilt expression and the number of children marked as changed by `rewrite`.
+pub fn rewrite_children(
+    expr: &Expr,
+    mut rewrite: impl FnMut(Expr) -> (Expr, bool),
+) -> (Expr, usize) {
+    let mut num_changed = 0;
+    let children: VecDeque<Expr> = expr
+        .children()
+        .into_iter()
+        .map(|child| {
+            let (new_child, changed) = rewrite(child);
+            if changed {
+                num_changed += 1;
+            }
+            new_child
+        })
+        .collect();
+
+    (expr.with_children(children), num_changed)
+}
+
+/// Returns the only direct `Vec<Expr>` child of `expr`, if it has exactly one.
+pub fn single_vec_child(expr: &Expr) -> Option<Vec<Expr>> {
+    let mut child_vecs: VecDeque<Vec<Expr>> = expr.children_bi();
+    if child_vecs.len() == 1 {
+        child_vecs.pop_front()
+    } else {
+        None
     }
-    true
+}
+
+/// Rebuilds `expr` with a replacement for its only direct `Vec<Expr>` child.
+pub fn with_single_vec_child(expr: &Expr, child: Vec<Expr>) -> Expr {
+    expr.with_children_bi(VecDeque::from([child]))
 }
 
 /// Returns the arity of a tuple constant expression, if this expression is one.
@@ -59,16 +94,10 @@ pub fn constant_record_names(expr: &Expr) -> Option<Vec<Name>> {
 
 /// True if the entire AST is constants.
 pub fn is_all_constant(expression: &Expr) -> bool {
-    for atom in expression.universe_bi() {
-        match atom {
-            Atom::Literal(_) => {}
-            _ => {
-                return false;
-            }
-        }
-    }
-
-    true
+    expression
+        .universe_bi()
+        .into_iter()
+        .all(|atom| matches!(atom, Atom::Literal(_)))
 }
 
 /// Converts a vector of expressions to a vector of atoms.


### PR DESCRIPTION
this is not exactly what @gskorokhod was suggesting in #1874 - but refactors a couple of other places where we can use Uniplate better. There shouldn't be any functional differences.