### PR TITLE
feat(test-suite): add selective expected-time acceptance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,16 @@ test-accept: install
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
 	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
 
-.PHONY: test-accept-times
-## Runs all tests in accept mode, updates the expected run times, then one more time in normal mode
-test-accept-times: install
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-times cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+.PHONY: test-accept-with-slower-times
+## Runs all tests in accept mode, only increases expected run times, then one more time in normal mode
+test-accept-with-slower-times: install
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+
+.PHONY: test-accept-with-exact-times
+## Runs all tests in accept mode, updates expected run times exactly, then one more time in normal mode
+test-accept-with-exact-times: install
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
 	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
 
 .PHONY: fix

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ CARGO_FEATURES ?=
 CARGO_TARGET_DIR ?= target
 DEV_CONTAINER_IMAGE ?= conjure-oxide-dev
 DEV_CONTAINER_FILE ?= Dockerfile.dev
+CARGO_TEST_WORKSPACE = cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+# Golden files follow the test-suite convention of `.expected` or `-expected-` in the file name.
+# This intentionally ignores config.toml, including expected-time-only changes.
+RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED = if test -n "$$(git status --porcelain -- ':(glob)**/*.expected*' ':(glob)**/*-expected-*')"; then echo "Golden files changed; running tests without ACCEPT"; PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE); else echo "No golden files changed; skipping non-accepting test run"; fi
 
 .PHONY: submodules
 ## Initialises git submodules needed for builds
@@ -53,7 +57,7 @@ install: build
 .PHONY: test
 ## Runs all tests
 test: submodules install
-	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE)
 
 .PHONY: test-coverage
 ## Runs all tests and produces a coverage report
@@ -61,22 +65,22 @@ test-coverage:
 	./tools/coverage.sh
 
 .PHONY: test-accept
-## Runs all tests in accept mode, then one more time in normal mode
+## Runs all tests in accept mode, then in normal mode if golden files changed
 test-accept: install
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
-	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_TEST_WORKSPACE)
+	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-slower-times
-## Runs all tests in accept mode, only increases expected run times, then one more time in normal mode
+## Runs all tests in accept mode, only increases expected run times, then in normal mode if golden files changed
 test-accept-with-slower-times: install
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
-	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_TEST_WORKSPACE)
+	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-exact-times
-## Runs all tests in accept mode, updates expected run times exactly, then one more time in normal mode
+## Runs all tests in accept mode, updates expected run times exactly, then in normal mode if golden files changed
 test-accept-with-exact-times: install
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
-	PATH="$$HOME/.cargo/bin:$$PATH" cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_TEST_WORKSPACE)
+	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: fix
 ## Tries to auto-fix hygiene issues reported by `make check`. 

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -40,6 +40,11 @@ Instead of comparing against the existing JSON files, the test harness will:
 
 `ACCEPT=true` lets you update expected outputs, while still guarding correctness by checking against old Conjure.
 
+To update `expected-time` entries, use `make test-accept-with-slower-times`. This only
+writes a new time when the rounded runtime is slower than the current value, so speedups
+remain visible as diffs. Use `make test-accept-with-exact-times` to overwrite times with
+the current observed runtime.
+
 ### Licence
 
 This project is licenced under the [Mozilla Public Licence

--- a/test-suite/src/accept.rs
+++ b/test-suite/src/accept.rs
@@ -2,9 +2,18 @@ use std::env;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AcceptMode {
+    /// Normal test mode: compare generated files with expected files and do not rewrite fixtures.
     Disabled,
+    /// Rewrite expected output fixtures, but leave expected runtime budgets untouched.
     Accept,
+    /// Rewrite output fixtures and runtime budgets exactly as observed.
     AcceptWithTimes,
+    /// Rewrite output fixtures, but only raise runtime budgets.
+    ///
+    /// Catching slowdowns is more important than automatically accepting speedups. Runtimes
+    /// are non-deterministic and machine/load dependent, so a significant slowdown may be
+    /// worth noticing while a one-off faster run should not lower the recorded budget.
+    AcceptWithSlowerTimes,
 }
 
 impl AcceptMode {
@@ -13,6 +22,8 @@ impl AcceptMode {
             Ok("false") => Self::Disabled,
             Ok("true") => Self::Accept,
             Ok("with-times") => Self::AcceptWithTimes,
+            Ok("with-exact-times") => Self::AcceptWithTimes,
+            Ok("with-slower-times") => Self::AcceptWithSlowerTimes,
             _ => Self::Disabled,
         }
     }
@@ -22,10 +33,20 @@ impl AcceptMode {
     }
 
     pub fn records_expected_time(self) -> bool {
-        matches!(self, Self::AcceptWithTimes)
+        matches!(self, Self::AcceptWithTimes | Self::AcceptWithSlowerTimes)
+    }
+
+    pub fn expected_time_to_record(self, current: Option<u64>, observed: u64) -> Option<u64> {
+        match self {
+            Self::AcceptWithTimes => Some(observed),
+            Self::AcceptWithSlowerTimes if current.is_none_or(|current| observed > current) => {
+                Some(observed)
+            }
+            _ => None,
+        }
     }
 
     pub fn refresh_hint() -> &'static str {
-        "Run with ACCEPT=true or ACCEPT=with-times"
+        "Run with ACCEPT=true, ACCEPT=with-slower-times, or ACCEPT=with-exact-times"
     }
 }

--- a/test-suite/tests/custom_tests.rs
+++ b/test-suite/tests/custom_tests.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Instant;
 use test_suite::AcceptMode;
+use test_suite::TestConfig;
 use test_suite::golden_files::assert_no_redundant_expected_files;
 use test_suite::test_config::{round_expected_time, upsert_expected_time_config};
 
@@ -31,6 +32,12 @@ pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
     );
     let expected_output_path = test_path.join("stdout.expected");
     let expected_error_path = test_path.join("stderr.expected");
+    let config_path = test_path.join("config.toml");
+    let file_config: TestConfig = if let Ok(config_contents) = fs::read_to_string(&config_path) {
+        toml::from_str(&config_contents).unwrap()
+    } else {
+        Default::default()
+    };
 
     // Execute the test script in the correct directory
     let output = Command::new("sh")
@@ -67,8 +74,12 @@ pub fn custom_test(test_dir: &str) -> Result<(), Box<dyn Error>> {
     assert_no_redundant_expected_files(Path::new(&test_path), &allowed_expected_files, None)?;
 
     if accept_mode.records_expected_time() {
-        let expected_time = round_expected_time(started_at.elapsed());
-        upsert_expected_time_config(&test_path.join("config.toml"), expected_time)?;
+        let observed_expected_time = round_expected_time(started_at.elapsed());
+        if let Some(expected_time) =
+            accept_mode.expected_time_to_record(file_config.expected_time, observed_expected_time)
+        {
+            upsert_expected_time_config(&config_path, expected_time)?;
+        }
     }
 
     Ok(())

--- a/test-suite/tests/integration_tests.rs
+++ b/test-suite/tests/integration_tests.rs
@@ -179,9 +179,13 @@ fn integration_test(path: &str, essence_base: &str, extension: &str) -> Result<(
     assert_no_redundant_expected_files(Path::new(path), &allowed_expected_files, None)?;
 
     if accept_mode.records_expected_time() {
-        let expected_time = round_expected_time(started_at.elapsed());
+        let observed_expected_time = round_expected_time(started_at.elapsed());
         let config_path = Path::new(path).join("config.toml");
-        upsert_expected_time_config(&config_path, expected_time)?;
+        if let Some(expected_time) =
+            accept_mode.expected_time_to_record(config.expected_time, observed_expected_time)
+        {
+            upsert_expected_time_config(&config_path, expected_time)?;
+        }
     }
 
     Ok(())

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -39,6 +39,9 @@ then
   exit 1
 fi
 
+# Allow the script to be invoked from any working directory.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 # Setup - enter rust project
 cargo locate-project &>/dev/null || { echo_err "Cannot find a rust project"; usage; exit 1; }
 


### PR DESCRIPTION
- add `ACCEPT=with-slower-times` to only raise `expected-time` values
- add `ACCEPT=with-exact-times` for exact runtime refreshes
- rename make targets to `test-accept-with-slower-times` and `test-accept-with-exact-times`
- skip the second non-accepting test run unless golden files changed

Rationale: Runtime measurements are noisy and machine/load dependent. We mostly want to notice slowdowns, while avoiding churn from one-off faster runs lowering recorded budgets. So we want to run `make test-accept-with-slower-times` locally and check the diff.
