### PR TITLE
refactor: add record indexing expression, remove record fields from symbol table

### DIFF
--- a/crates/conjure-cp-core/src/ast/declaration.rs
+++ b/crates/conjure-cp-core/src/ast/declaration.rs
@@ -2,8 +2,8 @@ use super::categories::{Category, CategoryOf};
 use super::name::Name;
 use super::serde::{DefaultWithId, HasId, IdPtr, ObjId, PtrAsInner};
 use super::{
-    DecisionVariable, DomainPtr, Expression, Field, GroundDomain, HasDomain, Moo, Reference,
-    ReturnType, Typeable,
+    DecisionVariable, DomainPtr, Expression, GroundDomain, HasDomain, Moo, Reference, ReturnType,
+    Typeable,
 };
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
@@ -260,27 +260,6 @@ impl DeclarationPtr {
         DeclarationPtr::new(name, kind)
     }
 
-    /// Creates a new record field declaration.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use conjure_cp_core::ast::{DeclarationPtr,Name,Field,Domain,Range};
-    ///
-    /// // create declaration for field A in `find rec: record {A: int(0..1), B: int(0..2)}`
-    ///
-    /// let field = Field {
-    ///     name: Name::User("n".into()),
-    ///     value: Domain::int(vec![Range::Bounded(1,5)])
-    /// };
-    ///
-    /// let declaration = DeclarationPtr::new_record_field(field);
-    /// ```
-    pub fn new_record_field(entry: Field<DomainPtr>) -> DeclarationPtr {
-        let kind = DeclarationKind::Field(entry.value);
-        DeclarationPtr::new(entry.name, kind)
-    }
-
     /**********************************************/
     /*        Declaration accessor methods        */
     /**********************************************/
@@ -308,7 +287,6 @@ impl DeclarationPtr {
             DeclarationKind::Given(domain) => Some(domain.clone()),
             DeclarationKind::Quantified(inner) => Some(inner.domain.clone()),
             DeclarationKind::QuantifiedExpr(expr) => expr.domain_of(),
-            DeclarationKind::Field(domain) => Some(domain.clone()),
         }
     }
 
@@ -594,7 +572,6 @@ impl CategoryOf for DeclarationPtr {
             DeclarationKind::Given(_) => Category::Parameter,
             DeclarationKind::Quantified(..) => Category::Quantified,
             DeclarationKind::QuantifiedExpr(..) => Category::Quantified,
-            DeclarationKind::Field(_) => Category::Bottom,
         }
     }
 }
@@ -629,7 +606,6 @@ impl Typeable for DeclarationPtr {
             DeclarationKind::Given(domain) => domain.return_type(),
             DeclarationKind::Quantified(inner) => inner.domain.return_type(),
             DeclarationKind::QuantifiedExpr(expr) => expr.return_type(),
-            DeclarationKind::Field(domain) => domain.return_type(),
         }
     }
 }
@@ -744,13 +720,6 @@ fn biplate_declaration_kind_references(
             (
                 tree,
                 Box::new(move |x| DeclarationKind::DomainLetting(recons_domain(x))),
-            )
-        }
-        DeclarationKind::Field(domain) => {
-            let (tree, recons_domain) = biplate_domain_ptr_references(domain);
-            (
-                tree,
-                Box::new(move |x| DeclarationKind::Field(recons_domain(x))),
             )
         }
         DeclarationKind::ValueLetting(expression, domain) => {
@@ -902,10 +871,6 @@ pub enum DeclarationKind {
     ///
     /// Unlike `ValueLetting`, this is not intended to represent a user-visible top-level `letting`.
     TemporaryValueLetting(Expression),
-
-    /// A named field inside a record / variant type.
-    /// e.g. A, B in record{A: int(0..1), B: int(0..2)}
-    Field(DomainPtr),
 }
 
 #[serde_as]

--- a/crates/conjure-cp-core/src/ast/domains/unresolved.rs
+++ b/crates/conjure-cp-core/src/ast/domains/unresolved.rs
@@ -237,7 +237,7 @@ impl IntVal {
                 ReturnType::Int => Some(IntVal::Reference(re.clone())),
                 _ => None,
             },
-            DeclarationKind::DomainLetting(_) | DeclarationKind::Field(_) => None,
+            DeclarationKind::DomainLetting(_) => None,
         }
     }
 
@@ -270,7 +270,7 @@ impl IntVal {
                 DeclarationKind::QuantifiedExpr(_) => None,
                 // Decision variables inside domains are unresolved until solving.
                 DeclarationKind::Find(_) => None,
-                DeclarationKind::DomainLetting(_) | DeclarationKind::Field(_) => bug!(
+                DeclarationKind::DomainLetting(_) => bug!(
                     "Expected integer expression, given, or letting inside int domain; Got: {re}"
                 ),
             },

--- a/crates/conjure-cp-core/src/ast/eval.rs
+++ b/crates/conjure-cp-core/src/ast/eval.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use crate::ast::{
-    AbstractLiteral, Atom, DeclarationKind, Expression as Expr, Literal as Lit, Metadata,
+    AbstractLiteral, Atom, DeclarationKind, Expression as Expr, Field, Literal as Lit, Metadata,
     comprehension::{Comprehension, ComprehensionQualifier},
     matrix,
 };
@@ -138,6 +138,20 @@ pub fn eval_constant(expr: &Expr) -> Option<Lit> {
             eval_constant_comprehension(comprehension.as_ref())
         }
         Expr::AbstractComprehension(_, _) => None,
+        Expr::RecordField(_, rec, fld_name) => {
+            if let Expr::Atomic(
+                _,
+                Atom::Literal(Lit::AbstractLiteral(AbstractLiteral::Record(ents))),
+            ) = rec.as_ref()
+            {
+                for Field { name, value } in ents {
+                    if name.eq(fld_name) {
+                        return Some(value.clone());
+                    }
+                }
+            }
+            None
+        }
         Expr::UnsafeIndex(_, subject, indices) | Expr::SafeIndex(_, subject, indices) => {
             let subject: Lit = eval_constant(subject.as_ref())?;
             let indices: Vec<Lit> = indices

--- a/crates/conjure-cp-core/src/ast/expressions.rs
+++ b/crates/conjure-cp-core/src/ast/expressions.rs
@@ -127,6 +127,16 @@ pub enum Expression {
 
     Atomic(Metadata, Atom),
 
+    /// Asserts that the given variant of a variant expression is in use.
+    /// See also: [GroundDomain::Variant]
+    #[compatible(JsonInput)]
+    Active(Metadata, Moo<Expression>, Name),
+
+    /// Indexing into a record expression, e.g `{foo = 1, bar = true}[foo]`
+    /// See also: [GroundDomain::Record]
+    #[compatible(JsonInput)]
+    RecordField(Metadata, Moo<Expression>, Name),
+
     /// A matrix index.
     ///
     /// Defined iff the indices are within their respective index domains.
@@ -636,10 +646,6 @@ pub enum Expression {
     /// Low-level minion constraint. See Expression::LexLeq
     FlatLexLeq(Metadata, Vec<Atom>, Vec<Atom>),
 
-    /// To tell which field is used in a variant domain
-    #[compatible(JsonInput)]
-    Active(Metadata, Moo<Expression>, Moo<Expression>),
-
     /// Alters the shape of relations by projection
     #[compatible(JsonInput)]
     RelationProj(Metadata, Moo<Expression>, Vec<Option<Expression>>),
@@ -776,6 +782,15 @@ impl Expression {
             Expression::Metavar(_, _) => None,
             Expression::Comprehension(_, comprehension) => comprehension.domain_of(),
             Expression::AbstractComprehension(_, comprehension) => comprehension.domain_of(),
+            Expression::RecordField(_, rec, field_name) => {
+                let rec_ents = rec.domain_of()?.as_record()?;
+                for ent in rec_ents {
+                    if ent.name.eq(field_name) {
+                        return Some(ent.value);
+                    }
+                }
+                None
+            }
             Expression::UnsafeIndex(_, matrix, index) | Expression::SafeIndex(_, matrix, index) => {
                 let dom = matrix.domain_of()?;
                 if let Some((elem_domain, _)) = dom.as_matrix() {
@@ -805,7 +820,9 @@ impl Expression {
                     };
                 }
 
-                bug!("subject of an index operation should support indexing")
+                bug!(
+                    "subject of an index operation should support indexing, but got {matrix}: {dom}"
+                )
             }
             Expression::UnsafeSlice(_, matrix, indices)
             | Expression::SafeSlice(_, matrix, indices) => {
@@ -1562,6 +1579,7 @@ impl Expression {
             FromSolution,
             Metavar,
             Atomic,
+            RecordField,
             UnsafeIndex,
             SafeIndex,
             UnsafeSlice,
@@ -1988,6 +2006,9 @@ impl Display for Expression {
             Expression::Comprehension(_, c) => c.fmt(f),
             Expression::AbstractComprehension(_, c) => c.fmt(f),
             Expression::UnsafeIndex(_, e1, e2) => write!(f, "{e1}{}", pretty_vec(e2)),
+            Expression::RecordField(_, r, fld) => {
+                write!(f, "{r}[{fld}]")
+            }
             Expression::SafeIndex(_, e1, e2) => write!(f, "SafeIndex({e1},{})", pretty_vec(e2)),
             Expression::UnsafeSlice(_, e1, es) => {
                 let args = es
@@ -2288,8 +2309,7 @@ fn minus_operand_return_type(expr: &Expression) -> ReturnType {
             match decl_kind {
                 DeclarationKind::Find(var) => var.return_type(),
                 DeclarationKind::Given(domain)
-                | DeclarationKind::DomainLetting(domain)
-                | DeclarationKind::Field(domain) => domain.return_type(),
+                | DeclarationKind::DomainLetting(domain) => domain.return_type(),
                 DeclarationKind::Quantified(inner) => inner.domain().return_type(),
                 DeclarationKind::QuantifiedExpr(inner)
                 | DeclarationKind::TemporaryValueLetting(inner)
@@ -2314,6 +2334,16 @@ impl Typeable for Expression {
             Expression::Subset(_, _, _) => ReturnType::Bool,
             Expression::SubsetEq(_, _, _) => ReturnType::Bool,
             Expression::AbstractLiteral(_, lit) => lit.return_type(),
+            Expression::RecordField(_, rec, field_name) => {
+                if let ReturnType::Record(ents) = rec.return_type() {
+                    for Field { name, value } in ents {
+                        if name.eq(field_name) {
+                            return value;
+                        }
+                    }
+                }
+                ReturnType::Unknown
+            }
             Expression::UnsafeIndex(_, subject, idx) | Expression::SafeIndex(_, subject, idx) => {
                 let subject_ty = subject.return_type();
                 match subject_ty {
@@ -2658,7 +2688,9 @@ impl Expression {
             | Expression::ToSet(_, m1)
             | Expression::ToMSet(_, m1)
             | Expression::ToRelation(_, m1)
-            | Expression::Card(_, m1) => {
+            | Expression::Card(_, m1)
+            | Expression::RecordField(_, m1, _)
+            | Expression::Active(_, m1, _) => {
                 f(m1);
             }
 
@@ -2702,7 +2734,6 @@ impl Expression {
             | Expression::LexLeq(_, m1, m2)
             | Expression::LexGt(_, m1, m2)
             | Expression::LexGeq(_, m1, m2)
-            | Expression::Active(_, m1, m2)
             | Expression::Subsequence(_, m1, m2)
             | Expression::Substring(_, m1, m2) => {
                 f(m1);
@@ -2928,7 +2959,6 @@ impl CacheHashable for Expression {
             | Expression::LexLeq(_, m1, m2)
             | Expression::LexGt(_, m1, m2)
             | Expression::LexGeq(_, m1, m2)
-            | Expression::Active(_, m1, m2)
             | Expression::Subsequence(_, m1, m2)
             | Expression::Substring(_, m1, m2) => {
                 m1.get_cached_hash().hash(&mut hasher);
@@ -2953,6 +2983,12 @@ impl CacheHashable for Expression {
                         None => 0u64.hash(&mut hasher),
                     }
                 }
+            }
+
+            // Moo<Expression> + Name
+            Expression::RecordField(_, m, n) | Expression::Active(_, m, n) => {
+                m.get_cached_hash().hash(&mut hasher);
+                n.hash(&mut hasher);
             }
 
             // Moo<Expression> + DomainPtr

--- a/crates/conjure-cp-core/src/ast/model.rs
+++ b/crates/conjure-cp-core/src/ast/model.rs
@@ -419,9 +419,6 @@ impl Display for Model {
                 DeclarationKind::QuantifiedExpr(expr) => {
                     writeln!(f, "quantified expr {name} <- {}", expr)?;
                 }
-                DeclarationKind::Field(_) => {
-                    // We do not want to print anything, as it will be in the domains
-                }
             }
         }
 

--- a/crates/conjure-cp-core/src/ast/partial_eval.rs
+++ b/crates/conjure-cp-core/src/ast/partial_eval.rs
@@ -224,6 +224,7 @@ pub fn run_partial_evaluator(expr: &Expr) -> ApplicationResult {
         Expr::UnsafeSlice(_, _, _) => Err(RuleNotApplicable),
         Expr::Table(_, _, _) => Err(RuleNotApplicable),
         Expr::NegativeTable(_, _, _) => Err(RuleNotApplicable),
+        Expr::RecordField(_, _, _) => Err(RuleNotApplicable),
         Expr::SafeIndex(_, subject, indices) => {
             // partially evaluate matrix literals indexed by a constant.
 

--- a/crates/conjure-cp-core/src/parse/parse_model.rs
+++ b/crates/conjure-cp-core/src/parse/parse_model.rs
@@ -444,16 +444,6 @@ fn parse_domain(
                 entries.push(rec);
             }
 
-            // add fields to symbol table
-            for decl in entries
-                .iter()
-                .cloned()
-                .map(DeclarationPtr::new_record_field)
-            {
-                symbols.insert(decl).ok_or(error!(
-                    "record field should not already be in the symbol table"
-                ))?;
-            }
             if is_record {
                 Ok(Domain::record(entries))
             } else {
@@ -792,7 +782,6 @@ fn binary_operator(op_name: &str) -> Option<BinOp> {
         "MkOpApart" => Some(Expression::Apart),
         "MkOpTogether" => Some(Expression::Together),
         "MkOpParty" => Some(Expression::Party),
-        "MkOpActive" => Some(Expression::Active),
         "MkOpSubstring" => Some(Expression::Substring),
         "MkOpSubsequence" => Some(Expression::Subsequence),
         _ => None,
@@ -838,6 +827,31 @@ fn unary_operator(op_name: &str, inner: Option<&Expression>) -> Option<UnaryOp> 
     }
 }
 
+fn parse_reference_name(obj: &JsonValue) -> Result<Name> {
+    // { Name: "x" } directly
+    if let Some(name) = obj.get("Name").and_then(|x| x.as_str()) {
+        return Ok(Name::User(Ustr::from(name)));
+    }
+
+    // {
+    //   Reference: [
+    //     { Name: "x" }
+    //   ]
+    // }
+    let ref_arr = obj["Reference"]
+        .as_array()
+        .ok_or_else(|| error!("Reference.as_array"))?;
+    let ref_obj = ref_arr
+        .first()
+        .and_then(|x| x.as_object())
+        .ok_or_else(|| error!("Reference[0].as_object"))?;
+    let name = ref_obj
+        .get("Name")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| error!("Reference[0].Name.as_str"))?;
+    Ok(Name::User(Ustr::from(name)))
+}
+
 pub fn parse_expression(obj: &JsonValue, scope: &SymbolTablePtr) -> Result<Expression> {
     let fail = |stage: &str| -> Error {
         Error::Parse(format!(
@@ -859,6 +873,8 @@ pub fn parse_expression(obj: &JsonValue, scope: &SymbolTablePtr) -> Result<Expre
                 parse_table_op(op_obj, scope)
             } else if op_obj.contains_key("MkOpIndexing") || op_obj.contains_key("MkOpSlicing") {
                 parse_indexing_slicing_op(op_obj, scope)
+            } else if op_obj.contains_key("MkOpActive") {
+                parse_active_op(op_obj, scope)
             } else if op_obj.contains_key("MkOpRelationProj") {
                 parse_relation_projection(op_obj, scope)
             } else if op_obj.contains_key("MkOpToSet") {
@@ -875,18 +891,7 @@ pub fn parse_expression(obj: &JsonValue, scope: &SymbolTablePtr) -> Result<Expre
             parse_comprehension(comprehension, scope.clone(), None)
         }
         Value::Object(refe) if refe.contains_key("Reference") => {
-            let ref_arr = refe["Reference"]
-                .as_array()
-                .ok_or_else(|| fail("Reference.as_array"))?;
-            let ref_obj = ref_arr
-                .first()
-                .and_then(|x| x.as_object())
-                .ok_or_else(|| fail("Reference[0].as_object"))?;
-            let name = ref_obj
-                .get("Name")
-                .and_then(|x| x.as_str())
-                .ok_or_else(|| fail("Reference[0].Name.as_str"))?;
-            let user_name = Name::User(Ustr::from(name));
+            let user_name = parse_reference_name(obj)?;
 
             let declaration: DeclarationPtr = scope
                 .read()
@@ -1325,6 +1330,55 @@ fn parse_table_op(
     ))
 }
 
+/// If LHS is a record/variant and RHS is a field name,
+/// returns Ok(Some(record_expr, field_name)).
+/// If LHS is any other type, return Ok(None).
+fn parse_record_field(
+    op_args: &[Value],
+    scope: &SymbolTablePtr,
+) -> Result<Option<(Expression, Name)>> {
+    if op_args.len() != 2 {
+        return Err(error!("Expected 2 arguments to record indexing operation"));
+    }
+
+    let lhs = parse_expression(&op_args[0], scope)?;
+    match lhs.return_type() {
+        // If indexing into a record, parse string field name
+        // and check that such a field exists
+        ReturnType::Record(ents) | ReturnType::Variant(ents) => {
+            let field_name = parse_reference_name(&op_args[1])?;
+            let has_name = ents.iter().any(|x| x.name.eq(&field_name));
+            if !has_name {
+                return Err(error!(format!(
+                    "Unknown field `{field_name}` in record `{lhs}`"
+                )));
+            }
+            Ok(Some((lhs, field_name)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_active_op(
+    op: &serde_json::Map<String, Value>,
+    scope: &SymbolTablePtr,
+) -> Result<Expression> {
+    // we know there is a single key value pair in this object
+    // extract the value, ignore the key
+    let (_, value) = op
+        .into_iter()
+        .next()
+        .ok_or(error!("MkOpActive op object is empty"))?;
+
+    let Value::Array(op_args) = &value else {
+        return Err(error!("MkOpActive op array is not an array"));
+    };
+    let Some((lhs, rhs)) = parse_record_field(op_args, scope)? else {
+        return Err(error!("MkOpActive op expected record or variant"));
+    };
+    Ok(Expression::Active(Metadata::new(), Moo::new(lhs), rhs))
+}
+
 fn parse_indexing_slicing_op(
     op: &serde_json::Map<String, Value>,
     scope: &SymbolTablePtr,
@@ -1355,7 +1409,15 @@ fn parse_indexing_slicing_op(
             match &value {
                 Value::Array(op_args) if op_args.len() == 2 => {
                     target = parse_expression(&op_args[0], scope)?;
-                    indices.push(Some(parse_expression(&op_args[1], scope)?));
+
+                    match parse_record_field(op_args, scope)? {
+                        // For record indexing, generate nested RecordField exprs
+                        Some((lhs, rhs)) => {
+                            target = Expression::RecordField(Metadata::new(), Moo::new(lhs), rhs)
+                        }
+                        // Append any other indices to the flat list as normal
+                        _ => indices.push(Some(parse_expression(&op_args[1], scope)?)),
+                    }
                 }
                 _ => return Err(error!("Unknown object inside MkOpIndexing")),
             };
@@ -1365,6 +1427,7 @@ fn parse_indexing_slicing_op(
             all_known = false;
             match &value {
                 Value::Array(op_args) if op_args.len() == 3 => {
+                    // NB: records can't be sliced into so no need to check!
                     target = parse_expression(&op_args[0], scope)?;
                     indices.push(None);
                 }
@@ -1393,6 +1456,11 @@ fn parse_indexing_slicing_op(
                 break;
             }
         }
+    }
+
+    // If we had a record field and no other indices, the list will be empty
+    if indices.is_empty() {
+        return Ok(target);
     }
 
     indices.reverse();
@@ -1706,5 +1774,58 @@ fn parse_constant(
             Err(error!(format!("Unhandled parse_constant {constant:#?}")))
         }
         otherwise => Err(error!(format!("Unhandled parse_constant {otherwise:#?}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::HasDomain;
+    use serde_json::json;
+
+    #[test]
+    fn parses_record_index() {
+        let scope = SymbolTablePtr::new();
+        scope.write().insert(DeclarationPtr::new_find(
+            Name::user("x"),
+            Domain::record(vec![Field {
+                name: Name::user("a"),
+                value: Domain::bool(),
+            }]),
+        ));
+
+        let value = json!({
+            "Op": {
+                "MkOpIndexing": [
+                    {
+                        "Reference": [
+                            {
+                                "Name": "x"
+                            },
+                            null
+                        ]
+                    },
+                    {
+                        "Reference": [
+                            {
+                                "Name": "a"
+                            },
+                            null
+                        ]
+                    }
+                ]
+            }
+        });
+
+        let expr = parse_expression(&value, &scope).expect("record index should parse");
+        let Expression::RecordField(_, rec_expr, field_name) = expr else {
+            panic!("expected record field access");
+        };
+        let Expression::Atomic(_, Atom::Reference(re)) = rec_expr.as_ref() else {
+            panic!("expected LHS to be a record reference");
+        };
+        assert_eq!(re.name().clone(), Name::user("x"));
+        assert!(re.domain_of().as_record().is_some());
+        assert_eq!(field_name, Name::user("a"));
     }
 }

--- a/crates/conjure-cp-essence-parser/src/parser/atom.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/atom.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::diagnostics::diagnostics_api::SymbolKind;
 use crate::diagnostics::source_map::{HoverInfo, span_with_hover};
 use crate::errors::{FatalParseError, RecoverableParseError};
@@ -8,9 +10,12 @@ use crate::parser::comprehension::parse_comprehension;
 use crate::parser::dominance::parse_pareto_expression;
 use crate::util::{TypecheckingContext, named_children};
 use crate::{field, named_child};
+
 use conjure_cp_core::ast::{
     Atom, DeclarationKind, DeclarationPtr, Expression, GroundDomain, Literal, Metadata, Moo, Name,
+    ReturnType, Typeable,
 };
+
 use tree_sitter::Node;
 use ustr::Ustr;
 
@@ -215,18 +220,43 @@ fn parse_index_or_slice(
     // Save current context and temporarily set to Unknown for the collection
     let saved_context = ctx.typechecking_context;
     ctx.typechecking_context = TypecheckingContext::Unknown;
-    let Some(collection_node) = field!(recover, ctx, node, "collection") else {
-        return Ok(None);
-    };
-    let Some(collection) = parse_atom(ctx, &collection_node)? else {
-        return Ok(None);
-    };
+    let mut collection: Expression;
+    match parse_atom(ctx, &field!(node, "collection"))? {
+        Some(expr) => collection = expr,
+        None => return Ok(None),
+    }
     ctx.typechecking_context = saved_context;
+
+    let indices_field = field!(node, "indices");
+    let mut idx_nodes = named_children(&indices_field).collect::<VecDeque<_>>();
+
+    // If LHS is a record, parse first index as a record field
+    if let ReturnType::Record(ents) = collection.return_type() {
+        let idx = idx_nodes
+            .pop_front()
+            .ok_or(FatalParseError::internal_error(
+                "Expected at least one indexing expression".into(),
+                Some(indices_field.range()),
+            ))?;
+        let name = Name::user(ctx.source_code[idx.start_byte()..idx.end_byte()].trim());
+        let has_name = ents.iter().any(|e| e.name == name);
+        if !has_name {
+            return Err(FatalParseError::internal_error(
+                format!("`{name}` is not a valid field name for `{collection}`"),
+                Some(idx.range()),
+            ));
+        }
+        collection = Expression::RecordField(Metadata::new(), Moo::new(collection), name);
+
+        // If there are no more indices, return the record field directly
+        if idx_nodes.is_empty() {
+            return Ok(Some(collection));
+        }
+    }
+
+    // Parse the rest of the indices as normal
     let mut indices = Vec::new();
-    let Some(indices_node) = field!(recover, ctx, node, "indices") else {
-        return Ok(None);
-    };
-    for idx_node in named_children(&indices_node) {
+    for idx_node in idx_nodes {
         indices.push(parse_index(ctx, &idx_node)?);
     }
 
@@ -298,7 +328,6 @@ fn parse_variable(ctx: &mut ParseContext, node: &Node) -> Result<Option<Atom>, F
                 DeclarationKind::DomainLetting(_) => SymbolKind::LettingVar,
                 DeclarationKind::Quantified(..) => SymbolKind::FindVar,
                 DeclarationKind::QuantifiedExpr(..) => SymbolKind::FindVar,
-                DeclarationKind::Field(_) => SymbolKind::Decimal,
                 &_ => todo!(),
             };
 

--- a/crates/conjure-cp-essence-parser/src/parser/dominance.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/dominance.rs
@@ -246,7 +246,6 @@ fn rewrite_references(expr: &Expression, to_previous_solution: bool) -> Expressi
                         | DeclarationKind::Quantified(_)
                         | DeclarationKind::QuantifiedExpr(_)
                         | DeclarationKind::DomainLetting(_)
-                        | DeclarationKind::Field(_)
                         | _ => ReferenceRewriteAction::LeaveAsIs,
                     }
                 };

--- a/crates/conjure-cp-essence-parser/src/parser/letting.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/letting.rs
@@ -112,14 +112,6 @@ pub fn parse_letting_statement(
                     continue;
                 };
 
-                // If it's a record domain, add the field names to the symbol table
-                if let Some(entries) = domain.as_record() {
-                    for entry in entries {
-                        // Add each field name as a record field declaration
-                        symbol_table.insert(DeclarationPtr::new_record_field(entry.clone()));
-                    }
-                }
-
                 symbol_table.insert(DeclarationPtr::new_domain_letting(Name::user(name), domain));
             }
         } else {

--- a/crates/conjure-cp-rules/src/records.rs
+++ b/crates/conjure-cp-rules/src/records.rs
@@ -3,7 +3,6 @@ use conjure_cp::ast::GroundDomain;
 use conjure_cp::ast::Moo;
 use conjure_cp::ast::SymbolTable;
 use conjure_cp::into_matrix_expr;
-use conjure_cp::matrix_expr;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, Reduction, register_rule,
 };
@@ -16,21 +15,16 @@ use conjure_cp::ast::Name;
 use conjure_cp::rule_engine::ApplicationError;
 use itertools::izip;
 
-//takes a safe index expression and converts it to an atom via the representation rules
-#[register_rule("Base", 2000, [SafeIndex])]
+// takes a record field access and converts it to an atom via the representation rules
+#[register_rule("Base", 2000, [RecordField])]
 fn index_record_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
-    // annoyingly, let chaining only works in if-lets, not let-elses,otherwise I could avoid the
+    // annoyingly, let chaining only works in if-lets, not let-elses, otherwise I could avoid the
     // indentation here!
-    if let Expr::SafeIndex(_, subject, indices) = expr
+    if let Expr::RecordField(_, subject, field_name) = expr
         && let Expr::Atomic(_, Atom::Reference(decl)) = &**subject
         && let Name::WithRepresentation(name, reprs) = &decl.name() as &Name
     {
         if reprs.first().is_none_or(|x| x.as_str() != "record_to_atom") {
-            return Err(RuleNotApplicable);
-        }
-
-        // tuples are always one dimensional
-        if indices.len() != 1 {
             return Err(RuleNotApplicable);
         }
 
@@ -39,23 +33,19 @@ fn index_record_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult
             .unwrap()[0]
             .clone();
 
-        let Some(GroundDomain::Record(_)) = decl.resolved_domain().as_deref() else {
+        // bind the domain to a variable so the borrowed entries outlive this statement
+        let domain = decl.resolved_domain();
+        let Some(GroundDomain::Record(entries)) = domain.as_deref() else {
             return Err(RuleNotApplicable);
         };
 
-        assert_eq!(
-            indices.len(),
-            1,
-            "record indexing is always one dimensional"
-        );
-
-        let index = indices[0].clone();
-
-        // during the conversion from unsafe index to safe index in bubbling
-        // we convert the field name to a literal integer for direct access
-        let Some(index) = index.into_literal() else {
-            return Err(RuleNotApplicable); // we don't support non-literal indices
+        // find the numerical index of the field name in the record, and convert it to an integer
+        // literal for direct access (the representation indexes its variables by integer)
+        let Some(idx) = entries.iter().position(|entry| &entry.name == field_name) else {
+            return Err(RuleNotApplicable);
         };
+
+        let index = Literal::Int(idx as i32 + 1);
 
         let indices_as_name = Name::Represented(Box::new((
             name.as_ref().clone(),
@@ -66,88 +56,6 @@ fn index_record_to_atom(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult
         let subject = repr.expression_down(symbols)?[&indices_as_name].clone();
 
         Ok(Reduction::pure(subject))
-    } else {
-        Err(RuleNotApplicable)
-    }
-}
-
-#[register_rule("Bubble", 8000, [UnsafeIndex])]
-fn record_index_to_bubble(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
-    // annoyingly, let chaining only works in if-lets, not let-elses,otherwise I could avoid the
-    // indentation here!
-    if let Expr::UnsafeIndex(_, subject, indices) = expr
-        && let Expr::Atomic(_, Atom::Reference(decl)) = &**subject
-        && let Name::WithRepresentation(_, reprs) = &decl.name() as &Name
-    {
-        if reprs.first().is_none_or(|x| x.as_str() != "record_to_atom") {
-            return Err(RuleNotApplicable);
-        }
-
-        let domain = subject
-            .domain_of()
-            .ok_or(ApplicationError::DomainError)?
-            .resolve()
-            .ok_or(ApplicationError::DomainError)?;
-
-        let GroundDomain::Record(elems) = domain.as_ref() else {
-            return Err(RuleNotApplicable);
-        };
-
-        assert_eq!(
-            indices.len(),
-            1,
-            "record indexing is always one dimensional"
-        );
-
-        let index = indices[0].clone();
-
-        let Expr::Atomic(_, Atom::Reference(decl)) = index else {
-            return Err(RuleNotApplicable);
-        };
-
-        let name: &Name = &decl.name();
-
-        // find what numerical index in elems matches the entry name
-        let Some(idx) = elems.iter().position(|x| &x.name == name) else {
-            return Err(RuleNotApplicable);
-        };
-
-        // converting to an integer for direct access
-        let idx = Expr::Atomic(Metadata::new(), Atom::Literal(Literal::Int(idx as i32 + 1)));
-
-        let bubble_constraint = Moo::new(Expression::And(
-            Metadata::new(),
-            Moo::new(matrix_expr![
-                Expression::Leq(
-                    Metadata::new(),
-                    Moo::new(idx.clone()),
-                    Moo::new(Expression::Atomic(
-                        Metadata::new(),
-                        Atom::Literal(Literal::Int(elems.len() as i32))
-                    ))
-                ),
-                Expression::Geq(
-                    Metadata::new(),
-                    Moo::new(idx.clone()),
-                    Moo::new(Expression::Atomic(
-                        Metadata::new(),
-                        Atom::Literal(Literal::Int(1))
-                    ))
-                )
-            ]),
-        ));
-
-        let new_expr = Moo::new(Expression::SafeIndex(
-            Metadata::new(),
-            subject.clone(),
-            Vec::from([idx]),
-        ));
-
-        Ok(Reduction::pure(Expression::Bubble(
-            Metadata::new(),
-            new_expr,
-            bubble_constraint,
-        )))
     } else {
         Err(RuleNotApplicable)
     }
@@ -184,23 +92,11 @@ fn record_equality(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     {
         let mut equality_constraints = vec![];
         // unroll the equality into equality constraints for each field
-        for i in 0..entries.len() {
-            let left_elem = Expression::SafeIndex(
-                Metadata::new(),
-                Moo::clone(left),
-                vec![Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Int((i + 1) as i32)),
-                )],
-            );
-            let right_elem = Expression::SafeIndex(
-                Metadata::new(),
-                Moo::clone(right),
-                vec![Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Int((i + 1) as i32)),
-                )],
-            );
+        for entry in entries {
+            let left_elem =
+                Expression::RecordField(Metadata::new(), Moo::clone(left), entry.name.clone());
+            let right_elem =
+                Expression::RecordField(Metadata::new(), Moo::clone(right), entry.name.clone());
 
             equality_constraints.push(Expression::Eq(
                 Metadata::new(),
@@ -250,23 +146,11 @@ fn record_to_const(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
             }
         }
         let mut equality_constraints = vec![];
-        for i in 0..entries.len() {
-            let left_elem = Expression::SafeIndex(
-                Metadata::new(),
-                Moo::clone(left),
-                vec![Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Int((i + 1) as i32)),
-                )],
-            );
-            let right_elem = Expression::SafeIndex(
-                Metadata::new(),
-                Moo::clone(right),
-                vec![Expression::Atomic(
-                    Metadata::new(),
-                    Atom::Literal(Literal::Int((i + 1) as i32)),
-                )],
-            );
+        for entry in entries {
+            let left_elem =
+                Expression::RecordField(Metadata::new(), Moo::clone(left), entry.name.clone());
+            let right_elem =
+                Expression::RecordField(Metadata::new(), Moo::clone(right), entry.name.clone());
 
             equality_constraints.push(Expression::Eq(
                 Metadata::new(),

--- a/test-suite/tests/custom/rule-trace-verbose/01/stdout.expected
+++ b/test-suite/tests/custom/rule-trace-verbose/01/stdout.expected
@@ -11,7 +11,7 @@ such that
 or([(class#matrix_to_atom_3 != class#matrix_to_atom_4),(class#matrix_to_atom_4 != class#matrix_to_atom_5),(class#matrix_to_atom_5 != class#matrix_to_atom_3);int(1..)])
 
 85
-313821
+309614
 letting n be 10
 find class: matrix indexed by [int(1..n)] of int(1..2)
 find class#matrix_to_atom_1: int(1..2)
@@ -31,4 +31,4 @@ or([(class#matrix_to_atom_3 != class#matrix_to_atom_4),(class#matrix_to_atom_4 !
 or([(class#matrix_to_atom_6 != class#matrix_to_atom_8),(class#matrix_to_atom_8 != class#matrix_to_atom_10),(class#matrix_to_atom_10 != class#matrix_to_atom_6);int(1..)])
 
 92
-388557
+383276

--- a/test-suite/tests/integration/basic/record/01-records/tree-sitter-morph-via-solver-ac-minion-expected-rule-trace.txt
+++ b/test-suite/tests/integration/basic/record/01-records/tree-sitter-morph-via-solver-ac-minion-expected-rule-trace.txt
@@ -29,9 +29,9 @@ find z#record_to_atom_2: int(0..9)
 
 such that
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
 Reify(z#record_to_atom_1, y#record_to_atom_1),
 (y#record_to_atom_2 = z#record_to_atom_2)

--- a/test-suite/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/test-suite/tests/integration/basic/record/01-records/tree-sitter-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -35,45 +35,9 @@ new variables:
 
 --
 
-x#record_to_atom[a], 
-   ~~> record_index_to_bubble ([("Bubble", 8000)])
-{SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])}
-
---
-
-({SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
-(x[b] = 3),
-(y = record {a = false,b = 4}),
-(y = z), 
-   ~~> constant_evaluator ([("Constant", 9001)])
-(SafeIndex(x#record_to_atom,[1]) = true),
-(x[b] = 3),
-(y = record {a = false,b = 4}),
-(y = z)
-
---
-
 x, 
    ~~> select_representation ([("Representations", 8000)])
 x#record_to_atom
-
---
-
-x#record_to_atom[b], 
-   ~~> record_index_to_bubble ([("Bubble", 8000)])
-{SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])}
-
---
-
-(SafeIndex(x#record_to_atom,[1]) = true),
-({SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = record {a = false,b = 4}),
-(y = z), 
-   ~~> constant_evaluator ([("Constant", 9001)])
-(SafeIndex(x#record_to_atom,[1]) = true),
-(SafeIndex(x#record_to_atom,[2]) = 3),
-(y = record {a = false,b = 4}),
-(y = z)
 
 --
 
@@ -101,19 +65,19 @@ new variables:
 
 --
 
-SafeIndex(x#record_to_atom,[1]), 
+(x#record_to_atom[a] = true), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(x#record_to_atom[a], true)
+
+--
+
+x#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 x#record_to_atom_1
 
 --
 
-(x#record_to_atom_1 = true), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(true, x#record_to_atom_1)
-
---
-
-SafeIndex(x#record_to_atom,[2]), 
+x#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 x#record_to_atom_2
 
@@ -121,36 +85,36 @@ x#record_to_atom_2
 
 (y#record_to_atom = record {a = false,b = 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)])
+and([(y#record_to_atom[a] = record {a = false,b = 4}[a]),(y#record_to_atom[b] = record {a = false,b = 4}[b]);int(1..)])
 
 --
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)]),
+and([(y#record_to_atom[a] = record {a = false,b = 4}[a]),(y#record_to_atom[b] = record {a = false,b = 4}[b]);int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-(SafeIndex(y#record_to_atom,[1]) = false),
-(SafeIndex(y#record_to_atom,[2]) = 4),
+(y#record_to_atom[a] = false),
+(y#record_to_atom[b] = 4),
 (y#record_to_atom = z#record_to_atom)
 
 --
 
-SafeIndex(y#record_to_atom,[1]), 
+(y#record_to_atom[a] = false), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(y#record_to_atom[a], false)
+
+--
+
+y#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_1
 
 --
 
-(y#record_to_atom_1 = false), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(false, y#record_to_atom_1)
-
---
-
-SafeIndex(y#record_to_atom,[2]), 
+y#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_2
 
@@ -158,50 +122,50 @@ y#record_to_atom_2
 
 (y#record_to_atom = z#record_to_atom), 
    ~~> record_equality ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]));int(1..)])
+and([(y#record_to_atom[a] = z#record_to_atom[a]),(y#record_to_atom[b] = z#record_to_atom[b]);int(1..)])
 
 --
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]));int(1..)]), 
+and([(y#record_to_atom[a] = z#record_to_atom[a]),(y#record_to_atom[b] = z#record_to_atom[b]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
-(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),
-(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]))
+(y#record_to_atom[a] = z#record_to_atom[a]),
+(y#record_to_atom[b] = z#record_to_atom[b])
 
 --
 
-SafeIndex(y#record_to_atom,[1]), 
+y#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_1
 
 --
 
-SafeIndex(z#record_to_atom,[1]), 
+(y#record_to_atom_1 = z#record_to_atom[a]), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(z#record_to_atom[a], y#record_to_atom_1)
+
+--
+
+z#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 z#record_to_atom_1
 
 --
 
-(y#record_to_atom_1 = z#record_to_atom_1), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(z#record_to_atom_1, y#record_to_atom_1)
-
---
-
-SafeIndex(y#record_to_atom,[2]), 
+y#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_2
 
 --
 
-SafeIndex(z#record_to_atom,[2]), 
+z#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 z#record_to_atom_2
 
@@ -222,9 +186,9 @@ find z#record_to_atom_2: int(0..9)
 
 such that
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
 Reify(z#record_to_atom_1, y#record_to_atom_1),
 (y#record_to_atom_2 = z#record_to_atom_2)

--- a/test-suite/tests/integration/basic/record/01-records/via-conjure-morph-via-solver-ac-minion-expected-rule-trace.txt
+++ b/test-suite/tests/integration/basic/record/01-records/via-conjure-morph-via-solver-ac-minion-expected-rule-trace.txt
@@ -29,9 +29,9 @@ find z#record_to_atom_2: int(0..9)
 
 such that
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
 Reify(z#record_to_atom_1, y#record_to_atom_1),
 (y#record_to_atom_2 = z#record_to_atom_2)

--- a/test-suite/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
+++ b/test-suite/tests/integration/basic/record/01-records/via-conjure-naive-via-solver-ac-minion-expected-rule-trace.txt
@@ -35,45 +35,9 @@ new variables:
 
 --
 
-x#record_to_atom[a], 
-   ~~> record_index_to_bubble ([("Bubble", 8000)])
-{SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])}
-
---
-
-({SafeIndex(x#record_to_atom,[1]) @ and([(1 <= 2),(1 >= 1);int(1..)])} = true),
-(x[b] = 3),
-(y = record {a = false,b = 4}),
-(y = z), 
-   ~~> constant_evaluator ([("Constant", 9001)])
-(SafeIndex(x#record_to_atom,[1]) = true),
-(x[b] = 3),
-(y = record {a = false,b = 4}),
-(y = z)
-
---
-
 x, 
    ~~> select_representation ([("Representations", 8000)])
 x#record_to_atom
-
---
-
-x#record_to_atom[b], 
-   ~~> record_index_to_bubble ([("Bubble", 8000)])
-{SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])}
-
---
-
-(SafeIndex(x#record_to_atom,[1]) = true),
-({SafeIndex(x#record_to_atom,[2]) @ and([(2 <= 2),(2 >= 1);int(1..)])} = 3),
-(y = record {a = false,b = 4}),
-(y = z), 
-   ~~> constant_evaluator ([("Constant", 9001)])
-(SafeIndex(x#record_to_atom,[1]) = true),
-(SafeIndex(x#record_to_atom,[2]) = 3),
-(y = record {a = false,b = 4}),
-(y = z)
 
 --
 
@@ -101,19 +65,19 @@ new variables:
 
 --
 
-SafeIndex(x#record_to_atom,[1]), 
+(x#record_to_atom[a] = true), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(x#record_to_atom[a], true)
+
+--
+
+x#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 x#record_to_atom_1
 
 --
 
-(x#record_to_atom_1 = true), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(true, x#record_to_atom_1)
-
---
-
-SafeIndex(x#record_to_atom,[2]), 
+x#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 x#record_to_atom_2
 
@@ -121,36 +85,36 @@ x#record_to_atom_2
 
 (y#record_to_atom = record {a = false,b = 4}), 
    ~~> record_to_const ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)])
+and([(y#record_to_atom[a] = record {a = false,b = 4}[a]),(y#record_to_atom[b] = record {a = false,b = 4}[b]);int(1..)])
 
 --
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(record {a = false,b = 4},[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(record {a = false,b = 4},[2]));int(1..)]),
+and([(y#record_to_atom[a] = record {a = false,b = 4}[a]),(y#record_to_atom[b] = record {a = false,b = 4}[b]);int(1..)]),
 (y#record_to_atom = z#record_to_atom), 
    ~~> constant_evaluator ([("Constant", 9001)])
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-(SafeIndex(y#record_to_atom,[1]) = false),
-(SafeIndex(y#record_to_atom,[2]) = 4),
+(y#record_to_atom[a] = false),
+(y#record_to_atom[b] = 4),
 (y#record_to_atom = z#record_to_atom)
 
 --
 
-SafeIndex(y#record_to_atom,[1]), 
+(y#record_to_atom[a] = false), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(y#record_to_atom[a], false)
+
+--
+
+y#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_1
 
 --
 
-(y#record_to_atom_1 = false), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(false, y#record_to_atom_1)
-
---
-
-SafeIndex(y#record_to_atom,[2]), 
+y#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_2
 
@@ -158,50 +122,50 @@ y#record_to_atom_2
 
 (y#record_to_atom = z#record_to_atom), 
    ~~> record_equality ([("Base", 2000)])
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]));int(1..)])
+and([(y#record_to_atom[a] = z#record_to_atom[a]),(y#record_to_atom[b] = z#record_to_atom[b]);int(1..)])
 
 --
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
-and([(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]));int(1..)]), 
+and([(y#record_to_atom[a] = z#record_to_atom[a]),(y#record_to_atom[b] = z#record_to_atom[b]);int(1..)]), 
    ~~> constant_evaluator ([("Constant", 9001)])
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
-(SafeIndex(y#record_to_atom,[1]) = SafeIndex(z#record_to_atom,[1])),
-(SafeIndex(y#record_to_atom,[2]) = SafeIndex(z#record_to_atom,[2]))
+(y#record_to_atom[a] = z#record_to_atom[a]),
+(y#record_to_atom[b] = z#record_to_atom[b])
 
 --
 
-SafeIndex(y#record_to_atom,[1]), 
+y#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_1
 
 --
 
-SafeIndex(z#record_to_atom,[1]), 
+(y#record_to_atom_1 = z#record_to_atom[a]), 
+   ~~> bool_eq_to_reify ([("Minion", 4400)])
+Reify(z#record_to_atom[a], y#record_to_atom_1)
+
+--
+
+z#record_to_atom[a], 
    ~~> index_record_to_atom ([("Base", 2000)])
 z#record_to_atom_1
 
 --
 
-(y#record_to_atom_1 = z#record_to_atom_1), 
-   ~~> bool_eq_to_reify ([("Minion", 4400)])
-Reify(z#record_to_atom_1, y#record_to_atom_1)
-
---
-
-SafeIndex(y#record_to_atom,[2]), 
+y#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 y#record_to_atom_2
 
 --
 
-SafeIndex(z#record_to_atom,[2]), 
+z#record_to_atom[b], 
    ~~> index_record_to_atom ([("Base", 2000)])
 z#record_to_atom_2
 
@@ -222,9 +186,9 @@ find z#record_to_atom_2: int(0..9)
 
 such that
 
-Reify(true, x#record_to_atom_1),
+Reify(x#record_to_atom_1, true),
 (x#record_to_atom_2 = 3),
-Reify(false, y#record_to_atom_1),
+Reify(y#record_to_atom_1, false),
 (y#record_to_atom_2 = 4),
 Reify(z#record_to_atom_1, y#record_to_atom_1),
 (y#record_to_atom_2 = z#record_to_atom_2)

--- a/test-suite/tests/roundtrip/invalid/semantic/params/06/via-conjure.expected-error.txt
+++ b/test-suite/tests/roundtrip/invalid/semantic/params/06/via-conjure.expected-error.txt
@@ -1,2 +1,2 @@
-Internal parser error:  DomainInt[1] contains an unknown object | File: crates/conjure-cp-core/src/parse/parse_model.rs | Function: conjure_cp_core::parse::parse_model | Line: 736
+Internal parser error:  DomainInt[1] contains an unknown object | File: crates/conjure-cp-core/src/parse/parse_model.rs | Function: conjure_cp_core::parse::parse_model | Line: 726
 This indicates a bug in the parser or syntax validator. Please report this issue.

--- a/test-suite/tests/roundtrip/records/ground/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/records/ground/via-conjure.expected.serialised.json
@@ -20,58 +20,11 @@
     "table": [
       [
         {
-          "User": "y"
-        },
-        {
-          "id": {
-            "object_id": 1,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      5
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "y"
-          }
-        }
-      ],
-      [
-        {
-          "User": "z"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": "Bool"
-            }
-          },
-          "name": {
-            "User": "z"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 3,
+            "object_id": 1,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {

--- a/test-suite/tests/roundtrip/records/unresovled/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/records/unresovled/via-conjure.expected.serialised.json
@@ -51,67 +51,11 @@
       ],
       [
         {
-          "User": "y"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Unresolved": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      {
-                        "Const": 1
-                      },
-                      {
-                        "Reference": {
-                          "ptr": {
-                            "object_id": 1,
-                            "type_name": "DeclarationPtrInner"
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "y"
-          }
-        }
-      ],
-      [
-        {
-          "User": "z"
-        },
-        {
-          "id": {
-            "object_id": 3,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": "Bool"
-            }
-          },
-          "name": {
-            "User": "z"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 4,
+            "object_id": 2,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {

--- a/test-suite/tests/roundtrip/variants/many_fields/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/variants/many_fields/via-conjure.expected.serialised.json
@@ -20,86 +20,11 @@
     "table": [
       [
         {
-          "User": "A"
-        },
-        {
-          "id": {
-            "object_id": 1,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      3
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "A"
-          }
-        }
-      ],
-      [
-        {
-          "User": "B"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": "Bool"
-            }
-          },
-          "name": {
-            "User": "B"
-          }
-        }
-      ],
-      [
-        {
-          "User": "C"
-        },
-        {
-          "id": {
-            "object_id": 3,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      0,
-                      5
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "C"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 4,
+            "object_id": 1,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {

--- a/test-suite/tests/roundtrip/variants/one_field/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/variants/one_field/via-conjure.expected.serialised.json
@@ -20,39 +20,11 @@
     "table": [
       [
         {
-          "User": "A"
-        },
-        {
-          "id": {
-            "object_id": 1,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      3
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "A"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 2,
+            "object_id": 1,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {

--- a/test-suite/tests/roundtrip/variants/operators/active/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/variants/operators/active/via-conjure.expected.serialised.json
@@ -19,7 +19,7 @@
                 {
                   "Reference": {
                     "ptr": {
-                      "object_id": 5,
+                      "object_id": 2,
                       "type_name": "DeclarationPtrInner"
                     }
                   }
@@ -27,19 +27,7 @@
               ]
             },
             {
-              "Atomic": [
-                {
-                  "etype": null
-                },
-                {
-                  "Reference": {
-                    "ptr": {
-                      "object_id": 2,
-                      "type_name": "DeclarationPtrInner"
-                    }
-                  }
-                }
-              ]
+              "User": "b"
             }
           ]
         }
@@ -58,86 +46,11 @@
     "table": [
       [
         {
-          "User": "a"
-        },
-        {
-          "id": {
-            "object_id": 1,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      4
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "a"
-          }
-        }
-      ],
-      [
-        {
-          "User": "b"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      2
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "b"
-          }
-        }
-      ],
-      [
-        {
-          "User": "c"
-        },
-        {
-          "id": {
-            "object_id": 3,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": "Bool"
-            }
-          },
-          "name": {
-            "User": "c"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 4,
+            "object_id": 1,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {
@@ -195,7 +108,7 @@
         },
         {
           "id": {
-            "object_id": 5,
+            "object_id": 2,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {
@@ -204,7 +117,7 @@
                 "Unresolved": {
                   "Reference": {
                     "ptr": {
-                      "object_id": 4,
+                      "object_id": 1,
                       "type_name": "DeclarationPtrInner"
                     }
                   }

--- a/test-suite/tests/roundtrip/variants/operators/index/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/variants/operators/index/via-conjure.expected.serialised.json
@@ -19,7 +19,7 @@
                 {
                   "Reference": {
                     "ptr": {
-                      "object_id": 5,
+                      "object_id": 2,
                       "type_name": "DeclarationPtrInner"
                     }
                   }
@@ -27,7 +27,7 @@
               ]
             },
             {
-              "UnsafeIndex": [
+              "RecordField": [
                 {
                   "etype": null
                 },
@@ -39,30 +39,16 @@
                     {
                       "Reference": {
                         "ptr": {
-                          "object_id": 4,
+                          "object_id": 1,
                           "type_name": "DeclarationPtrInner"
                         }
                       }
                     }
                   ]
                 },
-                [
-                  {
-                    "Atomic": [
-                      {
-                        "etype": null
-                      },
-                      {
-                        "Reference": {
-                          "ptr": {
-                            "object_id": 1,
-                            "type_name": "DeclarationPtrInner"
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
+                {
+                  "User": "a"
+                }
               ]
             }
           ]
@@ -82,86 +68,11 @@
     "table": [
       [
         {
-          "User": "a"
-        },
-        {
-          "id": {
-            "object_id": 1,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      4
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "a"
-          }
-        }
-      ],
-      [
-        {
-          "User": "b"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      2
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "b"
-          }
-        }
-      ],
-      [
-        {
-          "User": "c"
-        },
-        {
-          "id": {
-            "object_id": 3,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": "Bool"
-            }
-          },
-          "name": {
-            "User": "c"
-          }
-        }
-      ],
-      [
-        {
           "User": "x"
         },
         {
           "id": {
-            "object_id": 4,
+            "object_id": 1,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {
@@ -221,7 +132,7 @@
         },
         {
           "id": {
-            "object_id": 5,
+            "object_id": 2,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {

--- a/test-suite/tests/roundtrip/variants/unresolved/via-conjure.expected.serialised.json
+++ b/test-suite/tests/roundtrip/variants/unresolved/via-conjure.expected.serialised.json
@@ -51,76 +51,11 @@
       ],
       [
         {
-          "User": "a"
-        },
-        {
-          "id": {
-            "object_id": 2,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Ground": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      1,
-                      4
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "a"
-          }
-        }
-      ],
-      [
-        {
-          "User": "b"
-        },
-        {
-          "id": {
-            "object_id": 3,
-            "type_name": "DeclarationPtrInner"
-          },
-          "kind": {
-            "Field": {
-              "Unresolved": {
-                "Int": [
-                  {
-                    "Bounded": [
-                      {
-                        "Const": 1
-                      },
-                      {
-                        "Reference": {
-                          "ptr": {
-                            "object_id": 1,
-                            "type_name": "DeclarationPtrInner"
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-          },
-          "name": {
-            "User": "b"
-          }
-        }
-      ],
-      [
-        {
           "User": "y"
         },
         {
           "id": {
-            "object_id": 4,
+            "object_id": 2,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {
@@ -185,7 +120,7 @@
         },
         {
           "id": {
-            "object_id": 5,
+            "object_id": 3,
             "type_name": "DeclarationPtrInner"
           },
           "kind": {
@@ -194,7 +129,7 @@
                 "Unresolved": {
                   "Reference": {
                     "ptr": {
-                      "object_id": 4,
+                      "object_id": 2,
                       "type_name": "DeclarationPtrInner"
                     }
                   }


### PR DESCRIPTION
refactor: add a `RecordField(Expr, Name)` expression for record indexing instead of storing record fields in the symbol table

## Description

Previously, all fields of each record / variant in the model would be added to the symbol table.
This would cause clashes if there are multiple record variables with the same field names, possibly nested inside one another.

This PR removes `DeclarationKind::Field` and instead uses a `RecordField(Expr, Name)` AST expression for accesses to the fields of a record or variant (`x[foo]` and `{ foo = 1 }[foo]` in Essence).

This will be used to support nested records in future representation PRs