### PR TITLE
feat: more `GroundDomain::values` implementations

### DIFF
--- a/crates/conjure-cp-core/src/ast/declaration.rs
+++ b/crates/conjure-cp-core/src/ast/declaration.rs
@@ -292,7 +292,7 @@ impl DeclarationPtr {
 
     /// Gets the domain of the declaration and fully resolve it
     pub fn resolved_domain(&self) -> Option<Moo<GroundDomain>> {
-        self.domain()?.resolve()
+        self.domain()?.resolve().ok()
     }
 
     /// Gets the kind of the declaration.

--- a/crates/conjure-cp-core/src/ast/domains/attrs.rs
+++ b/crates/conjure-cp-core/src/ast/domains/attrs.rs
@@ -1,11 +1,12 @@
 use crate::ast::domains::Int;
 use crate::ast::domains::range::Range;
+use funcmap::{FuncMap, TryFuncMap};
 use itertools::Itertools;
 use polyquine::Quine;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct SetAttr<A = Int> {
     pub size: Range<A>,
@@ -43,17 +44,14 @@ impl<A> Default for SetAttr<A> {
 
 impl<A: Display> Display for SetAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self.size {
-            Range::Single(x) => write!(f, "(size {x})"),
-            Range::Bounded(l, r) => write!(f, "(minSize {l}, maxSize {r})"),
-            Range::UnboundedL(r) => write!(f, "(maxSize {r})"),
-            Range::UnboundedR(l) => write!(f, "(minSize {l})"),
-            Range::Unbounded => write!(f, ""),
+        match self.size {
+            Range::Unbounded => Ok(()),
+            _ => write!(f, "({})", fmt_size("size", &self.size)),
         }
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct MSetAttr<A = Int> {
     pub size: Range<A>,
@@ -84,21 +82,15 @@ impl<A> MSetAttr<A> {
 
 impl<A: Display> Display for MSetAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let size_str = match &self.size {
-            Range::Single(x) => format!("size {x}"),
-            Range::Bounded(l, r) => format!("minSize {l}, maxSize {r}"),
-            Range::UnboundedL(r) => format!("maxSize {r}"),
-            Range::UnboundedR(l) => format!("minSize {l}"),
-            Range::Unbounded => "".to_string(),
-        };
+        let size_str = fmt_size("size", &self.size);
 
         // It only makes sense in terms of min and max occurrence for the essence language,
         // so for single ranges it is still presented as min and max occurrence.
         let occ_str = match &self.occurrence {
-            Range::Single(x) => format!("minOccur {x}, maxOccur {x}"),
-            Range::Bounded(l, r) => format!("minOccur {l} , maxOccur {r}"),
-            Range::UnboundedL(r) => format!("maxOccur {r}"),
-            Range::UnboundedR(l) => format!("minOccur {l}"),
+            Range::Single(x) => format!("minOccur({x}), maxOccur({x})"),
+            Range::Bounded(l, r) => format!("minOccur({l}), maxOccur({r})"),
+            Range::UnboundedL(r) => format!("maxOccur({r})"),
+            Range::UnboundedR(l) => format!("minOccur({l})"),
             Range::Unbounded => "".to_string(),
         };
 
@@ -122,7 +114,7 @@ impl<A> Default for MSetAttr<A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct FuncAttr<A = Int> {
     pub size: Range<A>,
@@ -132,13 +124,7 @@ pub struct FuncAttr<A = Int> {
 
 impl<A: Display> Display for FuncAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let size_str = match &self.size {
-            Range::Single(x) => format!("size({x})"),
-            Range::Bounded(l, r) => format!("minSize({l}), maxSize({r})"),
-            Range::UnboundedL(r) => format!("maxSize({r})"),
-            Range::UnboundedR(l) => format!("minSize({l})"),
-            Range::Unbounded => "".to_string(),
-        };
+        let size_str = fmt_size("size", &self.size);
         let mut strs = [
             size_str,
             self.partiality.to_string(),
@@ -154,7 +140,7 @@ impl<A: Display> Display for FuncAttr<A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct SequenceAttr<A = Int> {
     pub size: Range<A>,
@@ -172,13 +158,7 @@ impl<A> Default for SequenceAttr<A> {
 
 impl<A: Display> Display for SequenceAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let size_str = match &self.size {
-            Range::Single(x) => format!("size {x}"),
-            Range::Bounded(l, r) => format!("minSize {l}, maxSize {r}"),
-            Range::UnboundedL(r) => format!("maxSize {r}"),
-            Range::UnboundedR(l) => format!("minSize {l}"),
-            Range::Unbounded => "".to_string(),
-        };
+        let size_str = fmt_size("size", &self.size);
         let mut strs = [size_str, self.jectivity.to_string()]
             .iter()
             .filter(|s| !s.is_empty())
@@ -190,7 +170,7 @@ impl<A: Display> Display for SequenceAttr<A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct PartitionAttr<A = Int> {
     pub num_parts: Range<A>, // i.e. how many parts there are in the partition
@@ -200,21 +180,8 @@ pub struct PartitionAttr<A = Int> {
 
 impl<A: Display> Display for PartitionAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let num_parts_str = match &self.num_parts {
-            Range::Single(x) => format!("numParts {x}"),
-            Range::Bounded(l, r) => format!("minNumParts {l}, maxNumParts {r}"),
-            Range::UnboundedL(r) => format!("maxNumParts {r}"),
-            Range::UnboundedR(l) => format!("minNumParts {l}"),
-            Range::Unbounded => "".to_string(),
-        };
-
-        let part_len_str = match &self.part_len {
-            Range::Single(x) => format!("partSize {x}"),
-            Range::Bounded(l, r) => format!("minPartSize {l} , maxPartSize {r}"),
-            Range::UnboundedL(r) => format!("maxPartSize {r}"),
-            Range::UnboundedR(l) => format!("minPartSize {l}"),
-            Range::Unbounded => "".to_string(),
-        };
+        let num_parts_str = fmt_size("numParts", &self.num_parts);
+        let part_len_str = fmt_size("partSize", &self.part_len);
 
         let regular_str = match &self.is_regular {
             true => "regular".to_string(),
@@ -276,7 +243,7 @@ impl Display for JectivityAttr {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub struct RelAttr<A = Int> {
     pub size: Range<A>,
@@ -294,13 +261,7 @@ impl<A> Default for RelAttr<A> {
 
 impl<A: Display> Display for RelAttr<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let size_str = match &self.size {
-            Range::Single(x) => format!("size {x}"),
-            Range::Bounded(l, r) => format!("minSize {l}, maxSize {r}"),
-            Range::UnboundedL(r) => format!("maxSize {r}"),
-            Range::UnboundedR(l) => format!("minSize {l}"),
-            Range::Unbounded => "".to_string(),
-        };
+        let size_str = fmt_size("size", &self.size);
         let mut strs = [size_str, self.binary.iter().join(", ")]
             .iter()
             .filter(|s| !s.is_empty())
@@ -346,5 +307,27 @@ impl Display for BinaryAttr {
             BinaryAttr::Equivalence => write!(f, "equivalence"),
             BinaryAttr::PartialOrder => write!(f, "partialOrder"),
         }
+    }
+}
+
+/// Format a range as Essence size attribute
+#[inline]
+fn fmt_size<A: Display>(suffix: &str, sz: &Range<A>) -> String {
+    let cap_suffix = capitalize(suffix);
+    match sz {
+        Range::Single(x) => format!("{suffix}({x})"),
+        Range::Bounded(l, r) => format!("min{cap_suffix}({l}), max{cap_suffix}({r})"),
+        Range::UnboundedL(r) => format!("max{cap_suffix}({r})"),
+        Range::UnboundedR(l) => format!("min{cap_suffix}({l})"),
+        Range::Unbounded => "".to_string(),
+    }
+}
+
+#[inline]
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().to_string() + c.as_str(),
     }
 }

--- a/crates/conjure-cp-core/src/ast/domains/domain.rs
+++ b/crates/conjure-cp-core/src/ast/domains/domain.rs
@@ -1,8 +1,10 @@
-use super::attrs::SetAttr;
-use super::ground::{FieldGround, GroundDomain};
-use super::range::Range;
-use super::unresolved::{FieldUnresolved, IntVal, UnresolvedDomain};
-use crate::ast::domains::attrs::{MSetAttr, PartitionAttr};
+use crate::ast::domains::{
+    attrs::{MSetAttr, PartitionAttr, SetAttr},
+    ground::{FieldGround, GroundDomain},
+    int_val::IntVal,
+    range::Range,
+    unresolved::{FieldUnresolved, UnresolvedDomain},
+};
 use crate::ast::{
     DeclarationPtr, DomainOpError, Expression, Field, FuncAttr, Literal, Moo, Reference, RelAttr,
     ReturnType, SequenceAttr, Typeable,
@@ -20,7 +22,7 @@ pub type Int = i32;
 pub type DomainPtr = Moo<Domain>;
 
 impl DomainPtr {
-    pub fn resolve(&self) -> Option<Moo<GroundDomain>> {
+    pub fn resolve(&self) -> Result<Moo<GroundDomain>, DomainOpError> {
         self.as_ref().resolve()
     }
 
@@ -298,9 +300,9 @@ impl Domain {
     /// Otherwise, try to resolve it; Return None if this is not yet possible.
     /// Domains which contain references to givens cannot be resolved until these
     /// givens are substituted for their concrete values.
-    pub fn resolve(&self) -> Option<Moo<GroundDomain>> {
+    pub fn resolve(&self) -> Result<Moo<GroundDomain>, DomainOpError> {
         match self {
-            Domain::Ground(gd) => Some(gd.clone()),
+            Domain::Ground(gd) => Ok(gd.clone()),
             Domain::Unresolved(ud) => ud.resolve().map(Moo::new),
         }
     }

--- a/crates/conjure-cp-core/src/ast/domains/error.rs
+++ b/crates/conjure-cp-core/src/ast/domains/error.rs
@@ -1,6 +1,7 @@
 use crate::ast::ReturnType;
 use crate::bug;
 use crate::utils::CombinatoricsError;
+use std::num::TryFromIntError;
 use thiserror::Error;
 
 /// An error thrown by an operation on domains.
@@ -21,6 +22,9 @@ pub enum DomainOpError {
     #[error("The operation failed as the input domain was not ground")]
     NotGround,
 
+    #[error("Result would exceed the bounds of this integer domain")]
+    OutOfBounds,
+
     #[error("Could not enumerate the domain as it is too large")]
     TooLarge,
 
@@ -36,5 +40,11 @@ impl From<CombinatoricsError> for DomainOpError {
                 bug!("Are we passing the right arguments here? ({})", msg)
             }
         }
+    }
+}
+
+impl From<TryFromIntError> for DomainOpError {
+    fn from(_: TryFromIntError) -> Self {
+        Self::OutOfBounds
     }
 }

--- a/crates/conjure-cp-core/src/ast/domains/ground.rs
+++ b/crates/conjure-cp-core/src/ast/domains/ground.rs
@@ -2,7 +2,8 @@ use crate::ast::domains::attrs::PartitionAttr;
 use crate::ast::domains::{MSetAttr, SequenceAttr};
 use crate::ast::pretty::pretty_vec;
 use crate::ast::{
-    AbstractLiteral, DomainOpError, FuncAttr, HasDomain, Literal, Moo, RelAttr, SetAttr, Typeable,
+    AbstractLiteral, DomainOpError, FuncAttr, HasDomain, Literal, Moo, Name, RelAttr, SetAttr,
+    Typeable,
     domains::{domain::Int, range::Range},
     matrix,
     records::Field,
@@ -15,7 +16,7 @@ use itertools::{Itertools, izip};
 use num_traits::ToPrimitive;
 use polyquine::Quine;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};
 use std::iter::zip;
 use uniplate::Uniplate;
@@ -92,9 +93,6 @@ impl GroundDomain {
             (GroundDomain::Matrix(_, _), _) | (_, GroundDomain::Matrix(_, _)) => {
                 Err(DomainOpError::WrongType)
             }
-            (GroundDomain::Sequence(_, _), _) | (_, GroundDomain::Sequence(_, _)) => {
-                Err(DomainOpError::WrongType)
-            }
             (GroundDomain::Tuple(in1s), GroundDomain::Tuple(in2s)) if in1s.len() == in2s.len() => {
                 let mut inners = Vec::new();
                 for (in1, in2) in zip(in1s, in2s) {
@@ -105,20 +103,25 @@ impl GroundDomain {
             (GroundDomain::Tuple(_), _) | (_, GroundDomain::Tuple(_)) => {
                 Err(DomainOpError::WrongType)
             }
-            // TODO: Eventually we may define semantics for joining record domains. This day is not today.
-            #[allow(unreachable_patterns)]
-            // Technically redundant but logically clearer to have both
+            (GroundDomain::Record(in1s), GroundDomain::Record(in2s))
+                if in1s.len() == in2s.len() =>
+            {
+                let lhs_fields: BTreeMap<&Name, &Moo<GroundDomain>> =
+                    in1s.iter().map(|x| (&x.name, &x.value)).collect();
+                let rhs_fields: BTreeMap<&Name, &Moo<GroundDomain>> =
+                    in2s.iter().map(|x| (&x.name, &x.value)).collect();
+                let mut new_fields = Vec::with_capacity(in1s.len());
+                for (n, d) in lhs_fields {
+                    let d2 = rhs_fields.get(&n).ok_or(DomainOpError::WrongType)?;
+                    let dom = d.union(d2)?;
+                    new_fields.push(Field {
+                        name: n.clone(),
+                        value: dom.into(),
+                    });
+                }
+                Ok(GroundDomain::Record(new_fields))
+            }
             (GroundDomain::Record(_), _) | (_, GroundDomain::Record(_)) => {
-                Err(DomainOpError::WrongType)
-            }
-            #[allow(unreachable_patterns)]
-            // Technically redundant but logically clearer to have both
-            (GroundDomain::Variant(_), _) | (_, GroundDomain::Variant(_)) => {
-                Err(DomainOpError::WrongType)
-            }
-            #[allow(unreachable_patterns)]
-            // Technically redundant but logically clearer to have both
-            (GroundDomain::Function(_, _, _), _) | (_, GroundDomain::Function(_, _, _)) => {
                 Err(DomainOpError::WrongType)
             }
             (GroundDomain::Relation(_, in1s), GroundDomain::Relation(_, in2s)) => {
@@ -128,12 +131,24 @@ impl GroundDomain {
                 }
                 Ok(GroundDomain::Tuple(inners))
             }
-            (GroundDomain::Relation(_, _), _) | (_, GroundDomain::Relation(_, _)) => {
+            (GroundDomain::Relation(..), _) | (_, GroundDomain::Relation(..)) => {
                 Err(DomainOpError::WrongType)
             }
             #[allow(unreachable_patterns)]
-            (GroundDomain::Partition(_, _), _) | (_, GroundDomain::Partition(_, _)) => {
-                Err(DomainOpError::WrongType)
+            (GroundDomain::Sequence(_, _), _) | (_, GroundDomain::Sequence(_, _)) => {
+                todo!("union sequence domains")
+            }
+            #[allow(unreachable_patterns)]
+            (GroundDomain::Variant(_), _) | (_, GroundDomain::Variant(_)) => {
+                todo!("union variant domains")
+            }
+            #[allow(unreachable_patterns)]
+            (GroundDomain::Function(..), _) | (_, GroundDomain::Function(..)) => {
+                todo!("union function domains")
+            }
+            #[allow(unreachable_patterns)]
+            (GroundDomain::Partition(..), _) | (_, GroundDomain::Partition(..)) => {
+                todo!("union partition domains")
             }
         }
     }

--- a/crates/conjure-cp-core/src/ast/domains/ground.rs
+++ b/crates/conjure-cp-core/src/ast/domains/ground.rs
@@ -295,7 +295,19 @@ impl GroundDomain {
 
                 Ok(Box::new(iter))
             }
-            GroundDomain::Set(..) => todo!("Enumerating set domains is not yet supported"),
+            GroundDomain::Set(attrs, inner_dom) => {
+                let n: Int = inner_dom.len_usize()?.try_into()?;
+                let min_sz = attrs.size.low().copied().unwrap_or(0);
+                let max_sz = attrs.size.high().copied().unwrap_or(n);
+
+                let pool = inner_dom.values()?.collect_vec();
+
+                Ok(Box::new(
+                    (min_sz..=max_sz)
+                        .flat_map(move |sz| pool.clone().into_iter().combinations(sz as usize))
+                        .map(|elems| Literal::AbstractLiteral(AbstractLiteral::Set(elems))),
+                ))
+            }
             GroundDomain::MSet(..) => todo!("Enumerating multi-set domains is not yet supported"),
             GroundDomain::Function(..) => {
                 todo!("Enumerating function domains is not yet supported")
@@ -1496,6 +1508,67 @@ mod tests {
                 value: Moo::new(GroundDomain::Bool),
             },
         ]);
+        let count = dom.values().unwrap().count();
+        let length = dom.length().unwrap();
+        assert_eq!(count as u64, length);
+    }
+
+    fn set_lit(elems: Vec<i32>) -> Literal {
+        Literal::AbstractLiteral(AbstractLiteral::Set(
+            elems.into_iter().map(Literal::Int).collect(),
+        ))
+    }
+
+    #[test]
+    fn set_values_unbounded() {
+        // set of int(1..3) => all 2^3 = 8 subsets, in order of ascending size
+        let dom = GroundDomain::Set(SetAttr::default(), domain_int_ground!(1..3));
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 8);
+        assert_eq!(values[0], set_lit(vec![])); // size 0
+        assert_eq!(values[1], set_lit(vec![1])); // size 1
+        assert_eq!(values[2], set_lit(vec![2]));
+        assert_eq!(values[3], set_lit(vec![3]));
+        assert_eq!(values[4], set_lit(vec![1, 2])); // size 2
+        assert_eq!(values[5], set_lit(vec![1, 3]));
+        assert_eq!(values[6], set_lit(vec![2, 3]));
+        assert_eq!(values[7], set_lit(vec![1, 2, 3])); // size 3
+    }
+
+    #[test]
+    fn set_values_fixed_size() {
+        // set (size 2) of int(1..3) => the 3 two-element subsets
+        let dom = GroundDomain::Set(SetAttr::new_size(2), domain_int_ground!(1..3));
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0], set_lit(vec![1, 2]));
+        assert_eq!(values[1], set_lit(vec![1, 3]));
+        assert_eq!(values[2], set_lit(vec![2, 3]));
+    }
+
+    #[test]
+    fn set_values_bounded_size() {
+        // set (minSize 1, maxSize 2) of int(1..3) => subsets of size 1 and 2
+        let dom = GroundDomain::Set(SetAttr::new_min_max_size(1, 2), domain_int_ground!(1..3));
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 6);
+        assert_eq!(values[0], set_lit(vec![1]));
+        assert_eq!(values[1], set_lit(vec![2]));
+        assert_eq!(values[2], set_lit(vec![3]));
+        assert_eq!(values[3], set_lit(vec![1, 2]));
+        assert_eq!(values[4], set_lit(vec![1, 3]));
+        assert_eq!(values[5], set_lit(vec![2, 3]));
+    }
+
+    #[test]
+    fn set_values_count_matches_length() {
+        let dom = GroundDomain::Set(SetAttr::default(), domain_int_ground!(1..4));
         let count = dom.values().unwrap().count();
         let length = dom.length().unwrap();
         assert_eq!(count as u64, length);

--- a/crates/conjure-cp-core/src/ast/domains/ground.rs
+++ b/crates/conjure-cp-core/src/ast/domains/ground.rs
@@ -4,6 +4,7 @@ use crate::ast::pretty::pretty_vec;
 use crate::ast::{
     AbstractLiteral, DomainOpError, FuncAttr, HasDomain, Literal, Moo, RelAttr, SetAttr, Typeable,
     domains::{domain::Int, range::Range},
+    matrix,
     records::Field,
 };
 use crate::range;
@@ -209,7 +210,7 @@ impl GroundDomain {
         match self {
             GroundDomain::Empty(_) => Ok(Box::new(vec![].into_iter())),
             GroundDomain::Bool => Ok(Box::new(
-                vec![Literal::from(true), Literal::from(false)].into_iter(),
+                vec![Literal::from(false), Literal::from(true)].into_iter(),
             )),
             GroundDomain::Int(rngs) => {
                 let rng_iters = rngs
@@ -221,10 +222,81 @@ impl GroundDomain {
                     rng_iters.into_iter().flat_map(|ri| ri.map(Literal::from)),
                 ))
             }
-            GroundDomain::Matrix(elem_domain, index_domains) => Ok(Box::new(
-                enumerate_matrix_values(elem_domain.as_ref(), index_domains)?.into_iter(),
-            )),
-            _ => todo!("Enumerating nested domains is not yet supported"),
+            GroundDomain::Matrix(elem_dom, idx_doms) => {
+                let shape = matrix::shape_of_dom(self)?;
+                let idx_doms = idx_doms.clone();
+
+                // Collect all possible element values
+                let elem_values: Vec<Literal> = elem_dom.values()?.collect();
+
+                // Generate all possible cell assignments in lexicographic order
+                let iter = std::iter::repeat_n(elem_values, shape.size)
+                    .multi_cartesian_product()
+                    .map(move |flat_elems| {
+                        matrix::unflatten_matrix::<Literal>(&flat_elems, &idx_doms, &shape.strides)
+                    });
+
+                Ok(Box::new(iter))
+            }
+            GroundDomain::Tuple(elem_doms) => {
+                // Collect the possible values for each element
+                let elem_value_pools: Vec<Vec<Literal>> = elem_doms
+                    .iter()
+                    .map(|d| d.values().map(|it| it.collect()))
+                    .collect::<Result<_, _>>()?;
+
+                // Generate all combinations in lexicographic order
+                let iter = elem_value_pools
+                    .into_iter()
+                    .multi_cartesian_product()
+                    .map(|elems| Literal::AbstractLiteral(AbstractLiteral::Tuple(elems)));
+
+                Ok(Box::new(iter))
+            }
+            GroundDomain::Record(entries) => {
+                // Sort entries by name
+                let mut sorted: Vec<&_> = entries.iter().collect();
+                sorted.sort_by(|a, b| a.name.cmp(&b.name));
+
+                let names: Vec<_> = sorted.iter().map(|e| e.name.clone()).collect();
+                let value_pools: Vec<Vec<Literal>> = sorted
+                    .iter()
+                    .map(|e| e.value.values().map(|it| it.collect()))
+                    .collect::<Result<_, _>>()?;
+
+                // Generate all combinations in lexicographic order
+                let iter = value_pools
+                    .into_iter()
+                    .multi_cartesian_product()
+                    .map(move |vals| {
+                        let record_entries = names
+                            .iter()
+                            .cloned()
+                            .zip(vals)
+                            .map(|(name, value)| Field { name, value })
+                            .collect();
+                        Literal::AbstractLiteral(AbstractLiteral::Record(record_entries))
+                    });
+
+                Ok(Box::new(iter))
+            }
+            GroundDomain::Set(..) => todo!("Enumerating set domains is not yet supported"),
+            GroundDomain::MSet(..) => todo!("Enumerating multi-set domains is not yet supported"),
+            GroundDomain::Function(..) => {
+                todo!("Enumerating function domains is not yet supported")
+            }
+            GroundDomain::Partition(..) => {
+                todo!("Enumerating partition domains is not yet supported")
+            }
+            GroundDomain::Relation(..) => {
+                todo!("Enumerating relation domains is not yet supported")
+            }
+            GroundDomain::Sequence(..) => {
+                todo!("Enumerating sequence domains is not yet supported")
+            }
+            GroundDomain::Variant(..) => {
+                todo!("Enumerating variant domains is not yet supported")
+            }
         }
     }
 
@@ -1194,28 +1266,223 @@ impl Display for GroundDomain {
     }
 }
 
-fn enumerate_matrix_values(
-    elem_domain: &GroundDomain,
-    index_domains: &[Moo<GroundDomain>],
-) -> Result<Vec<Literal>, DomainOpError> {
-    let Some((current_index_domain, remaining_index_domains)) = index_domains.split_first() else {
-        panic!("a matrix should have at least one index domain");
-    };
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Name;
+    use crate::{domain_int_ground, matrix_lit};
 
-    let current_dimension_len =
-        usize::try_from(current_index_domain.length()?).map_err(|_| DomainOpError::TooLarge)?;
+    #[test]
+    fn matrix_values_1d_bool_of_bool() {
+        // matrix indexed by [bool] of bool
+        // 2 cells, 2 possible values => 2^2 = 4 matrices
+        let dom = GroundDomain::Matrix(
+            Moo::new(GroundDomain::Bool),
+            vec![Moo::new(GroundDomain::Bool)],
+        );
 
-    let entry_values = if remaining_index_domains.is_empty() {
-        elem_domain.values()?.collect_vec()
-    } else {
-        enumerate_matrix_values(elem_domain, remaining_index_domains)?
-    };
+        let values: Vec<Literal> = dom.values().unwrap().collect();
 
-    Ok((0..current_dimension_len)
-        .map(|_| entry_values.iter().cloned())
-        .multi_cartesian_product()
-        .map(|elems| {
-            Literal::AbstractLiteral(AbstractLiteral::Matrix(elems, current_index_domain.clone()))
-        })
-        .collect())
+        assert_eq!(values.len(), 4);
+        assert_eq!(
+            values[0],
+            matrix_lit![false, false; Moo::new(GroundDomain::Bool)]
+        );
+        assert_eq!(
+            values[1],
+            matrix_lit![false, true; Moo::new(GroundDomain::Bool)]
+        );
+        assert_eq!(
+            values[2],
+            matrix_lit![true, false; Moo::new(GroundDomain::Bool)]
+        );
+        assert_eq!(
+            values[3],
+            matrix_lit![true, true; Moo::new(GroundDomain::Bool)]
+        );
+    }
+
+    #[test]
+    fn matrix_values_1d_int() {
+        // matrix indexed by [int(1..2)] of int(0..1)
+        // 2 cells, 2 possible values => 4 matrices
+        let dom = GroundDomain::Matrix(domain_int_ground!(0..1), vec![domain_int_ground!(1..2)]);
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 4);
+        assert_eq!(values[0], matrix_lit![0, 0; domain_int_ground!(1..2)]);
+        assert_eq!(values[1], matrix_lit![0, 1; domain_int_ground!(1..2)]);
+        assert_eq!(values[2], matrix_lit![1, 0; domain_int_ground!(1..2)]);
+        assert_eq!(values[3], matrix_lit![1, 1; domain_int_ground!(1..2)]);
+    }
+
+    #[test]
+    fn matrix_values_2d_lexicographic() {
+        // matrix indexed by [int(1..2), int(1..2)] of int(0..1)
+        // 4 cells, 2 possible values => 2^4 = 16 matrices
+        let dom = GroundDomain::Matrix(
+            domain_int_ground!(0..1),
+            vec![domain_int_ground!(1..2), domain_int_ground!(1..2)],
+        );
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 16);
+
+        // First: [[0,0],[0,0]]
+        assert_eq!(
+            values[0],
+            matrix_lit![[0, 0], [0, 0]; [domain_int_ground!(1..2), domain_int_ground!(1..2)]]
+        );
+        // Second: [[0,0],[0,1]]
+        assert_eq!(
+            values[1],
+            matrix_lit![[0, 0], [0, 1]; [domain_int_ground!(1..2), domain_int_ground!(1..2)]]
+        );
+        // Third: [[0,0],[1,0]]
+        assert_eq!(
+            values[2],
+            matrix_lit![[0, 0], [1, 0]; [domain_int_ground!(1..2), domain_int_ground!(1..2)]]
+        );
+        // Fourth: [[0,0],[1,1]]
+        assert_eq!(
+            values[3],
+            matrix_lit![[0, 0], [1, 1]; [domain_int_ground!(1..2), domain_int_ground!(1..2)]]
+        );
+        // Last: [[1,1],[1,1]]
+        assert_eq!(
+            values[15],
+            matrix_lit![[1, 1], [1, 1]; [domain_int_ground!(1..2), domain_int_ground!(1..2)]]
+        );
+    }
+
+    #[test]
+    fn matrix_values_count_matches_length() {
+        // matrix indexed by [int(1..3)] of int(0..1)
+        // 3 cells, 2 possible values => 2^3 = 8 matrices
+        let dom = GroundDomain::Matrix(domain_int_ground!(0..1), vec![domain_int_ground!(1..3)]);
+
+        let count = dom.values().unwrap().count();
+        let length = dom.length().unwrap();
+
+        assert_eq!(count as u64, length);
+    }
+
+    #[test]
+    fn tuple_values_two_bools() {
+        // tuple of (bool, bool) => 2*2 = 4 values
+        let dom = GroundDomain::Tuple(vec![
+            Moo::new(GroundDomain::Bool),
+            Moo::new(GroundDomain::Bool),
+        ]);
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 4);
+        let t = |a, b| {
+            Literal::AbstractLiteral(AbstractLiteral::Tuple(vec![
+                Literal::Bool(a),
+                Literal::Bool(b),
+            ]))
+        };
+        assert_eq!(values[0], t(false, false));
+        assert_eq!(values[1], t(false, true));
+        assert_eq!(values[2], t(true, false));
+        assert_eq!(values[3], t(true, true));
+    }
+
+    #[test]
+    fn tuple_values_mixed_domains() {
+        // tuple of (bool, int(0..2)) => 2*3 = 6 values, lexicographic
+        let dom = GroundDomain::Tuple(vec![Moo::new(GroundDomain::Bool), domain_int_ground!(0..2)]);
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        assert_eq!(values.len(), 6);
+        let t = |b: bool, i: i32| {
+            Literal::AbstractLiteral(AbstractLiteral::Tuple(vec![
+                Literal::Bool(b),
+                Literal::Int(i),
+            ]))
+        };
+        // bool false first, then ints 0,1,2
+        assert_eq!(values[0], t(false, 0));
+        assert_eq!(values[1], t(false, 1));
+        assert_eq!(values[2], t(false, 2));
+        // then bool true
+        assert_eq!(values[3], t(true, 0));
+        assert_eq!(values[4], t(true, 1));
+        assert_eq!(values[5], t(true, 2));
+    }
+
+    #[test]
+    fn tuple_values_count_matches_length() {
+        let dom = GroundDomain::Tuple(vec![
+            domain_int_ground!(1..3),
+            Moo::new(GroundDomain::Bool),
+            domain_int_ground!(0..1),
+        ]);
+        let count = dom.values().unwrap().count();
+        let length = dom.length().unwrap();
+        assert_eq!(count as u64, length);
+    }
+
+    #[test]
+    fn record_values_lexicographic_by_name() {
+        // record {b: bool, a: int(0..1)}
+        // Entries should be ordered by name: a first, then b
+        let dom = GroundDomain::Record(vec![
+            Field {
+                name: Name::user("b"),
+                value: Moo::new(GroundDomain::Bool),
+            },
+            Field {
+                name: Name::user("a"),
+                value: domain_int_ground!(0..1),
+            },
+        ]);
+
+        let values: Vec<Literal> = dom.values().unwrap().collect();
+
+        // 2 * 2 = 4 values
+        assert_eq!(values.len(), 4);
+
+        // Entries should be sorted by name: "a" before "b"
+        let r = |a_val: i32, b_val: bool| {
+            Literal::AbstractLiteral(AbstractLiteral::Record(vec![
+                Field {
+                    name: Name::user("a"),
+                    value: Literal::Int(a_val),
+                },
+                Field {
+                    name: Name::user("b"),
+                    value: Literal::Bool(b_val),
+                },
+            ]))
+        };
+
+        // "a" (int) varies slowest, "b" (bool) varies fastest
+        assert_eq!(values[0], r(0, false));
+        assert_eq!(values[1], r(0, true));
+        assert_eq!(values[2], r(1, false));
+        assert_eq!(values[3], r(1, true));
+    }
+
+    #[test]
+    fn record_values_count_matches_length() {
+        let dom = GroundDomain::Record(vec![
+            Field {
+                name: Name::user("x"),
+                value: domain_int_ground!(1..3),
+            },
+            Field {
+                name: Name::user("y"),
+                value: Moo::new(GroundDomain::Bool),
+            },
+        ]);
+        let count = dom.values().unwrap().count();
+        let length = dom.length().unwrap();
+        assert_eq!(count as u64, length);
+    }
 }

--- a/crates/conjure-cp-core/src/ast/domains/int_val.rs
+++ b/crates/conjure-cp-core/src/ast/domains/int_val.rs
@@ -1,0 +1,281 @@
+use crate::ast::{
+    DeclarationKind, DomainOpError, Expression, FuncAttr, Literal, Metadata, Moo, PartitionAttr,
+    Reference, RelAttr, ReturnType, SequenceAttr, Typeable,
+    domains::{Int, MSetAttr, Range, SetAttr},
+    eval_constant,
+};
+use crate::{bug, into_matrix_expr, matrix_expr};
+use funcmap::{FuncMap, TryFuncMap};
+use polyquine::Quine;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use uniplate::Uniplate;
+
+/// A variable or expression appearing inside an int range of an unresolved domain;
+/// E.g `int(1..x)`, `int(2, 4..(2*y))`, `set (minSize x) of int(1..5)`, etc
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine, Uniplate)]
+#[path_prefix(conjure_cp::ast)]
+#[biplate(to=Expression)]
+#[biplate(to=Reference)]
+pub enum IntVal {
+    // For ergonomics, we use a type bigger than both Int and UInt so both fit;
+    // Overflows are handled when resolving
+    Const(i64),
+    #[polyquine_skip]
+    Reference(Reference),
+    Expr(Moo<Expression>),
+}
+
+// ------------------------------------
+// ------ Trait impls for IntVal ------
+// ------------------------------------
+
+impl<T> From<T> for IntVal
+where
+    T: Into<i64>,
+{
+    fn from(v: T) -> Self {
+        IntVal::Const(v.into())
+    }
+}
+
+impl TryFrom<IntVal> for Int {
+    type Error = DomainOpError;
+
+    fn try_from(value: IntVal) -> Result<Int, Self::Error> {
+        match value {
+            IntVal::Const(val) => val.try_into().map_err(|_| DomainOpError::OutOfBounds),
+            _ => Err(DomainOpError::NotGround),
+        }
+    }
+}
+
+impl Display for IntVal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntVal::Const(val) => write!(f, "{val}"),
+            IntVal::Reference(re) => write!(f, "{re}"),
+            IntVal::Expr(expr) => write!(f, "({expr})"),
+        }
+    }
+}
+
+impl std::ops::Neg for IntVal {
+    type Output = IntVal;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            IntVal::Const(val) => IntVal::Const(-val),
+            IntVal::Reference(re) => IntVal::Expr(Moo::new(Expression::Neg(
+                Metadata::new(),
+                Moo::new(re.into()),
+            ))),
+            IntVal::Expr(expr) => IntVal::Expr(Moo::new(Expression::Neg(Metadata::new(), expr))),
+        }
+    }
+}
+
+// ----------------------------------------
+// ------ Core IntVal implementation ------
+// ----------------------------------------
+
+impl IntVal {
+    pub fn new_const(val: Int) -> IntVal {
+        IntVal::Const(val as i64)
+    }
+
+    pub fn new_ref(re: &Reference) -> Result<IntVal, DomainOpError> {
+        match re.ptr.kind().deref() {
+            DeclarationKind::ValueLetting(expr, _)
+            | DeclarationKind::TemporaryValueLetting(expr) => match expr.return_type() {
+                ReturnType::Int => Ok(IntVal::Reference(re.clone())),
+                _ => Err(DomainOpError::WrongType),
+            },
+            DeclarationKind::Given(dom) => match dom.return_type() {
+                ReturnType::Int => Ok(IntVal::Reference(re.clone())),
+                _ => Err(DomainOpError::WrongType),
+            },
+            // TODO: I'm not sure if this is correct, see discussion #1890
+            // Assume that for `y : int(1..x)`, where x is an induction variable, to be valid,
+            // x must be an integer (e.g x : int(1..3)). I don't know how the generator expression
+            // fits into this.
+            DeclarationKind::Quantified(inner) => match inner.domain().return_type() {
+                ReturnType::Int => Ok(IntVal::Reference(re.clone())),
+                _ => Err(DomainOpError::WrongType),
+            },
+            // TODO: I'm not sure if this is correct, see discussion #1890
+            // Assume that for `y : int(1..x)`, where `x <- expr`, to be valid,
+            // x must be a collection of integers; E.g, `x <- {1, 2, 3}`.
+            DeclarationKind::QuantifiedExpr(expr) => match expr.return_type().elem_type() {
+                Some(ReturnType::Int) => Ok(IntVal::Reference(re.clone())),
+                _ => Err(DomainOpError::WrongType),
+            },
+            DeclarationKind::Find(var) => match var.return_type() {
+                ReturnType::Int => Ok(IntVal::Reference(re.clone())),
+                _ => Err(DomainOpError::WrongType),
+            },
+            DeclarationKind::DomainLetting(_) => Err(DomainOpError::WrongType),
+        }
+    }
+
+    pub fn new_expr(value: Moo<Expression>) -> Result<IntVal, DomainOpError> {
+        if value.return_type() != ReturnType::Int {
+            return Err(DomainOpError::WrongType);
+        }
+        Ok(IntVal::Expr(value))
+    }
+
+    pub fn resolve(&self) -> Result<Int, DomainOpError> {
+        match self {
+            IntVal::Const(value) => (*value).try_into().map_err(|_| DomainOpError::OutOfBounds),
+            IntVal::Expr(expr) => eval_expr_to_int(expr).ok_or(DomainOpError::NotGround),
+            IntVal::Reference(re) => match re.ptr.kind().deref() {
+                DeclarationKind::ValueLetting(expr, _)
+                | DeclarationKind::TemporaryValueLetting(expr) => {
+                    eval_expr_to_int(expr).ok_or(DomainOpError::NotGround)
+                }
+                // If this is an int given we will be able to resolve it eventually, but not yet
+                DeclarationKind::Given(_) => Err(DomainOpError::NotGround),
+                DeclarationKind::Quantified(inner) => {
+                    if let Some(generator) = inner.generator()
+                        && let Some(expr) = generator.as_value_letting()
+                    {
+                        eval_expr_to_int(&expr).ok_or(DomainOpError::NotGround)
+                    } else {
+                        Err(DomainOpError::NotGround)
+                    }
+                }
+                // Decision variables inside domains are unresolved until solving.
+                DeclarationKind::Find(_) => Err(DomainOpError::NotGround),
+                DeclarationKind::DomainLetting(_) | DeclarationKind::QuantifiedExpr(_) => bug!(
+                    "Expected integer expression, given, or letting inside int domain; Got: {re}"
+                ),
+            },
+        }
+    }
+
+    pub fn try_add<T: Into<Expression>>(self, rhs: T) -> Result<IntVal, DomainOpError> {
+        let sum = Expression::Sum(
+            Metadata::new(),
+            Moo::new(matrix_expr!(self.try_into()?, rhs.into())),
+        );
+        Ok(IntVal::Expr(Moo::new(sum)))
+    }
+
+    pub fn try_sub<T: Into<Expression>>(self, rhs: T) -> Result<IntVal, DomainOpError> {
+        let rhs_neg = Expression::Neg(Metadata::new(), Moo::new(rhs.into()));
+        let sum = Expression::Sum(
+            Metadata::new(),
+            Moo::new(matrix_expr!(self.try_into()?, rhs_neg)),
+        );
+        Ok(IntVal::Expr(Moo::new(sum)))
+    }
+}
+
+// ------------------------------------------
+// ------ Expression-related miscellanea ----
+// ------------------------------------------
+
+impl Range<IntVal> {
+    /// Generates the expression to compute the size of this range
+    pub fn len_expr(self) -> Result<Expression, DomainOpError> {
+        match self {
+            Range::Single(a) => Ok(a.try_into()?),
+            Range::Bounded(a, b) => {
+                let neg_b = Expression::Neg(Metadata::new(), b.try_into()?);
+                let sum_matr = into_matrix_expr!(vec![a.try_into()?, neg_b]);
+                Ok(Expression::Sum(Metadata::new(), sum_matr.into()))
+            }
+            _ => Err(DomainOpError::Unbounded),
+        }
+    }
+
+    /// Generates the expression to compute the size of a list of ranges
+    pub fn len_expr_of(rngs: &[Range<IntVal>]) -> Result<Expression, DomainOpError> {
+        let mut rng_sizes = Vec::with_capacity(rngs.len());
+        for rng in rngs {
+            rng_sizes.push(rng.clone().len_expr()?);
+        }
+        let rng_sizes = into_matrix_expr!(rng_sizes);
+        Ok(Expression::Sum(Metadata::new(), rng_sizes.into()))
+    }
+}
+
+fn eval_expr_to_int(expr: &Expression) -> Option<Int> {
+    match eval_constant(expr)? {
+        Literal::Int(v) => Some(v),
+        _ => bug!("Expected integer expression, got: {expr}"),
+    }
+}
+
+impl TryFrom<IntVal> for Moo<Expression> {
+    type Error = DomainOpError;
+
+    fn try_from(value: IntVal) -> Result<Self, Self::Error> {
+        match value {
+            IntVal::Const(val) => {
+                let val: Int = val.try_into().map_err(|_| DomainOpError::OutOfBounds)?;
+                Ok(Moo::new(val.into()))
+            }
+            IntVal::Reference(re) => Ok(Moo::new(re.into())),
+            IntVal::Expr(expr) => Ok(expr),
+        }
+    }
+}
+
+impl TryFrom<IntVal> for Expression {
+    type Error = DomainOpError;
+    fn try_from(value: IntVal) -> Result<Self, Self::Error> {
+        Ok(Moo::unwrap_or_clone(value.try_into()?))
+    }
+}
+
+// --------------------------------------------------------------
+// ------ Derive into / resolve for container types by macro ----
+// --------------------------------------------------------------
+
+macro_rules! impl_int_conversions {
+    ($container:ident) => {
+        impl From<$container<Int>> for $container<IntVal> {
+            fn from(val: $container<Int>) -> Self {
+                val.func_map(IntVal::from)
+            }
+        }
+
+        impl TryFrom<$container<IntVal>> for $container<Int> {
+            type Error = DomainOpError;
+
+            fn try_from(val: $container<IntVal>) -> Result<Self, Self::Error> {
+                val.try_func_map(IntVal::try_into)
+            }
+        }
+
+        impl $container<IntVal> {
+            // All inner types are either i64 or pointers so cloning should be relatively cheap;
+            // so, for ergonomics, we pretend that `resolve` methods take a reference :)
+            pub fn resolve(&self) -> Result<$container<Int>, DomainOpError> {
+                self.clone().try_func_map(|x| IntVal::resolve(&x))
+            }
+        }
+    };
+}
+
+macro_rules! impl_int_conversions_for {
+    ($($container:ident),+ $(,)?) => {
+        $(impl_int_conversions!($container);)+
+    };
+}
+
+// To add a new type in the future:
+// 1. Add #[derive(FuncMap, TryFuncMap)] to the container type or impl the traits yourself
+// 2. Add the container type to the list below
+impl_int_conversions_for!(
+    Range,
+    SetAttr,
+    MSetAttr,
+    FuncAttr,
+    SequenceAttr,
+    PartitionAttr,
+    RelAttr
+);

--- a/crates/conjure-cp-core/src/ast/domains/mod.rs
+++ b/crates/conjure-cp-core/src/ast/domains/mod.rs
@@ -3,6 +3,7 @@ mod domain;
 mod domain_conversions;
 mod error;
 mod ground;
+mod int_val;
 mod range;
 mod unresolved;
 
@@ -13,5 +14,6 @@ pub use attrs::{
 pub use domain::{Domain, DomainPtr, HasDomain, Int};
 pub use error::DomainOpError;
 pub use ground::GroundDomain;
+pub use int_val::IntVal;
 pub use range::Range;
-pub use unresolved::{IntVal, UnresolvedDomain};
+pub use unresolved::UnresolvedDomain;

--- a/crates/conjure-cp-core/src/ast/domains/range.rs
+++ b/crates/conjure-cp-core/src/ast/domains/range.rs
@@ -218,7 +218,10 @@ impl<A: Num + Ord + Clone> Range<A> {
     pub fn join(&self, other: &Range<A>) -> Option<Range<A>> {
         if self.joins(other) {
             let lo = Ord::min(self.low(), other.low());
-            let hi = Ord::max(self.high(), other.high());
+            let hi = match (self.high(), other.high()) {
+                (Some(a), Some(b)) => Some(Ord::max(a, b)),
+                _ => None,
+            };
             return Some(Range::new(lo.cloned(), hi.cloned()));
         }
         None
@@ -464,5 +467,17 @@ mod test {
             Range::spanning(&[range!(..0), range!(2..)]),
             Range::Unbounded
         );
+    }
+
+    #[test]
+    pub fn test_range_join() {
+        assert_eq!(range!(1..3).join(&range!(2..4)), Some(range!(1..4)));
+        assert_eq!(range!(1..3).join(&range!(3..4)), Some(range!(1..4)));
+        assert_eq!(range!(1..3).join(&range!(4..5)), Some(range!(1..5)));
+        assert_eq!(range!(..3).join(&range!(4..5)), Some(range!(..5)));
+        assert_eq!(range!(1..3).join(&range!(4..)), Some(range!(1..)));
+        assert_eq!(range!(4..).join(&range!(1..3)), Some(range!(1..)));
+        assert_eq!(range!(..3).join(&range!(4..)), Some(Range::Unbounded));
+        assert_eq!(range!(1..3).join(&range!(5..6)), None);
     }
 }

--- a/crates/conjure-cp-core/src/ast/domains/range.rs
+++ b/crates/conjure-cp-core/src/ast/domains/range.rs
@@ -1,10 +1,11 @@
 use crate::ast::{DomainOpError, domains::Int};
+use funcmap::{FuncMap, TryFuncMap};
 use num_traits::Num;
 use polyquine::Quine;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, FuncMap, TryFuncMap, Quine)]
 #[path_prefix(conjure_cp::ast)]
 pub enum Range<A = Int> {
     Single(A),

--- a/crates/conjure-cp-core/src/ast/domains/range.rs
+++ b/crates/conjure-cp-core/src/ast/domains/range.rs
@@ -281,12 +281,43 @@ impl<A: Num + Ord + Clone> Range<A> {
         }
     }
 
+    /// Lazily iterate all values in a list of ranges
     pub fn values(rngs: &[Range<A>]) -> Option<impl Iterator<Item = A>> {
         let itrs = rngs
             .iter()
             .map(Range::iter)
             .collect::<Option<Vec<RangeIterator<A>>>>()?;
         Some(itrs.into_iter().flatten())
+    }
+
+    /// True if the list of ranges is contiguous
+    pub fn is_contiguous(rngs: &[Range<A>]) -> bool {
+        Self::squeeze(rngs).len() <= 1
+    }
+
+    /// Lowest value from a sequence of ranges
+    pub fn low_of(rngs: &[Range<A>]) -> Option<&A> {
+        let mut low = rngs.first()?.low()?;
+        for rng in rngs {
+            low = Ord::min(low, rng.low()?);
+        }
+        Some(low)
+    }
+
+    /// Lowest value from a sequence of ranges
+    pub fn high_of(rngs: &[Range<A>]) -> Option<&A> {
+        let mut hi = rngs.first()?.high()?;
+        for rng in rngs {
+            hi = Ord::min(hi, rng.low()?);
+        }
+        Some(hi)
+    }
+
+    /// Total number of values across a slice of ranges.
+    /// Returns `None` if any range is unbounded.
+    pub fn total_length(rngs: &[Range<A>]) -> Option<A> {
+        rngs.iter()
+            .try_fold(A::zero(), |acc, r| Some(acc + r.length()?))
     }
 }
 

--- a/crates/conjure-cp-core/src/ast/domains/unresolved.rs
+++ b/crates/conjure-cp-core/src/ast/domains/unresolved.rs
@@ -1,6 +1,5 @@
 use std::fmt::{Display, Formatter};
 use std::iter::zip;
-use std::ops::Deref;
 
 use crate::ast::domains::attrs::MSetAttr;
 use crate::ast::domains::attrs::PartitionAttr;
@@ -8,396 +7,18 @@ use crate::ast::domains::attrs::SetAttr;
 use crate::ast::domains::ground::FieldGround;
 use crate::ast::records::Field;
 use crate::ast::{
-    DeclarationKind, DomainOpError, Expression, FuncAttr, Literal, Metadata, Moo, Reference,
-    RelAttr, ReturnType, SequenceAttr, Typeable,
-    domains::{
-        GroundDomain,
-        domain::{DomainPtr, Int},
-        range::Range,
-    },
-    eval_constant,
+    DomainOpError, Expression, FuncAttr, Moo, Reference, RelAttr, ReturnType, SequenceAttr,
+    Typeable,
+    domains::{DomainPtr, GroundDomain, int_val::IntVal, range::Range},
     pretty::pretty_vec,
 };
-use crate::{bug, domain_int, matrix_expr, range};
+use crate::bug;
 
 use funcmap::{FuncMap, TryFuncMap};
 use itertools::Itertools;
 use polyquine::Quine;
 use serde::{Deserialize, Serialize};
 use uniplate::Uniplate;
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Quine, Uniplate)]
-#[path_prefix(conjure_cp::ast)]
-#[biplate(to=Expression)]
-#[biplate(to=Reference)]
-pub enum IntVal {
-    Const(Int),
-    #[polyquine_skip]
-    Reference(Reference),
-    Expr(Moo<Expression>),
-}
-
-impl From<Int> for IntVal {
-    fn from(value: Int) -> Self {
-        Self::Const(value)
-    }
-}
-
-impl TryInto<Int> for IntVal {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<Int, Self::Error> {
-        match self {
-            IntVal::Const(val) => Ok(val),
-            _ => Err(DomainOpError::NotGround),
-        }
-    }
-}
-
-impl From<Range<Int>> for Range<IntVal> {
-    fn from(value: Range<Int>) -> Self {
-        match value {
-            Range::Single(x) => Range::Single(x.into()),
-            Range::Bounded(l, r) => Range::Bounded(l.into(), r.into()),
-            Range::UnboundedL(r) => Range::UnboundedL(r.into()),
-            Range::UnboundedR(l) => Range::UnboundedR(l.into()),
-            Range::Unbounded => Range::Unbounded,
-        }
-    }
-}
-
-impl TryInto<Range<Int>> for Range<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<Range<Int>, Self::Error> {
-        match self {
-            Range::Single(x) => Ok(Range::Single(x.try_into()?)),
-            Range::Bounded(l, r) => Ok(Range::Bounded(l.try_into()?, r.try_into()?)),
-            Range::UnboundedL(r) => Ok(Range::UnboundedL(r.try_into()?)),
-            Range::UnboundedR(l) => Ok(Range::UnboundedR(l.try_into()?)),
-            Range::Unbounded => Ok(Range::Unbounded),
-        }
-    }
-}
-
-impl From<SetAttr<Int>> for SetAttr<IntVal> {
-    fn from(value: SetAttr<Int>) -> Self {
-        SetAttr {
-            size: value.size.into(),
-        }
-    }
-}
-
-impl TryInto<SetAttr<Int>> for SetAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<SetAttr<Int>, Self::Error> {
-        let size: Range<Int> = self.size.try_into()?;
-        Ok(SetAttr { size })
-    }
-}
-
-impl From<MSetAttr<Int>> for MSetAttr<IntVal> {
-    fn from(value: MSetAttr<Int>) -> Self {
-        MSetAttr {
-            size: value.size.into(),
-            occurrence: value.occurrence.into(),
-        }
-    }
-}
-
-impl TryInto<MSetAttr<Int>> for MSetAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<MSetAttr<Int>, Self::Error> {
-        let size: Range<Int> = self.size.try_into()?;
-        let occurrence: Range<Int> = self.occurrence.try_into()?;
-        Ok(MSetAttr { size, occurrence })
-    }
-}
-
-impl From<FuncAttr<Int>> for FuncAttr<IntVal> {
-    fn from(value: FuncAttr<Int>) -> Self {
-        FuncAttr {
-            size: value.size.into(),
-            partiality: value.partiality,
-            jectivity: value.jectivity,
-        }
-    }
-}
-
-impl TryInto<FuncAttr<Int>> for FuncAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<FuncAttr<Int>, Self::Error> {
-        let size: Range<Int> = self.size.try_into()?;
-        Ok(FuncAttr {
-            size,
-            jectivity: self.jectivity,
-            partiality: self.partiality,
-        })
-    }
-}
-
-impl From<RelAttr<Int>> for RelAttr<IntVal> {
-    fn from(value: RelAttr<Int>) -> Self {
-        RelAttr {
-            size: value.size.into(),
-            binary: value.binary,
-        }
-    }
-}
-
-impl TryInto<RelAttr<Int>> for RelAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<RelAttr<Int>, Self::Error> {
-        let size: Range<Int> = self.size.try_into()?;
-        Ok(RelAttr {
-            size,
-            binary: self.binary,
-        })
-    }
-}
-
-impl From<PartitionAttr<Int>> for PartitionAttr<IntVal> {
-    fn from(value: PartitionAttr<Int>) -> Self {
-        PartitionAttr {
-            num_parts: value.num_parts.into(),
-            part_len: value.part_len.into(),
-            is_regular: value.is_regular,
-        }
-    }
-}
-
-impl TryInto<PartitionAttr<Int>> for PartitionAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<PartitionAttr<Int>, Self::Error> {
-        let num_parts: Range<Int> = self.num_parts.try_into()?;
-        let part_len: Range<Int> = self.part_len.try_into()?;
-        let is_regular: bool = self.is_regular;
-        Ok(PartitionAttr {
-            num_parts,
-            part_len,
-            is_regular,
-        })
-    }
-}
-
-impl From<SequenceAttr<Int>> for SequenceAttr<IntVal> {
-    fn from(value: SequenceAttr<Int>) -> Self {
-        SequenceAttr {
-            size: value.size.into(),
-            jectivity: value.jectivity,
-        }
-    }
-}
-
-impl TryInto<SequenceAttr<Int>> for SequenceAttr<IntVal> {
-    type Error = DomainOpError;
-
-    fn try_into(self) -> Result<SequenceAttr<Int>, Self::Error> {
-        let size: Range<Int> = self.size.try_into()?;
-        Ok(SequenceAttr {
-            size,
-            jectivity: self.jectivity,
-        })
-    }
-}
-
-impl Display for IntVal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IntVal::Const(val) => write!(f, "{val}"),
-            IntVal::Reference(re) => write!(f, "{re}"),
-            IntVal::Expr(expr) => write!(f, "({expr})"),
-        }
-    }
-}
-
-impl IntVal {
-    pub fn new_ref(re: &Reference) -> Option<IntVal> {
-        match re.ptr.kind().deref() {
-            DeclarationKind::ValueLetting(expr, _)
-            | DeclarationKind::TemporaryValueLetting(expr)
-            | DeclarationKind::QuantifiedExpr(expr) => match expr.return_type() {
-                ReturnType::Int => Some(IntVal::Reference(re.clone())),
-                _ => None,
-            },
-            DeclarationKind::Given(dom) => match dom.return_type() {
-                ReturnType::Int => Some(IntVal::Reference(re.clone())),
-                _ => None,
-            },
-            DeclarationKind::Quantified(inner) => match inner.domain().return_type() {
-                ReturnType::Int => Some(IntVal::Reference(re.clone())),
-                _ => None,
-            },
-            DeclarationKind::Find(var) => match var.return_type() {
-                ReturnType::Int => Some(IntVal::Reference(re.clone())),
-                _ => None,
-            },
-            DeclarationKind::DomainLetting(_) => None,
-        }
-    }
-
-    pub fn new_expr(value: Moo<Expression>) -> Option<IntVal> {
-        if value.return_type() != ReturnType::Int {
-            return None;
-        }
-        Some(IntVal::Expr(value))
-    }
-
-    pub fn resolve(&self) -> Option<Int> {
-        match self {
-            IntVal::Const(value) => Some(*value),
-            IntVal::Expr(expr) => eval_expr_to_int(expr),
-            IntVal::Reference(re) => match re.ptr.kind().deref() {
-                DeclarationKind::ValueLetting(expr, _)
-                | DeclarationKind::TemporaryValueLetting(expr) => eval_expr_to_int(expr),
-                // If this is an int given we will be able to resolve it eventually, but not yet
-                DeclarationKind::Given(_) => None,
-                DeclarationKind::Quantified(inner) => {
-                    if let Some(generator) = inner.generator()
-                        && let Some(expr) = generator.as_value_letting()
-                    {
-                        eval_expr_to_int(&expr)
-                    } else {
-                        None
-                    }
-                }
-                // TODO: idk what this whole file does but I very much doubt it affects this
-                DeclarationKind::QuantifiedExpr(_) => None,
-                // Decision variables inside domains are unresolved until solving.
-                DeclarationKind::Find(_) => None,
-                DeclarationKind::DomainLetting(_) => bug!(
-                    "Expected integer expression, given, or letting inside int domain; Got: {re}"
-                ),
-            },
-        }
-    }
-}
-
-fn eval_expr_to_int(expr: &Expression) -> Option<Int> {
-    match eval_constant(expr)? {
-        Literal::Int(v) => Some(v),
-        _ => bug!("Expected integer expression, got: {expr}"),
-    }
-}
-
-impl From<IntVal> for Expression {
-    fn from(value: IntVal) -> Self {
-        match value {
-            IntVal::Const(val) => val.into(),
-            IntVal::Reference(re) => re.into(),
-            IntVal::Expr(expr) => expr.as_ref().clone(),
-        }
-    }
-}
-
-impl From<IntVal> for Moo<Expression> {
-    fn from(value: IntVal) -> Self {
-        match value {
-            IntVal::Const(val) => Moo::new(val.into()),
-            IntVal::Reference(re) => Moo::new(re.into()),
-            IntVal::Expr(expr) => expr,
-        }
-    }
-}
-
-impl std::ops::Neg for IntVal {
-    type Output = IntVal;
-
-    fn neg(self) -> Self::Output {
-        match self {
-            IntVal::Const(val) => IntVal::Const(-val),
-            IntVal::Reference(_) | IntVal::Expr(_) => {
-                IntVal::Expr(Moo::new(Expression::Neg(Metadata::new(), self.into())))
-            }
-        }
-    }
-}
-
-impl<T> std::ops::Add<T> for IntVal
-where
-    T: Into<Expression>,
-{
-    type Output = IntVal;
-
-    fn add(self, rhs: T) -> Self::Output {
-        let lhs: Expression = self.into();
-        let rhs: Expression = rhs.into();
-        let sum = matrix_expr!(lhs, rhs; domain_int!(1..));
-        IntVal::Expr(Moo::new(Expression::Sum(Metadata::new(), Moo::new(sum))))
-    }
-}
-
-impl Range<IntVal> {
-    pub fn resolve(&self) -> Option<Range<Int>> {
-        match self {
-            Range::Single(x) => Some(Range::Single(x.resolve()?)),
-            Range::Bounded(l, r) => Some(Range::Bounded(l.resolve()?, r.resolve()?)),
-            Range::UnboundedL(r) => Some(Range::UnboundedL(r.resolve()?)),
-            Range::UnboundedR(l) => Some(Range::UnboundedR(l.resolve()?)),
-            Range::Unbounded => Some(Range::Unbounded),
-        }
-    }
-}
-
-impl SetAttr<IntVal> {
-    pub fn resolve(&self) -> Option<SetAttr<Int>> {
-        Some(SetAttr {
-            size: self.size.resolve()?,
-        })
-    }
-}
-
-impl SequenceAttr<IntVal> {
-    pub fn resolve(&self) -> Option<SequenceAttr<Int>> {
-        Some(SequenceAttr {
-            size: self.size.resolve()?,
-            jectivity: self.jectivity.clone(),
-        })
-    }
-}
-
-impl MSetAttr<IntVal> {
-    pub fn resolve(&self) -> Option<MSetAttr<Int>> {
-        Some(MSetAttr {
-            size: self.size.resolve()?,
-            occurrence: self.occurrence.resolve()?,
-        })
-    }
-}
-
-impl PartitionAttr<IntVal> {
-    pub fn resolve(&self) -> Option<PartitionAttr<Int>> {
-        Some(PartitionAttr {
-            num_parts: self.num_parts.resolve()?,
-            part_len: self.part_len.resolve()?,
-            is_regular: self.is_regular,
-        })
-    }
-}
-
-impl FuncAttr<IntVal> {
-    pub fn resolve(&self) -> Option<FuncAttr<Int>> {
-        Some(FuncAttr {
-            size: self.size.resolve()?,
-            partiality: self.partiality.clone(),
-            jectivity: self.jectivity.clone(),
-        })
-    }
-}
-
-impl RelAttr<IntVal> {
-    pub fn resolve(&self) -> Option<RelAttr<Int>> {
-        Some(RelAttr {
-            size: self.size.resolve()?,
-            binary: self.binary.clone(),
-        })
-    }
-}
 
 pub(super) type FieldUnresolved = Field<DomainPtr>;
 
@@ -445,37 +66,37 @@ pub enum UnresolvedDomain {
 }
 
 impl UnresolvedDomain {
-    pub fn resolve(&self) -> Option<GroundDomain> {
+    pub fn resolve(&self) -> Result<GroundDomain, DomainOpError> {
         match self {
             UnresolvedDomain::Int(rngs) => rngs
                 .iter()
                 .map(Range::<IntVal>::resolve)
-                .collect::<Option<_>>()
+                .collect::<Result<_, _>>()
                 .map(GroundDomain::Int),
             UnresolvedDomain::Set(attr, inner) => {
-                Some(GroundDomain::Set(attr.resolve()?, inner.resolve()?))
+                Ok(GroundDomain::Set(attr.resolve()?, inner.resolve()?))
             }
             UnresolvedDomain::MSet(attr, inner) => {
-                Some(GroundDomain::MSet(attr.resolve()?, inner.resolve()?))
+                Ok(GroundDomain::MSet(attr.resolve()?, inner.resolve()?))
             }
             UnresolvedDomain::Partition(attr, inner) => {
-                Some(GroundDomain::Partition(attr.resolve()?, inner.resolve()?))
+                Ok(GroundDomain::Partition(attr.resolve()?, inner.resolve()?))
             }
             UnresolvedDomain::Matrix(inner, idx_doms) => {
                 let inner_gd = inner.resolve()?;
                 idx_doms
                     .iter()
                     .map(DomainPtr::resolve)
-                    .collect::<Option<_>>()
+                    .collect::<Result<_, _>>()
                     .map(|idx| GroundDomain::Matrix(inner_gd, idx))
             }
             UnresolvedDomain::Sequence(attr, inner) => {
-                Some(GroundDomain::Sequence(attr.resolve()?, inner.resolve()?))
+                Ok(GroundDomain::Sequence(attr.resolve()?, inner.resolve()?))
             }
             UnresolvedDomain::Tuple(inners) => inners
                 .iter()
                 .map(DomainPtr::resolve)
-                .collect::<Option<_>>()
+                .collect::<Result<_, _>>()
                 .map(GroundDomain::Tuple),
             UnresolvedDomain::Record(entries) => entries
                 .iter()
@@ -485,7 +106,7 @@ impl UnresolvedDomain {
                         value: gd,
                     })
                 })
-                .collect::<Option<_>>()
+                .collect::<Result<_, _>>()
                 .map(GroundDomain::Record),
             UnresolvedDomain::Reference(re) => re
                 .ptr
@@ -495,15 +116,11 @@ impl UnresolvedDomain {
                 })
                 .resolve()
                 .map(Moo::unwrap_or_clone),
-            UnresolvedDomain::Function(attr, dom, cdom) => {
-                if let Some(attr_gd) = attr.resolve()
-                    && let Some(dom_gd) = dom.resolve()
-                    && let Some(cdom_gd) = cdom.resolve()
-                {
-                    return Some(GroundDomain::Function(attr_gd, dom_gd, cdom_gd));
-                }
-                None
-            }
+            UnresolvedDomain::Function(attr, dom, cdom) => Ok(GroundDomain::Function(
+                attr.resolve()?,
+                dom.resolve()?,
+                cdom.resolve()?,
+            )),
             UnresolvedDomain::Variant(entries) => entries
                 .iter()
                 .map(|f| {
@@ -512,14 +129,14 @@ impl UnresolvedDomain {
                         value: gd,
                     })
                 })
-                .collect::<Option<_>>()
+                .collect::<Result<_, _>>()
                 .map(GroundDomain::Variant),
             UnresolvedDomain::Relation(attr, inners) => {
                 let resolved_attr = attr.resolve()?;
                 inners
                     .iter()
                     .map(DomainPtr::resolve)
-                    .collect::<Option<_>>()
+                    .collect::<Result<_, _>>()
                     .map(|items| GroundDomain::Relation(resolved_attr, items))
             }
         }
@@ -584,17 +201,15 @@ impl UnresolvedDomain {
                 Err(DomainOpError::NotGround)
             }
             // TODO: Could we define semantics for merging record domains?
-            #[allow(unreachable_patterns)] // Technically redundant but logically makes sense
+            #[allow(unreachable_patterns)]
             (UnresolvedDomain::Record(_), _) | (_, UnresolvedDomain::Record(_)) => {
                 Err(DomainOpError::WrongType)
             }
             #[allow(unreachable_patterns)]
-            // Technically redundant but logically clearer to have both
             (UnresolvedDomain::Function(_, _, _), _) | (_, UnresolvedDomain::Function(_, _, _)) => {
                 Err(DomainOpError::WrongType)
             }
             #[allow(unreachable_patterns)]
-            // Technically redundant but logically clearer to have both
             (UnresolvedDomain::Partition(_, _), _) | (_, UnresolvedDomain::Partition(_, _)) => {
                 Err(DomainOpError::WrongType)
             }

--- a/crates/conjure-cp-core/src/ast/eval.rs
+++ b/crates/conjure-cp-core/src/ast/eval.rs
@@ -854,7 +854,11 @@ fn eval_comprehension_qualifiers(
     match &comprehension.qualifiers[qualifier_index] {
         ComprehensionQualifier::Generator { ptr } => {
             let domain = ptr.domain()?;
-            let generator_values = domain.resolve()?.values().ok()?.collect_vec();
+            let generator_values = domain
+                .resolve()
+                .and_then(|x| x.values())
+                .ok()?
+                .collect_vec();
 
             for value in generator_values {
                 with_temporary_quantified_binding(ptr, &value, || {

--- a/crates/conjure-cp-core/src/ast/expressions.rs
+++ b/crates/conjure-cp-core/src/ast/expressions.rs
@@ -685,7 +685,7 @@ fn bounded_i32_domain_for_matrix_literal_monotonic(
 
     let expr = exprs.pop()?;
     let dom = expr.domain_of()?;
-    let resolved = dom.resolve()?;
+    let resolved = dom.resolve().ok()?;
     let GroundDomain::Int(ranges) = resolved.as_ref() else {
         return None;
     };
@@ -694,7 +694,7 @@ fn bounded_i32_domain_for_matrix_literal_monotonic(
 
     for expr in exprs {
         let dom = expr.domain_of()?;
-        let resolved = dom.resolve()?;
+        let resolved = dom.resolve().ok()?;
         let GroundDomain::Int(ranges) = resolved.as_ref() else {
             return None;
         };
@@ -861,7 +861,8 @@ impl Expression {
             .or_else(|| matrix_element_domain(e)),
             Expression::UnsafeDiv(_, a, b) => a
                 .domain_of()?
-                .resolve()?
+                .resolve()
+                .ok()?
                 .apply_i32(
                     // rust integer division is truncating; however, we want to always round down,
                     // including for negative numbers.
@@ -872,7 +873,7 @@ impl Expression {
                             None
                         }
                     },
-                    b.domain_of()?.resolve()?.as_ref(),
+                    b.domain_of()?.resolve().ok()?.as_ref(),
                 )
                 .map(DomainPtr::from)
                 .ok(),
@@ -881,7 +882,8 @@ impl Expression {
                 // including for negative numbers.
                 let domain = a
                     .domain_of()?
-                    .resolve()?
+                    .resolve()
+                    .ok()?
                     .apply_i32(
                         |x, y| {
                             if y != 0 {
@@ -890,7 +892,7 @@ impl Expression {
                                 None
                             }
                         },
-                        b.domain_of()?.resolve()?.as_ref(),
+                        b.domain_of()?.resolve().ok()?.as_ref(),
                     )
                     .unwrap_or_else(|err| bug!("Got {err} when computing domain of {self}"));
 
@@ -904,20 +906,22 @@ impl Expression {
             }
             Expression::UnsafeMod(_, a, b) => a
                 .domain_of()?
-                .resolve()?
+                .resolve()
+                .ok()?
                 .apply_i32(
                     |x, y| if y != 0 { Some(x % y) } else { None },
-                    b.domain_of()?.resolve()?.as_ref(),
+                    b.domain_of()?.resolve().ok()?.as_ref(),
                 )
                 .map(DomainPtr::from)
                 .ok(),
             Expression::SafeMod(_, a, b) => {
                 let domain = a
                     .domain_of()?
-                    .resolve()?
+                    .resolve()
+                    .ok()?
                     .apply_i32(
                         |x, y| if y != 0 { Some(x % y) } else { None },
-                        b.domain_of()?.resolve()?.as_ref(),
+                        b.domain_of()?.resolve().ok()?.as_ref(),
                     )
                     .unwrap_or_else(|err| bug!("Got {err} when computing domain of {self}"));
 
@@ -931,7 +935,8 @@ impl Expression {
             }
             Expression::SafePow(_, a, b) | Expression::UnsafePow(_, a, b) => a
                 .domain_of()?
-                .resolve()?
+                .resolve()
+                .ok()?
                 .apply_i32(
                     |x, y| {
                         if (x != 0 || y != 0) && y >= 0 {
@@ -940,7 +945,7 @@ impl Expression {
                             None
                         }
                     },
-                    b.domain_of()?.resolve()?.as_ref(),
+                    b.domain_of()?.resolve().ok()?.as_ref(),
                 )
                 .map(DomainPtr::from)
                 .ok(),
@@ -973,7 +978,7 @@ impl Expression {
                     }
                 } else {
                     // TODO: currently only works for matrices
-                    let dom = m.domain_of()?.resolve()?;
+                    let dom = m.domain_of()?.resolve().ok()?;
                     let (val_dom, idx_doms) = match dom.as_ref() {
                         GroundDomain::Matrix(val, idx) => (val, idx),
                         _ => return None,
@@ -1015,8 +1020,8 @@ impl Expression {
                 Some(Domain::int(ranges))
             }
             Expression::Minus(_, a, b) => {
-                let a_resolved = a.domain_of()?.resolve()?;
-                let b_resolved = b.domain_of()?.resolve()?;
+                let a_resolved = a.domain_of()?.resolve().ok()?;
+                let b_resolved = b.domain_of()?.resolve().ok()?;
 
                 if matches!(a_resolved.as_ref(), GroundDomain::Int(_))
                     && matches!(b_resolved.as_ref(), GroundDomain::Int(_))
@@ -1040,8 +1045,12 @@ impl Expression {
             Expression::FlatWeightedSumGeq(_, _, _, _) => Some(Domain::bool()),
             Expression::Abs(_, a) => a
                 .domain_of()?
-                .resolve()?
-                .apply_i32(|a, _| Some(a.abs()), a.domain_of()?.resolve()?.as_ref())
+                .resolve()
+                .ok()?
+                .apply_i32(
+                    |a, _| Some(a.abs()),
+                    a.domain_of()?.resolve().ok()?.as_ref(),
+                )
                 .map(DomainPtr::from)
                 .ok(),
             Expression::MinionPow(_, _, _, _) => Some(Domain::bool()),
@@ -1051,14 +1060,16 @@ impl Expression {
             }
             Expression::PairwiseSum(_, a, b) => a
                 .domain_of()?
-                .resolve()?
-                .apply_i32(|a, b| Some(a + b), b.domain_of()?.resolve()?.as_ref())
+                .resolve()
+                .ok()?
+                .apply_i32(|a, b| Some(a + b), b.domain_of()?.resolve().ok()?.as_ref())
                 .map(DomainPtr::from)
                 .ok(),
             Expression::PairwiseProduct(_, a, b) => a
                 .domain_of()?
-                .resolve()?
-                .apply_i32(|a, b| Some(a * b), b.domain_of()?.resolve()?.as_ref())
+                .resolve()
+                .ok()?
+                .apply_i32(|a, b| Some(a * b), b.domain_of()?.resolve().ok()?.as_ref())
                 .map(DomainPtr::from)
                 .ok(),
             Expression::Defined(_, function) => {
@@ -1074,9 +1085,9 @@ impl Expression {
             }
             Expression::Range(_, function) => {
                 let (attrs, domain, codomain) = function.domain_of()?.as_function()?;
-                let jectivity = attrs.resolve()?.jectivity;
+                let jectivity = attrs.resolve().ok()?.jectivity;
 
-                let size_size = attrs.resolve()?.size;
+                let size_size = attrs.resolve().ok()?.size;
                 let size_size = match size_size {
                     Range::Unbounded => Range::UnboundedR(0),
                     // If lower bound we can guarantee one mapping (unless size = 0)
@@ -1097,7 +1108,7 @@ impl Expression {
                 };
 
                 // Gets the size imposed by the partiality and jectivity attributes
-                let partiality = attrs.resolve()?.partiality;
+                let partiality = attrs.resolve().ok()?.partiality;
                 let codomain_length = codomain.length_signed();
                 let attr_size = match jectivity {
                     // Bijective and surjective functions must have every element in the codomain mapped to
@@ -1158,7 +1169,7 @@ impl Expression {
             Expression::PreImage(_, function, _) => {
                 let (attrs, domain, codomain) = function.domain_of()?.as_function()?;
 
-                let size_size = attrs.resolve()?.size;
+                let size_size = attrs.resolve().ok()?.size;
                 let size_size = match size_size {
                     // Our only guarantee is an upper bound is the same
                     Range::Unbounded => Range::UnboundedR(0),
@@ -1168,7 +1179,7 @@ impl Expression {
                     Range::Bounded(_, y) => Range::Bounded(0, y),
                 };
 
-                let jectivity = attrs.resolve()?.jectivity;
+                let jectivity = attrs.resolve().ok()?.jectivity;
                 let codomain_length = codomain.length_signed();
                 let attr_size = match jectivity {
                     // When there is 1-to-1 mapping we can guarantee no more than 1 occurrence
@@ -1253,7 +1264,7 @@ impl Expression {
                         new_dom = Domain::int(ranges);
                     }
                 }
-                let attr_size = attrs.resolve()?.size;
+                let attr_size = attrs.resolve().ok()?.size;
                 let new_size = match new_dom.length_signed() {
                     // Combines current size attributes with length of new domain
                     Ok(len) => match Range::minimal(&[attr_size, Range::Bounded(0, len)]) {
@@ -1378,8 +1389,8 @@ impl Expression {
                 let (attr, inner) = p.domain_of()?.as_partition()?;
                 let len = inner.length_signed().ok()?;
 
-                let p_parts = attr.resolve()?.num_parts;
-                let p_card = attr.resolve()?.part_len;
+                let p_parts = attr.resolve().ok()?.num_parts;
+                let p_card = attr.resolve().ok()?.part_len;
 
                 // if
                 match (p_parts.low(), p_parts.high(), p_card.low(), p_card.high()) {
@@ -1445,21 +1456,20 @@ impl Expression {
                         Some(Domain::int(vec![Range::<i32>::Unbounded]))
                     }
                 } else if let Some((attr, dom)) = domain.as_set() {
-                    let attr_size = attr.resolve()?.size;
+                    let attr_size = attr.resolve().ok()?.size;
                     if let Ok(length) = dom.length_signed() {
                         let unsafe_range = Range::minimal(&[attr_size, Range::Bounded(0, length)]);
-                        match unsafe_range {
-                            Ok(range) => return Some(Domain::int(vec![range])),
-                            Err(_) => return None,
-                        }
+                        return match unsafe_range {
+                            Ok(range) => Some(Domain::int(vec![range])),
+                            Err(_) => None,
+                        };
                     }
                     // If the domain is not known we just need to go off of attributes
                     Some(Domain::int(vec![attr_size]))
                 } else if let Some((attrs, dom)) = domain.as_mset() {
-                    let attr_size = attrs.resolve()?.size;
-                    let attr_occ_range = attrs.resolve()?.occurrence;
+                    let attrs_gd = attrs.resolve().ok()?;
                     // Gets maximum value of the occurrence
-                    let attr_occ = match attr_occ_range {
+                    let attr_occ = match attrs_gd.occurrence {
                         Range::Single(x) => Some(x),
                         Range::Unbounded | Range::UnboundedR(_) => None,
                         Range::Bounded(_, x) => Some(x),
@@ -1468,37 +1478,37 @@ impl Expression {
                     if let Some(occ) = attr_occ {
                         if let Ok(length) = dom.length_signed() {
                             let unsafe_range =
-                                Range::minimal(&[attr_size, Range::Bounded(0, length * occ)]);
+                                Range::minimal(&[attrs_gd.size, Range::Bounded(0, length * occ)]);
                             match unsafe_range {
                                 Ok(range) => Some(Domain::int(vec![range])),
                                 Err(_) => None,
                             }
                         } else {
                             // If the domain is not known we just need to go off of attributes
-                            Some(Domain::int(vec![attr_size]))
+                            Some(Domain::int(vec![attrs_gd.size]))
                         }
                     } else {
                         // If no occurrence is provided then it must have bounded size
-                        Some(Domain::int(vec![attr_size]))
+                        Some(Domain::int(vec![attrs_gd.size]))
                     }
                 } else if let Some((attrs, doms)) = domain.as_relation() {
                     // TODO: Further inference may be possible using the binary attributes
 
-                    let attr_size = attrs.resolve()?.size;
+                    let attrs_gd = attrs.resolve().ok()?;
                     // See if all domains are ground
                     let doms_sizes: Result<Vec<i32>, _> =
                         doms.iter().map(|x| x.length_signed()).collect();
                     if let Ok(doms_sizes) = doms_sizes {
                         let length = Range::Bounded(0, doms_sizes.iter().product());
                         // Combine the attributes and the domain possibilities
-                        let unsafe_range = Range::minimal(&[attr_size, length]);
-                        match unsafe_range {
-                            Ok(range) => return Some(Domain::int(vec![range])),
-                            Err(_) => return None,
-                        }
+                        let unsafe_range = Range::minimal(&[attrs_gd.size, length]);
+                        return match unsafe_range {
+                            Ok(range) => Some(Domain::int(vec![range])),
+                            Err(_) => None,
+                        };
                     }
                     // If the domain is not known we just need to go off of attributes
-                    Some(Domain::int(vec![attr_size]))
+                    Some(Domain::int(vec![attrs_gd.size]))
                 } else if let Some((attrs, dom, codom)) = domain.as_function() {
                     let size = Self::function_elements_size(attrs, &dom, &codom);
                     size.map(|size| Domain::int(vec![size]))
@@ -1517,22 +1527,17 @@ impl Expression {
         domain: &DomainPtr,
         codomain: &DomainPtr,
     ) -> Option<Range> {
-        // Gets the size imposed by the size attribute
-        // The elements defined in the domain is the same as the size of the function itself
-        let size_size = attrs.resolve()?.size;
-        // Gets the size imposed by the partiality and jectivity attributes
-        let partiality = attrs.resolve()?.partiality;
-        let jectivity = attrs.resolve()?.jectivity;
+        let attrs_gd = attrs.resolve().ok()?;
         let domain_length = domain.length_signed();
         // We can only infer if the domain is ground and the length is known
         let attr_size = match domain_length {
-            Ok(len) => match partiality {
+            Ok(len) => match attrs_gd.partiality {
                 PartialityAttr::Total => Some(Range::Single(len)),
                 PartialityAttr::Partial => {
                     // When partial we also need the codomain to be ground and known
                     let codomain_length = codomain.length_signed();
                     match codomain_length {
-                        Ok(co_len) => match jectivity {
+                        Ok(co_len) => match attrs_gd.jectivity {
                             JectivityAttr::Bijective => Some(Range::Single(co_len)),
                             JectivityAttr::Surjective => Some(Range::Bounded(co_len, len)),
                             JectivityAttr::Injective => {
@@ -1547,16 +1552,16 @@ impl Expression {
             Err(_) => None,
         };
         // We combine the sizes:
-        // size_size relates to size constraints imposed by the size attributes of the function
+        // attrs_gd.size relates to size constraints imposed by the size attributes of the function
         // attr_size relates to size constraints imposed by the jectivity and partiality attributes.
         //       This uses inference from the domain and codomain lengths.
         // If the attributes clash the function is unsolveable, and an empty domain is returned
         match attr_size {
             Some(attr_size) => {
-                let unsafe_range = Range::minimal(&[size_size, attr_size]);
+                let unsafe_range = Range::minimal(&[attrs_gd.size, attr_size]);
                 unsafe_range.ok()
             }
-            None => Some(size_size),
+            None => Some(attrs_gd.size),
         }
     }
 
@@ -1842,14 +1847,14 @@ impl Expression {
 pub fn get_function_codomain(function: &Moo<Expression>) -> Option<DomainPtr> {
     let function_domain = function.domain_of()?;
     match function_domain.resolve().as_ref() {
-        Some(d) => {
+        Ok(d) => {
             match d.as_ref() {
                 GroundDomain::Function(_, _, codomain) => Some(codomain.clone().into()),
                 // Not defined for anything other than a function
                 _ => None,
             }
         }
-        None => {
+        Err(_) => {
             match function_domain.as_unresolved()? {
                 UnresolvedDomain::Function(_, _, codomain) => Some(codomain.clone()),
                 // Not defined for anything other than a function

--- a/crates/conjure-cp-core/src/ast/literals.rs
+++ b/crates/conjure-cp-core/src/ast/literals.rs
@@ -857,7 +857,7 @@ impl AbstractLiteral<Expression> {
                     literals.push(literal);
                 }
 
-                Some(AbstractLiteral::Matrix(literals, domain.resolve()?))
+                Some(AbstractLiteral::Matrix(literals, domain.resolve().ok()?))
             }
             AbstractLiteral::Sequence(elements) => {
                 let literals = elements

--- a/crates/conjure-cp-core/src/ast/matrix.rs
+++ b/crates/conjure-cp-core/src/ast/matrix.rs
@@ -254,7 +254,7 @@ pub fn resolved_index_domains(
 ) -> Result<Vec<Moo<GroundDomain>>, DomainOpError> {
     index_domains(matrix)
         .into_iter()
-        .map(|d| d.resolve().ok_or(DomainOpError::NotGround))
+        .map(|d| d.resolve())
         .try_collect()
 }
 
@@ -379,7 +379,7 @@ pub fn flat_index_to_full_index(index_domains: &[Moo<GroundDomain>], index: u64)
 /// the literal's realised size in that dimension. For non-literals, this falls back to the
 /// expression's resolved domain.
 pub fn bound_index_domains_of_expr(expr: &Expr) -> Option<Vec<Moo<GroundDomain>>> {
-    let dom = expr.domain_of().and_then(|dom| dom.resolve())?;
+    let dom = expr.domain_of().and_then(|dom| dom.resolve().ok())?;
     let GroundDomain::Matrix(_, index_domains) = dom.as_ref() else {
         return None;
     };

--- a/crates/conjure-cp-core/src/ast/partial_eval.rs
+++ b/crates/conjure-cp-core/src/ast/partial_eval.rs
@@ -67,7 +67,7 @@ fn simplify_in_domain(expr: &Expr, domain: &DomainPtr) -> Option<bool> {
     }
 
     let expr_domain = resolved_ground_domain_of_for_partial_eval(expr)?;
-    let domain = domain.resolve()?;
+    let domain = domain.resolve().ok()?;
     let intersection = expr_domain.intersect(&domain).ok()?;
 
     if normalise_int_domain(&intersection) == normalise_int_domain(expr_domain.as_ref()) {
@@ -153,7 +153,7 @@ fn resolved_ground_domain_of_for_partial_eval(expr: &Expr) -> Option<Moo<GroundD
             }
         }
         Expr::UnsafeIndex(_, _, _) | Expr::UnsafeSlice(_, _, _) => None,
-        _ => expr.domain_of()?.resolve(),
+        _ => expr.domain_of()?.resolve().ok(),
     }
 }
 
@@ -274,8 +274,8 @@ pub fn run_partial_evaluator(expr: &Expr) -> ApplicationResult {
                     .domain()
                     .ok_or(RuleNotApplicable)?
                     .resolve()
-                    .ok_or(RuleNotApplicable)?;
-                let domain = domain.resolve().ok_or(RuleNotApplicable)?;
+                    .map_err(|_| RuleNotApplicable)?;
+                let domain = domain.resolve().map_err(|_| RuleNotApplicable)?;
 
                 let intersection = decl_domain
                     .intersect(&domain)
@@ -302,10 +302,8 @@ pub fn run_partial_evaluator(expr: &Expr) -> ApplicationResult {
             } else if let Expr::Atomic(_, Atom::Literal(lit)) = x.as_ref() {
                 if domain
                     .resolve()
-                    .ok_or(RuleNotApplicable)?
-                    .contains(lit)
-                    .ok()
-                    .ok_or(RuleNotApplicable)?
+                    .and_then(|gd| gd.contains(lit))
+                    .map_err(|_| RuleNotApplicable)?
                 {
                     Ok(Reduction::pure(Expr::Atomic(Metadata::new(), true.into())))
                 } else {
@@ -643,23 +641,23 @@ pub fn run_partial_evaluator(expr: &Expr) -> ApplicationResult {
         }
         Expr::Imply(_m, x, y) => {
             if let Expr::Atomic(_, Atom::Literal(Lit::Bool(x))) = x.as_ref() {
-                if *x {
+                return if *x {
                     // (true) -> y ~~> y
-                    return Ok(Reduction::pure(Moo::unwrap_or_clone(y.clone())));
+                    Ok(Reduction::pure(Moo::unwrap_or_clone(y.clone())))
                 } else {
                     // (false) -> y ~~> true
-                    return Ok(Reduction::pure(Expr::Atomic(Metadata::new(), true.into())));
-                }
+                    Ok(Reduction::pure(Expr::Atomic(Metadata::new(), true.into())))
+                };
             };
 
             if let Expr::Atomic(_, Atom::Literal(Lit::Bool(y))) = y.as_ref() {
-                if *y {
+                return if *y {
                     // x -> (true) ~~> true
-                    return Ok(Reduction::pure(Expr::from(true)));
+                    Ok(Reduction::pure(Expr::from(true)))
                 } else {
                     // x -> (false) ~~> !x
-                    return Ok(Reduction::pure(Expr::Not(Metadata::new(), x.clone())));
-                }
+                    Ok(Reduction::pure(Expr::Not(Metadata::new(), x.clone())))
+                };
             };
 
             // reflexivity: p -> p ~> true
@@ -677,22 +675,22 @@ pub fn run_partial_evaluator(expr: &Expr) -> ApplicationResult {
         }
         Expr::Iff(_m, x, y) => {
             if let Expr::Atomic(_, Atom::Literal(Lit::Bool(x))) = x.as_ref() {
-                if *x {
+                return if *x {
                     // (true) <-> y ~~> y
-                    return Ok(Reduction::pure(Moo::unwrap_or_clone(y.clone())));
+                    Ok(Reduction::pure(Moo::unwrap_or_clone(y.clone())))
                 } else {
                     // (false) <-> y ~~> !y
-                    return Ok(Reduction::pure(Expr::Not(Metadata::new(), y.clone())));
-                }
+                    Ok(Reduction::pure(Expr::Not(Metadata::new(), y.clone())))
+                };
             };
             if let Expr::Atomic(_, Atom::Literal(Lit::Bool(y))) = y.as_ref() {
-                if *y {
+                return if *y {
                     // x <-> (true) ~~> x
-                    return Ok(Reduction::pure(Moo::unwrap_or_clone(x.clone())));
+                    Ok(Reduction::pure(Moo::unwrap_or_clone(x.clone())))
                 } else {
                     // x <-> (false) ~~> !x
-                    return Ok(Reduction::pure(Expr::Not(Metadata::new(), x.clone())));
-                }
+                    Ok(Reduction::pure(Expr::Not(Metadata::new(), x.clone())))
+                };
             };
 
             // reflexivity: p <-> p ~> true

--- a/crates/conjure-cp-core/src/ast/reference.rs
+++ b/crates/conjure-cp-core/src/ast/reference.rs
@@ -57,7 +57,7 @@ impl Reference {
     }
 
     pub fn resolved_domain(&self) -> Option<Moo<GroundDomain>> {
-        self.domain()?.resolve()
+        self.domain()?.resolve().ok()
     }
 
     /// Returns the expression behind a value-letting reference, if this is one.

--- a/crates/conjure-cp-core/src/ast/symbol_table.rs
+++ b/crates/conjure-cp-core/src/ast/symbol_table.rs
@@ -350,7 +350,7 @@ impl SymbolTable {
     ///
     /// See [`SymbolTable::domain`].
     pub fn resolve_domain(&self, name: &Name) -> Option<Moo<GroundDomain>> {
-        self.domain(name)?.resolve()
+        self.domain(name)?.resolve().ok()
     }
 
     /// Iterates over entries in the LOCAL symbol table.

--- a/crates/conjure-cp-core/src/ast/types.rs
+++ b/crates/conjure-cp-core/src/ast/types.rs
@@ -29,6 +29,20 @@ pub enum ReturnType {
     Unknown,
 }
 
+impl ReturnType {
+    /// If this is a collection of elements of the same type (e.g. matrix / set),
+    /// get the element type. Otherwise, returns None.
+    pub fn elem_type(&self) -> Option<ReturnType> {
+        match self {
+            ReturnType::Matrix(e)
+            | ReturnType::Set(e)
+            | ReturnType::MSet(e)
+            | ReturnType::Sequence(e) => Some(*e.clone()),
+            _ => None,
+        }
+    }
+}
+
 /// Guaranteed to always typecheck
 pub trait Typeable {
     fn return_type(&self) -> ReturnType;

--- a/crates/conjure-cp-core/src/instantiate.rs
+++ b/crates/conjure-cp-core/src/instantiate.rs
@@ -43,12 +43,12 @@ pub fn instantiate_model(problem_model: Model, param_model: Model) -> anyhow::Re
             let expr_value = eval_constant(&expr)
                 .ok_or_else(|| anyhow!("Letting expression `{expr}` cannot be evaluated"))?;
 
-            let Some(ground_domain) = domain.resolve() else {
+            let Ok(ground_domain) = domain.resolve() else {
                 next_pending.push(name);
                 continue;
             };
 
-            if !ground_domain.contains(&expr_value).unwrap() {
+            if !ground_domain.contains(&expr_value)? {
                 return Err(anyhow!(
                     "Domain of given statement `{name}` does not contain letting value"
                 ));

--- a/crates/conjure-cp-core/src/parse/parse_model.rs
+++ b/crates/conjure-cp-core/src/parse/parse_model.rs
@@ -734,16 +734,17 @@ fn parse_expression_to_int_val(obj: &JsonValue, scope: &SymbolTablePtr) -> Resul
     let expr = parse_expression(obj, scope)?;
 
     if let Some(Literal::Int(i)) = expr.clone().into_literal() {
-        return Ok(IntVal::Const(i));
+        return Ok(IntVal::Const(i as i64));
     }
 
     if let Expression::Atomic(_, Atom::Reference(reference)) = &expr
-        && let Some(reference_val) = IntVal::new_ref(reference)
+        && let Ok(reference_val) = IntVal::new_ref(reference)
     {
         return Ok(reference_val);
     }
 
-    IntVal::new_expr(Moo::new(expr)).ok_or(error!("Could not parse integer expression"))
+    IntVal::new_expr(Moo::new(expr))
+        .map_err(|e| error!(format!("Could not parse integer expression: {e}")))
 }
 
 type BinOp = fn(Metadata, Moo<Expression>, Moo<Expression>) -> Expression;

--- a/crates/conjure-cp-core/src/solver/adaptors/minion/parse_model.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/minion/parse_model.rs
@@ -121,12 +121,10 @@ fn load_var(
     let resolved_domain = var.domain_of().resolve();
     let force_discrete = table_vars.contains(name);
     match resolved_domain.as_deref() {
-        Some(conjure_ast::GroundDomain::Int(ranges)) => {
+        Ok(conjure_ast::GroundDomain::Int(ranges)) => {
             load_intdomain_var(name, ranges, search_var, force_discrete, minion_model)
         }
-        Some(conjure_ast::GroundDomain::Bool) => {
-            load_booldomain_var(name, search_var, minion_model)
-        }
+        Ok(conjure_ast::GroundDomain::Bool) => load_booldomain_var(name, search_var, minion_model),
         x => Err(ModelFeatureNotSupported(format!("{x:?}"))),
     }
 }

--- a/crates/conjure-cp-core/src/solver/adaptors/smt/convert_model.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/smt/convert_model.rs
@@ -67,7 +67,7 @@ fn var_to_ast(
     let dom = var
         .domain_of()
         .resolve()
-        .unwrap_or_else(|| bug!("could not resolve domain for {}", name));
+        .unwrap_or_else(|e| bug!("could not resolve domain for {name}: {e}"));
     let (sort, restrict_fn) = domain_to_sort(dom.as_ref(), theories)?;
     let new_const = Dynamic::new_const(sym.clone(), &sort);
 
@@ -256,7 +256,7 @@ fn list_elements(expr: &Expression) -> SolverResult<Vec<Expression>> {
 
     let subject_domain = subject
         .domain_of()
-        .and_then(|d| d.resolve())
+        .and_then(|d| d.resolve().ok())
         .ok_or_else(|| {
             SolverError::ModelFeatureNotImplemented(format!(
                 "cannot resolve domain of sliced expression: {expr}"

--- a/crates/conjure-cp-essence-parser/src/parser/atom.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/atom.rs
@@ -379,7 +379,7 @@ fn typecheck_variable(
 
     // Get the variable's domain and resolve it
     let domain = decl.domain()?;
-    let ground_domain = domain.resolve()?;
+    let ground_domain = domain.resolve().ok()?;
 
     // Determine what type is expected
     let expected = match context {

--- a/crates/conjure-cp-essence-parser/src/parser/domain.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/domain.rs
@@ -215,15 +215,14 @@ fn parse_int_domain(
     if all_resolved {
         let ranges: Vec<Range<i32>> = ranges_unresolved
             .into_iter()
-            .map(|r| match r {
-                Range::Single(IntVal::Const(v)) => Range::Single(v),
-                Range::Bounded(IntVal::Const(l), IntVal::Const(u)) => Range::Bounded(l, u),
-                Range::UnboundedR(IntVal::Const(l)) => Range::UnboundedR(l),
-                Range::UnboundedL(IntVal::Const(u)) => Range::UnboundedL(u),
-                Range::Unbounded => Range::Unbounded,
-                _ => unreachable!("all_resolved should be true only if all are Const"),
-            })
-            .collect();
+            .map(|r| r.resolve())
+            .collect::<Result<_, _>>()
+            .map_err(|e| {
+                FatalParseError::internal_error(
+                    format!("could not resolve range: {e}"),
+                    Some(int_domain.range()),
+                )
+            })?;
 
         ctx.add_span_and_doc_hover(&int_keyword_node, "L_int", SymbolKind::Domain, None, None);
         Ok(Some(Domain::int(ranges)))
@@ -243,11 +242,11 @@ fn parse_int_val(ctx: &mut ParseContext, node: Node) -> Result<Option<IntVal>, F
     if node.kind() == "atom" {
         let text = &ctx.source_code[node.start_byte()..node.end_byte()];
         if let Ok(integer) = text.parse::<i32>() {
-            return Ok(Some(IntVal::Const(integer)));
+            return Ok(Some(IntVal::new_const(integer)));
         }
         // Otherwise, check if it's an identifier reference
         let Some(decl) = get_declaration_ptr_from_identifier(ctx, node)? else {
-            // If identifier isn't defined, its a semantic error
+            // If identifier isn't defined, it's a semantic error
             return Ok(None);
         };
         return Ok(Some(IntVal::Reference(Reference::new(decl))));

--- a/crates/conjure-cp-essence-parser/src/parser/expression.rs
+++ b/crates/conjure-cp-essence-parser/src/parser/expression.rs
@@ -611,7 +611,7 @@ fn inferred_context_from_expression(expr: &Expression) -> TypecheckingContext {
     let Some(domain) = expr.domain_of() else {
         return TypecheckingContext::Unknown;
     };
-    let Some(ground) = domain.resolve() else {
+    let Ok(ground) = domain.resolve() else {
         return TypecheckingContext::Unknown;
     };
 

--- a/crates/conjure-cp-rules/src/comprehensions/expansion/expand_native.rs
+++ b/crates/conjure-cp-rules/src/comprehensions/expansion/expand_native.rs
@@ -83,9 +83,9 @@ fn expand_qualifiers(
 }
 
 fn resolve_generator_values(name: &Name, domain: &DomainPtr) -> Result<Vec<Literal>, SolverError> {
-    let resolved = domain.resolve().ok_or_else(|| {
+    let resolved = domain.resolve().map_err(|e| {
         SolverError::ModelFeatureNotSupported(format!(
-            "quantified variable '{name}' has unresolved domain after assigning previous generators: {domain}"
+            "quantified variable '{name}' has unresolved domain after assigning previous generators: {domain}; error: {e}"
         ))
     })?;
 

--- a/crates/conjure-cp-rules/src/matrix/bubble.rs
+++ b/crates/conjure-cp-rules/src/matrix/bubble.rs
@@ -20,7 +20,7 @@ fn expression_membership_proof(
     domain: &GroundDomain,
     index: &Expression,
 ) -> Result<MembershipProof, ApplicationError> {
-    let Some(index_domain) = index.domain_of().and_then(|domain| domain.resolve()) else {
+    let Some(index_domain) = index.domain_of().and_then(|domain| domain.resolve().ok()) else {
         return Ok(MembershipProof::Unknown);
     };
 
@@ -109,7 +109,7 @@ fn index_to_bubble(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
         .domain_of()
         .ok_or(ApplicationError::DomainError)?
         .resolve()
-        .ok_or(RuleNotApplicable)?;
+        .map_err(|_| RuleNotApplicable)?;
 
     // TODO: tuple, this is a hack right now just to avoid the rule being applied to tuples, but could we safely modify the rule to
     // handle tuples as well?
@@ -160,7 +160,7 @@ fn slice_to_bubble(expr: &Expression, _: &SymbolTable) -> ApplicationResult {
         .domain_of()
         .ok_or(ApplicationError::DomainError)?
         .resolve()
-        .ok_or(RuleNotApplicable)?;
+        .map_err(|_| RuleNotApplicable)?;
 
     let GroundDomain::Matrix(_, index_domains) = domain.as_ref() else {
         bug!(

--- a/crates/conjure-cp-rules/src/select_representation.rs
+++ b/crates/conjure-cp-rules/src/select_representation.rs
@@ -42,7 +42,7 @@ fn select_representation_matrix(expr: &Expr, symbols: &SymbolTable) -> Applicati
     let matrix_vars = symbols.clone().into_iter_local().filter_map(|(n, decl)| {
         let id = decl.id();
         let var = decl.as_find()?.clone();
-        let resolved_domain = var.domain.resolve()?;
+        let resolved_domain = var.domain.resolve().ok()?;
 
         let GroundDomain::Matrix(valdom, indexdoms) = resolved_domain.as_ref() else {
             return None;

--- a/crates/conjure-cp-rules/src/smt/smt_rules.rs
+++ b/crates/conjure-cp-rules/src/smt/smt_rules.rs
@@ -20,7 +20,7 @@ fn flatten_indomain(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     };
 
-    let dom = domain.resolve().ok_or(RuleNotApplicable)?;
+    let dom = domain.resolve().map_err(|_| RuleNotApplicable)?;
     let new_expr = match dom.as_ref() {
         // Bool values are always in the bool domain
         GroundDomain::Bool => Ok(Expr::Atomic(
@@ -296,8 +296,14 @@ fn unwrap_subseteq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     };
 
-    let dom_a = a.domain_of().and_then(|d| d.resolve()).ok_or(DomainError)?;
-    let dom_b = b.domain_of().and_then(|d| d.resolve()).ok_or(DomainError)?;
+    let dom_a = a
+        .domain_of()
+        .and_then(|d| d.resolve().ok())
+        .ok_or(DomainError)?;
+    let dom_b = b
+        .domain_of()
+        .and_then(|d| d.resolve().ok())
+        .ok_or(DomainError)?;
 
     let GroundDomain::Set(_, elem_dom_a) = dom_a.as_ref() else {
         return Err(RuleNotApplicable);
@@ -338,8 +344,14 @@ fn unwrap_set_eq(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
         return Err(RuleNotApplicable);
     };
 
-    let dom_a = a.domain_of().and_then(|d| d.resolve()).ok_or(DomainError)?;
-    let dom_b = b.domain_of().and_then(|d| d.resolve()).ok_or(DomainError)?;
+    let dom_a = a
+        .domain_of()
+        .and_then(|d| d.resolve().ok())
+        .ok_or(DomainError)?;
+    let dom_b = b
+        .domain_of()
+        .and_then(|d| d.resolve().ok())
+        .ok_or(DomainError)?;
 
     let GroundDomain::Set(_, elem_dom_a) = dom_a.as_ref() else {
         return Err(RuleNotApplicable);

--- a/crates/conjure-cp-rules/src/smt/unwrap_alldiff.rs
+++ b/crates/conjure-cp-rules/src/smt/unwrap_alldiff.rs
@@ -26,7 +26,7 @@ fn unwrap_alldiff(expr: &Expr, _: &SymbolTable) -> ApplicationResult {
     };
 
     let dom = m.domain_of().ok_or(RuleNotApplicable)?;
-    let Some(GroundDomain::Matrix(val_domain, index_domains)) =
+    let Ok(GroundDomain::Matrix(val_domain, index_domains)) =
         dom.resolve().map(Moo::unwrap_or_clone)
     else {
         return Err(RuleNotApplicable);

--- a/crates/conjure-cp-rules/src/variables_in_domains.rs
+++ b/crates/conjure-cp-rules/src/variables_in_domains.rs
@@ -7,6 +7,7 @@ use conjure_cp::{
         Atom, DecisionVariable, DeclarationKind, Domain, DomainPtr, Expression as Expr, HasDomain,
         IntVal, Literal as Lit, Metadata, Moo, Name, Range, Reference, SymbolTable,
     },
+    bug,
     rule_engine::{ApplicationError, ApplicationResult, Reduction, register_rule},
 };
 use uniplate::Biplate;
@@ -51,7 +52,7 @@ fn handle_variables_in_domains(expr: &Expr, symbols: &SymbolTable) -> Applicatio
             known_int_bounds.insert(decl.name().clone(), bounds);
         }
 
-        if domain.resolve().is_some() {
+        if domain.resolve().is_ok() {
             continue;
         }
 
@@ -104,7 +105,7 @@ fn symbols_have_decision_variable_references(symbols: &SymbolTable) -> bool {
                     })
         }) || declaration.as_find().is_some_and(|find| {
             let domain = find.domain_of();
-            domain.resolve().is_none() && domain.as_ref().as_int().is_some()
+            domain.resolve().is_ok() && domain.as_ref().as_int().is_some()
         })
     })
 }
@@ -117,7 +118,7 @@ fn resolve_or_widen_int_domain(
     known_int_bounds: &mut IntBoundsCache,
     visiting: &mut VisitingStack,
 ) -> Option<DomainPtr> {
-    if let Some(resolved) = domain.resolve() {
+    if let Ok(resolved) = domain.resolve() {
         return Some(resolved.into());
     }
 
@@ -176,12 +177,12 @@ fn int_val_bounds(
     known_int_bounds: &mut IntBoundsCache,
     visiting: &mut VisitingStack,
 ) -> Option<(i32, i32)> {
-    if let Some(v) = value.resolve() {
+    if let Ok(v) = value.resolve() {
         return Some((v, v));
     }
 
     match value {
-        IntVal::Const(v) => Some((*v, *v)),
+        IntVal::Const(v) => Some((*v as i32, *v as i32)),
         IntVal::Reference(reference) => {
             let name = reference.name().clone();
             int_bounds_for_name(&name, symbols, known_int_bounds, visiting)
@@ -241,7 +242,7 @@ fn domain_consistency_constraints(
     declaration: &conjure_cp::ast::DeclarationPtr,
     original_domain: &DomainPtr,
 ) -> Option<Vec<Expr>> {
-    if original_domain.resolve().is_some() {
+    if original_domain.resolve().is_ok() {
         return Some(Vec::new());
     }
 
@@ -256,23 +257,26 @@ fn domain_consistency_constraints(
     );
     let mut allowed_intervals = Vec::new();
 
+    let make_expr =
+        |iv: IntVal| Expr::try_from(iv).unwrap_or_else(|e| bug!("invalid int domain range: {e}"));
+
     for range in ranges {
         let interval = match range {
             Range::Single(v) => Expr::Eq(
                 Metadata::new(),
                 Moo::new(var_expr.clone()),
-                Moo::new(Expr::from(v)),
+                Moo::new(make_expr(v)),
             ),
             Range::Bounded(l, r) => {
                 let geq = Expr::Geq(
                     Metadata::new(),
                     Moo::new(var_expr.clone()),
-                    Moo::new(Expr::from(l)),
+                    Moo::new(make_expr(l)),
                 );
                 let leq = Expr::Leq(
                     Metadata::new(),
                     Moo::new(var_expr.clone()),
-                    Moo::new(Expr::from(r)),
+                    Moo::new(make_expr(r)),
                 );
                 Expr::And(
                     Metadata::new(),

--- a/test-suite/tests/custom/expression-domains/01/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/01/stdout.expected
@@ -1,7 +1,7 @@
 ((x union y) subsetEq (a intersect b)) :: bool
  (x union y) :: set  of set  of int(1..3)
-  x :: set (maxSize 1) of int(1..2)
-  y :: set (maxSize 1) of int(2..3)
+  x :: set (maxSize(1)) of int(1..2)
+  y :: set (maxSize(1)) of int(2..3)
  (a intersect b) :: set  of set  of int(1..2)
-  a :: set (maxSize 2) of int(1..2)
-  b :: set (maxSize 2) of int(1..3)
+  a :: set (maxSize(2)) of int(1..2)
+  b :: set (maxSize(2)) of int(1..3)

--- a/test-suite/tests/custom/expression-domains/02/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/02/stdout.expected
@@ -1,7 +1,7 @@
 ((x union y) subsetEq (a intersect b)) :: bool
  (x union y) :: set  of set  of int(1..4)
-  x :: set (maxSize 1) of int(1..2)
-  y :: set (maxSize 1) of int(3..4)
+  x :: set (maxSize(1)) of int(1..2)
+  y :: set (maxSize(1)) of int(3..4)
  (a intersect b) :: set  of set  of int(1..2)
-  a :: set (maxSize 2) of int(1..3)
-  b :: set (maxSize 2) of int(1..2)
+  a :: set (maxSize(2)) of int(1..3)
+  b :: set (maxSize(2)) of int(1..2)

--- a/test-suite/tests/custom/expression-domains/03/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/03/stdout.expected
@@ -1,7 +1,7 @@
 ((x union y) subsetEq (a intersect b)) :: bool
  (x union y) :: set  of set  of int(1..3)
-  x :: set (minSize 1, maxSize 1) of int(2..3)
-  y :: set (minSize 1, maxSize 1) of int(1..2)
+  x :: set (minSize(1), maxSize(1)) of int(2..3)
+  y :: set (minSize(1), maxSize(1)) of int(1..2)
  (a intersect b) :: set  of set  of int(2..3)
-  a :: set (minSize 1, maxSize 2) of int(1..3)
-  b :: set (minSize 1, maxSize 2) of int(2..4)
+  a :: set (minSize(1), maxSize(2)) of int(1..3)
+  b :: set (minSize(1), maxSize(2)) of int(2..4)

--- a/test-suite/tests/custom/expression-domains/04/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/04/stdout.expected
@@ -1,7 +1,7 @@
 ((x union y) = (a intersect b)) :: bool
  (x union y) :: set  of set  of int(1..4)
-  x :: set (minSize 1, maxSize 2) of int(1..3)
-  y :: set (minSize 1, maxSize 1) of int(2..4)
+  x :: set (minSize(1), maxSize(2)) of int(1..3)
+  y :: set (minSize(1), maxSize(1)) of int(2..4)
  (a intersect b) :: set  of set  of int(2)
-  a :: set (minSize 1, maxSize 2) of int(2..3)
-  b :: set (minSize 1, maxSize 2) of int(1..2)
+  a :: set (minSize(1), maxSize(2)) of int(2..3)
+  b :: set (minSize(1), maxSize(2)) of int(1..2)

--- a/test-suite/tests/custom/expression-domains/05/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/05/stdout.expected
@@ -1,7 +1,7 @@
 ((x union y) = (a intersect b)) :: bool
  (x union y) :: set  of set  of int(1..4)
-  x :: set (minSize 2, maxSize 2) of int(1..3)
-  y :: set (minSize 1, maxSize 1) of int(3..4)
+  x :: set (minSize(2), maxSize(2)) of int(1..3)
+  y :: set (minSize(1), maxSize(1)) of int(3..4)
  (a intersect b) :: set  of set  of int(2..3)
-  a :: set (minSize 2, maxSize 2) of int(2..4)
-  b :: set (minSize 2, maxSize 2) of int(1..3)
+  a :: set (minSize(2), maxSize(2)) of int(2..4)
+  b :: set (minSize(2), maxSize(2)) of int(1..3)

--- a/test-suite/tests/custom/expression-domains/cardinality/mset/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/cardinality/mset/stdout.expected
@@ -1,4 +1,4 @@
 (y = |x|) :: bool
  y :: int(1..100)
  |x| :: int(2..50)
-  x :: mset (minSize 2, maxOccur 5) of int(1..10)
+  x :: mset (minSize(2), maxOccur(5)) of int(1..10)

--- a/test-suite/tests/custom/expression-domains/cardinality/relation/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/cardinality/relation/stdout.expected
@@ -1,4 +1,4 @@
 (y = |x|) :: bool
  y :: int(1..100)
  |x| :: int(6)
-  x :: relation (size 6) of (int(1..4) * bool * int(1..3))
+  x :: relation (size(6)) of (int(1..4) * bool * int(1..3))

--- a/test-suite/tests/custom/expression-domains/cardinality/set/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/cardinality/set/stdout.expected
@@ -1,4 +1,4 @@
 (y = |x|) :: bool
  y :: int(1..100)
  |x| :: int(0..8)
-  x :: set (maxSize 8) of int(1..10)
+  x :: set (maxSize(8)) of int(1..10)

--- a/test-suite/tests/custom/expression-domains/function/defined/01/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/01/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (minSize 0, maxSize 5) of int(1..5)
+ defined(x) :: set (minSize(0), maxSize(5)) of int(1..5)
   x :: function  int(1..5) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/defined/02/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/02/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (minSize 0, maxSize 10) of int(1..15)
+ defined(x) :: set (minSize(0), maxSize(10)) of int(1..15)
   x :: function (injective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/defined/03/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/03/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (minSize 10, maxSize 15) of int(1..15)
+ defined(x) :: set (minSize(10), maxSize(15)) of int(1..15)
   x :: function (surjective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/defined/04/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/04/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (size 10) of int(1..15)
+ defined(x) :: set (size(10)) of int(1..15)
   x :: function (bijective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/defined/05/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/05/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (size 10) of int(1..10)
+ defined(x) :: set (size(10)) of int(1..10)
   x :: function (total, injective) int(1..10) --> int(1..15) 

--- a/test-suite/tests/custom/expression-domains/function/defined/06/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/06/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (minSize 4, maxSize 10) of int(1..10)
+ defined(x) :: set (minSize(4), maxSize(10)) of int(1..10)
   x :: function (minSize(4), injective) int(1..10) --> int(1..15) 

--- a/test-suite/tests/custom/expression-domains/function/defined/08/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/defined/08/stdout.expected
@@ -1,4 +1,4 @@
 (y = defined(x)) :: bool
  y :: set  of int(1..100)
- defined(x) :: set (minSize 10, maxSize 12) of int(1..15)
+ defined(x) :: set (minSize(10), maxSize(12)) of int(1..15)
   x :: function (minSize(7), maxSize(12), surjective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/pre_image/01/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/01/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 5) of int(1..5)
+ preImage(x,3) :: set (minSize(0), maxSize(5)) of int(1..5)
   x :: function  int(1..5) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/02/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/02/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 1) of int(1..15)
+ preImage(x,3) :: set (minSize(0), maxSize(1)) of int(1..15)
   x :: function (injective) int(1..15) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/03/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/03/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 1, maxSize 6) of int(1..15)
+ preImage(x,3) :: set (minSize(1), maxSize(6)) of int(1..15)
   x :: function (surjective) int(1..15) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/04/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/04/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (size 1) of int(1..15)
+ preImage(x,3) :: set (size(1)) of int(1..15)
   x :: function (bijective) int(1..15) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/05/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/05/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 1) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(1)) of int(1..10)
   x :: function (total, injective) int(1..10) --> int(1..15) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/06/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/06/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 1, maxSize 3) of int(1..15)
+ preImage(x,3) :: set (minSize(1), maxSize(3)) of int(1..15)
   x :: function (minSize(7), maxSize(12), surjective) int(1..15) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/07/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/07/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 4) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(4)) of int(1..10)
   x :: function (size(4)) int(1..10) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/08/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/08/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 10) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(10)) of int(1..10)
   x :: function (minSize(4)) int(1..10) --> int(1..15) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/09/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/09/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 8) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(8)) of int(1..10)
   x :: function (maxSize(8)) int(1..10) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/10/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/10/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 1) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(1)) of int(1..10)
   x :: function (minSize(8), injective) int(1..10) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/pre_image/11/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/pre_image/11/stdout.expected
@@ -1,5 +1,5 @@
 (y = preImage(x,3)) :: bool
  y :: set  of int(1..100)
- preImage(x,3) :: set (minSize 0, maxSize 1) of int(1..10)
+ preImage(x,3) :: set (minSize(0), maxSize(1)) of int(1..10)
   x :: function (size(6), injective) int(1..10) --> int(1..10) 
   3 :: int(3)

--- a/test-suite/tests/custom/expression-domains/function/range/01/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/01/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 0, maxSize 5) of int(1..10)
+ range(x) :: set (minSize(0), maxSize(5)) of int(1..10)
   x :: function  int(1..5) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/02/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/02/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 0, maxSize 10) of int(1..10)
+ range(x) :: set (minSize(0), maxSize(10)) of int(1..10)
   x :: function (injective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/03/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/03/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (size 10) of int(1..10)
+ range(x) :: set (size(10)) of int(1..10)
   x :: function (surjective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/04/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/04/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (size 10) of int(1..10)
+ range(x) :: set (size(10)) of int(1..10)
   x :: function (bijective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/05/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/05/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (size 10) of int(1..15)
+ range(x) :: set (size(10)) of int(1..15)
   x :: function (total, injective) int(1..10) --> int(1..15) 

--- a/test-suite/tests/custom/expression-domains/function/range/06/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/06/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (size 10) of int(1..10)
+ range(x) :: set (size(10)) of int(1..10)
   x :: function (minSize(7), maxSize(12), surjective) int(1..15) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/07/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/07/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 1, maxSize 4) of int(1..10)
+ range(x) :: set (minSize(1), maxSize(4)) of int(1..10)
   x :: function (size(4)) int(1..10) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/08/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/08/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 1, maxSize 10) of int(1..15)
+ range(x) :: set (minSize(1), maxSize(10)) of int(1..15)
   x :: function (minSize(4)) int(1..10) --> int(1..15) 

--- a/test-suite/tests/custom/expression-domains/function/range/09/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/09/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 0, maxSize 8) of int(1..10)
+ range(x) :: set (minSize(0), maxSize(8)) of int(1..10)
   x :: function (maxSize(8)) int(1..10) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/10/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/10/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (minSize 8, maxSize 10) of int(1..10)
+ range(x) :: set (minSize(8), maxSize(10)) of int(1..10)
   x :: function (minSize(8), injective) int(1..10) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/function/range/11/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/function/range/11/stdout.expected
@@ -1,4 +1,4 @@
 (y = range(x)) :: bool
  y :: set  of int(1..100)
- range(x) :: set (size 6) of int(1..10)
+ range(x) :: set (size(6)) of int(1..10)
   x :: function (size(6), injective) int(1..10) --> int(1..10) 

--- a/test-suite/tests/custom/expression-domains/partitions/Participants/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/partitions/Participants/stdout.expected
@@ -1,4 +1,4 @@
 (bar = participants(foo)) :: bool
  bar :: set  of int(1..20)
- participants(foo) :: set (size 10) of int(1..10)
-  foo :: partition (minNumParts 3, maxPartSize 4) from int(1..10)
+ participants(foo) :: set (size(10)) of int(1..10)
+  foo :: partition (minNumParts(3), maxPartSize(4)) from int(1..10)

--- a/test-suite/tests/custom/expression-domains/partitions/Participants_Empty/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/partitions/Participants_Empty/stdout.expected
@@ -1,4 +1,4 @@
 (bar = participants(foo)) :: bool
  bar :: set  of int(1..10)
  participants(foo) :: empty(set of int)
-  foo :: partition (numParts 2, partSize 4) from int(1..10)
+  foo :: partition (numParts(2), partSize(4)) from int(1..10)

--- a/test-suite/tests/custom/expression-domains/partitions/Parts/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/partitions/Parts/stdout.expected
@@ -1,5 +1,5 @@
 (parts(foo) = parts(foo)) :: bool
- parts(foo) :: set (size 3) of set (size 2) of int(1..15)
-  foo :: partition (numParts 3, partSize 2) from int(1..15)
- parts(foo) :: set (size 3) of set (size 2) of int(1..15)
-  foo :: partition (numParts 3, partSize 2) from int(1..15)
+ parts(foo) :: set (size(3)) of set (size(2)) of int(1..15)
+  foo :: partition (numParts(3), partSize(2)) from int(1..15)
+ parts(foo) :: set (size(3)) of set (size(2)) of int(1..15)
+  foo :: partition (numParts(3), partSize(2)) from int(1..15)

--- a/test-suite/tests/custom/expression-domains/partitions/Party/stdout.expected
+++ b/test-suite/tests/custom/expression-domains/partitions/Party/stdout.expected
@@ -1,5 +1,5 @@
 (bar = party(7, foo)) :: bool
  bar :: set  of int(1..10)
- party(7, foo) :: set (minSize 3, maxSize 5) of int(1..10)
+ party(7, foo) :: set (minSize(3), maxSize(5)) of int(1..10)
   7 :: int(7)
-  foo :: partition (minPartSize 3 , maxPartSize 5) from int(1..10)
+  foo :: partition (minPartSize(3), maxPartSize(5)) from int(1..10)

--- a/test-suite/tests/integration/smt/set/eq/tree-sitter-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq/tree-sitter-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 
@@ -11,8 +11,8 @@ such that
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq/tree-sitter-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq/tree-sitter-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 
@@ -24,8 +24,8 @@ and([(1 in a) <-> (1 in b),(2 in a) <-> (2 in b);int(1..)]),
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 
@@ -11,8 +11,8 @@ such that
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 
@@ -24,8 +24,8 @@ and([(1 in a) <-> (1 in b),(2 in a) <-> (2 in b);int(1..)]),
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(1..2)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(1..2)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq_overlap/tree-sitter-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq_overlap/tree-sitter-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 
@@ -11,8 +11,8 @@ such that
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq_overlap/tree-sitter-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq_overlap/tree-sitter-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 
@@ -25,8 +25,8 @@ and([!(1 in a),(2 in a) <-> (2 in b),!(3 in b);int(1..)]),
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq_overlap/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq_overlap/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 
@@ -11,8 +11,8 @@ such that
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/eq_overlap/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/eq_overlap/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 
@@ -25,8 +25,8 @@ and([!(1 in a),(2 in a) <-> (2 in b),!(3 in b);int(1..)]),
 
 Final model:
 
-find a: set (minSize 1) of int(1..2)
-find b: set (minSize 1) of int(2..3)
+find a: set (minSize(1)) of int(1..2)
+find b: set (minSize(1)) of int(2..3)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/subset-sum/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/subset-sum/via-conjure-morph-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
 letting s be 0
-find x: set (minSize 1) of int(-7, -3..-2, 5, 8)
+find x: set (minSize(1)) of int(-7, -3..-2, 5, 8)
 
 such that
 
@@ -12,7 +12,7 @@ such that
 Final model:
 
 letting s be 0
-find x: set (minSize 1) of int(-7, -3..-2, 5, 8)
+find x: set (minSize(1)) of int(-7, -3..-2, 5, 8)
 
 such that
 

--- a/test-suite/tests/integration/smt/set/subset-sum/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
+++ b/test-suite/tests/integration/smt/set/subset-sum/via-conjure-naive-via-solver-ac-smt-lia-arrays-expected-rule-trace.txt
@@ -1,7 +1,7 @@
 Model before rewriting:
 
 letting s be 0
-find x: set (minSize 1) of int(-7, -3..-2, 5, 8)
+find x: set (minSize(1)) of int(-7, -3..-2, 5, 8)
 
 such that
 
@@ -24,7 +24,7 @@ sum([product([-7,toInt(-7 in x);int(1..)]),product([-3,toInt(-3 in x);int(1..)])
 Final model:
 
 letting s be 0
-find x: set (minSize 1) of int(-7, -3..-2, 5, 8)
+find x: set (minSize(1)) of int(-7, -3..-2, 5, 8)
 
 such that
 

--- a/test-suite/tests/roundtrip/functions/operators/toMSet/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/functions/operators/toMSet/via-conjure.expected.essence
@@ -1,5 +1,5 @@
 find x: function  int(1..3) --> int(1..3) 
-find y: mset (maxOccur 5) of tuple (int(1..6), int(1..6))
+find y: mset (maxOccur(5)) of tuple (int(1..6), int(1..6))
 
 such that
 

--- a/test-suite/tests/roundtrip/msets/attributes/both_1/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/both_1/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (minSize 3, maxOccur 2) of int(0..9)
+find foo: mset (minSize(3), maxOccur(2)) of int(0..9)

--- a/test-suite/tests/roundtrip/msets/attributes/both_2/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/both_2/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (size 24, minOccur 2 , maxOccur 5) of int(0..100)
+find foo: mset (size(24), minOccur(2), maxOccur(5)) of int(0..100)

--- a/test-suite/tests/roundtrip/msets/attributes/maxOcc/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/maxOcc/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (maxOccur 5) of int(0..1)
+find foo: mset (maxOccur(5)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/attributes/maxSize/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/maxSize/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (maxSize 5) of int(0..1)
+find foo: mset (maxSize(5)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/attributes/minOcc/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/minOcc/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (minOccur 5) of int(0..1)
+find foo: mset (minOccur(5)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/attributes/minSize/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/minSize/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (minSize 5) of int(0..1)
+find foo: mset (minSize(5)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/attributes/minmaxOcc/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/minmaxOcc/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (minOccur 1 , maxOccur 3) of int(0..1)
+find foo: mset (minOccur(1), maxOccur(3)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/attributes/minmaxSize/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/attributes/minmaxSize/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: mset (minSize 3, maxSize 5) of int(0..1)
+find foo: mset (minSize(3), maxSize(5)) of int(0..1)

--- a/test-suite/tests/roundtrip/msets/operators/toSet/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/msets/operators/toSet/via-conjure.expected.essence
@@ -1,4 +1,4 @@
-find x: mset (maxOccur 2) of int(1..5)
+find x: mset (maxOccur(2)) of int(1..5)
 find y: set  of int(1..6)
 
 such that

--- a/test-suite/tests/roundtrip/partitions/attributes/maxParts-Len/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/partitions/attributes/maxParts-Len/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: partition (maxNumParts 3, partSize 1) from int(1..5)
+find foo: partition (maxNumParts(3), partSize(1)) from int(1..5)

--- a/test-suite/tests/roundtrip/partitions/attributes/minmaxParts-minmaxLen-regular/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/partitions/attributes/minmaxParts-minmaxLen-regular/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: partition (minNumParts 2, maxNumParts 3, minPartSize 0 , maxPartSize 1, regular) from int(1..5)
+find foo: partition (minNumParts(2), maxNumParts(3), minPartSize(0), maxPartSize(1), regular) from int(1..5)

--- a/test-suite/tests/roundtrip/partitions/attributes/numParts-minLen/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/partitions/attributes/numParts-minLen/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find foo: partition (numParts 2, minPartSize 2) from int(1..5)
+find foo: partition (numParts(2), minPartSize(2)) from int(1..5)

--- a/test-suite/tests/roundtrip/relations/attributes/everything/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/attributes/everything/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: relation (minSize 3, coreflexive, antiSymmetric, transitive, total, Euclidean, serial, equivalence, partialOrder) of (int(1..10) * int(1..10))
+find x: relation (minSize(3), coreflexive, antiSymmetric, transitive, total, Euclidean, serial, equivalence, partialOrder) of (int(1..10) * int(1..10))

--- a/test-suite/tests/roundtrip/relations/attributes/maxSize_connex_asymmetric/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/attributes/maxSize_connex_asymmetric/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: relation (maxSize 2, aSymmetric, connex) of (int(0..5) * int(0..5))
+find x: relation (maxSize(2), aSymmetric, connex) of (int(0..5) * int(0..5))

--- a/test-suite/tests/roundtrip/relations/attributes/minMaxSize_symmetric/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/attributes/minMaxSize_symmetric/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: relation (minSize 1, maxSize 4, symmetric) of (int(0..5) * int(0..5))
+find x: relation (minSize(1), maxSize(4), symmetric) of (int(0..5) * int(0..5))

--- a/test-suite/tests/roundtrip/relations/attributes/minSize_reflexive/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/attributes/minSize_reflexive/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: relation (minSize 3, reflexive) of (int(0..5) * int(0..5))
+find x: relation (minSize(3), reflexive) of (int(0..5) * int(0..5))

--- a/test-suite/tests/roundtrip/relations/attributes/size_irreflexive/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/attributes/size_irreflexive/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: relation (size 2, irreflexive) of (int(0..5) * int(0..5))
+find x: relation (size(2), irreflexive) of (int(0..5) * int(0..5))

--- a/test-suite/tests/roundtrip/relations/ground-and-unresolved/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/ground-and-unresolved/via-conjure.expected.essence
@@ -1,2 +1,2 @@
 letting n be 5
-find foo: relation (maxSize 2) of (int(0..4) * int(0..n))
+find foo: relation (maxSize(2)) of (int(0..4) * int(0..n))

--- a/test-suite/tests/roundtrip/relations/operators/toMSet/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/relations/operators/toMSet/via-conjure.expected.essence
@@ -1,5 +1,5 @@
 find x: relation  of (int(1..3) * int(1..5) * bool)
-find y: mset (maxOccur 5) of tuple (int(1..6), int(1..6), bool)
+find y: mset (maxOccur(5)) of tuple (int(1..6), int(1..6), bool)
 
 such that
 

--- a/test-suite/tests/roundtrip/sequences/attributes/maxSize-injective/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/attributes/maxSize-injective/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (maxSize 2, injective) of int(1..3)
+find x: sequence (maxSize(2), injective) of int(1..3)

--- a/test-suite/tests/roundtrip/sequences/attributes/maxSize-surjective/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/attributes/maxSize-surjective/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (maxSize 3, surjective) of int(1..2)
+find x: sequence (maxSize(3), surjective) of int(1..2)

--- a/test-suite/tests/roundtrip/sequences/attributes/minMaxSize-injective/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/attributes/minMaxSize-injective/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (minSize 2, maxSize 3, injective) of int(1..3)
+find x: sequence (minSize(2), maxSize(3), injective) of int(1..3)

--- a/test-suite/tests/roundtrip/sequences/attributes/size-bijective/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/attributes/size-bijective/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (size 2, bijective) of int(1..2)
+find x: sequence (size(2), bijective) of int(1..2)

--- a/test-suite/tests/roundtrip/sequences/attributes/size_injective/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/attributes/size_injective/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (size 2, injective) of int(2..3)
+find x: sequence (size(2), injective) of int(2..3)

--- a/test-suite/tests/roundtrip/sequences/operators/Subsequence/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/operators/Subsequence/via-conjure.expected.essence
@@ -1,5 +1,5 @@
 letting t be sequence(1,2,3)
-find s: sequence (size 2, injective) of int(1, 3)
+find s: sequence (size(2), injective) of int(1, 3)
 
 such that
 

--- a/test-suite/tests/roundtrip/sequences/operators/Substring/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/operators/Substring/via-conjure.expected.essence
@@ -1,5 +1,5 @@
 letting t be sequence(1,2,3)
-find s: sequence (size 2, injective) of int(1..3)
+find s: sequence (size(2), injective) of int(1..3)
 
 such that
 

--- a/test-suite/tests/roundtrip/sequences/simple/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/sequences/simple/via-conjure.expected.essence
@@ -1,1 +1,1 @@
-find x: sequence (size 2) of int(1..3)
+find x: sequence (size(2)) of int(1..3)

--- a/test-suite/tests/roundtrip/set_attrs/via-conjure.expected.essence
+++ b/test-suite/tests/roundtrip/set_attrs/via-conjure.expected.essence
@@ -1,4 +1,4 @@
-find s: set (size 2) of int(1..3)
+find s: set (size(2)) of int(1..3)
 
 such that
 


### PR DESCRIPTION
## Description

- Implement `GroundDomain::union` for records
- Implement `GroundDomain::values` for records, sets, tuples
- Clean up IntVal and domain attribute code
- Unify formatting of domain attributes like `size` / `minSize` / `maxSize`

## Related issues

- Closes #1501 
- Closes #1032 
- Closes #1033 
- Closes #1035 

## How to test/review

Refactor is (mostly) limited to `domains/`, so everything else should work as before.
Some unit tests have been added for the new `values` impls.
