### PR TITLE
test: switch test runner to nextest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     - crates/**
     - test-suite/**
     - Cargo.*
+    - Makefile
     - rust-toolchain.toml
     - .github/workflows/test.yml
   pull_request:
@@ -15,6 +16,7 @@ on:
     - crates/**
     - test-suite/**
     - Cargo.*
+    - Makefile
     - rust-toolchain.toml
     - .github/workflows/test.yml
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CARGO_TEST_WORKSPACE = cargo nextest run $(CARGO_LOCKED) $(CARGO_FEATURES) --wor
 CARGO_DOC_TEST_WORKSPACE = cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace --doc
 # Golden files follow the test-suite convention of `.expected` or `-expected-` in the file name.
 # This intentionally ignores config.toml, including expected-time-only changes.
-RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED = if test -n "$$(git status --porcelain -- ':(glob)**/*.expected*' ':(glob)**/*-expected-*')"; then echo "Golden files changed; running tests without ACCEPT"; PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE); PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_DOC_TEST_WORKSPACE); else echo "No golden files changed; skipping non-accepting test run"; fi
+RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED = if test -n "$$(git status --porcelain -- ':(glob)**/*.expected*' ':(glob)**/*-expected-*')"; then echo "Golden files changed; running tests without ACCEPT"; PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_DOC_TEST_WORKSPACE); PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE); else echo "No golden files changed; skipping non-accepting test run"; fi
 
 .PHONY: submodules
 ## Initialises git submodules needed for builds
@@ -58,8 +58,8 @@ install: build
 .PHONY: test
 ## Runs all tests
 test: submodules install .installed-cargo-nextest.checkpoint
-	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE)
 	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_DOC_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE)
 
 .PHONY: test-coverage
 ## Runs all tests and produces a coverage report
@@ -69,22 +69,22 @@ test-coverage:
 .PHONY: test-accept
 ## Runs all tests in accept mode, then in normal mode if golden files changed
 test-accept: install .installed-cargo-nextest.checkpoint
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_TEST_WORKSPACE)
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_DOC_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-slower-times
 ## Runs all tests in accept mode, only increases expected run times, then in normal mode if golden files changed
 test-accept-with-slower-times: install .installed-cargo-nextest.checkpoint
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_TEST_WORKSPACE)
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_DOC_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-exact-times
 ## Runs all tests in accept mode, updates expected run times exactly, then in normal mode if golden files changed
 test-accept-with-exact-times: install .installed-cargo-nextest.checkpoint
-	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_TEST_WORKSPACE)
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_DOC_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: fix

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,11 @@ CARGO_FEATURES ?=
 CARGO_TARGET_DIR ?= target
 DEV_CONTAINER_IMAGE ?= conjure-oxide-dev
 DEV_CONTAINER_FILE ?= Dockerfile.dev
-CARGO_TEST_WORKSPACE = cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+CARGO_TEST_WORKSPACE = cargo nextest run $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace
+CARGO_DOC_TEST_WORKSPACE = cargo test $(CARGO_LOCKED) $(CARGO_FEATURES) --workspace --doc
 # Golden files follow the test-suite convention of `.expected` or `-expected-` in the file name.
 # This intentionally ignores config.toml, including expected-time-only changes.
-RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED = if test -n "$$(git status --porcelain -- ':(glob)**/*.expected*' ':(glob)**/*-expected-*')"; then echo "Golden files changed; running tests without ACCEPT"; PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE); else echo "No golden files changed; skipping non-accepting test run"; fi
+RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED = if test -n "$$(git status --porcelain -- ':(glob)**/*.expected*' ':(glob)**/*-expected-*')"; then echo "Golden files changed; running tests without ACCEPT"; PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE); PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_DOC_TEST_WORKSPACE); else echo "No golden files changed; skipping non-accepting test run"; fi
 
 .PHONY: submodules
 ## Initialises git submodules needed for builds
@@ -56,8 +57,9 @@ install: build
 
 .PHONY: test
 ## Runs all tests
-test: submodules install
+test: submodules install .installed-cargo-nextest.checkpoint
 	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" $(CARGO_DOC_TEST_WORKSPACE)
 
 .PHONY: test-coverage
 ## Runs all tests and produces a coverage report
@@ -66,20 +68,23 @@ test-coverage:
 
 .PHONY: test-accept
 ## Runs all tests in accept mode, then in normal mode if golden files changed
-test-accept: install
+test-accept: install .installed-cargo-nextest.checkpoint
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=true $(CARGO_DOC_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-slower-times
 ## Runs all tests in accept mode, only increases expected run times, then in normal mode if golden files changed
-test-accept-with-slower-times: install
+test-accept-with-slower-times: install .installed-cargo-nextest.checkpoint
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-slower-times $(CARGO_DOC_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: test-accept-with-exact-times
 ## Runs all tests in accept mode, updates expected run times exactly, then in normal mode if golden files changed
-test-accept-with-exact-times: install
+test-accept-with-exact-times: install .installed-cargo-nextest.checkpoint
 	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_TEST_WORKSPACE)
+	PATH="$$HOME/.cargo/bin:$$PATH" ACCEPT=with-exact-times $(CARGO_DOC_TEST_WORKSPACE)
 	@$(RUN_NON_ACCEPTING_TESTS_IF_GOLDEN_FILES_CHANGED)
 
 .PHONY: fix
@@ -124,6 +129,10 @@ install-cargo-extensions: .installed-cargo-extensions.checkpoint
 .installed-cargo-extensions.checkpoint: Makefile
 	cargo install cargo-shear
 	touch .installed-cargo-extensions.checkpoint
+
+.installed-cargo-nextest.checkpoint: Makefile
+	@if ! command -v cargo-nextest >/dev/null 2>&1; then cargo install cargo-nextest --locked; fi
+	touch .installed-cargo-nextest.checkpoint
 
 test-clean:
 	cd test-suite/tests/integration/; find -type f -path '**generated**' -delete

--- a/crates/minion-sys/README.md
+++ b/crates/minion-sys/README.md
@@ -15,5 +15,5 @@ Debug symbols for Minion can be enabled by setting the environment variable `DEB
 Eg.
 
 ```shell
-DEBUG_MINION=true cargo test
+DEBUG_MINION=true cargo nextest run -p minion-sys
 ```

--- a/crates/tree-morph/README.md
+++ b/crates/tree-morph/README.md
@@ -89,7 +89,7 @@ fn check_my_expression() {
 }
 ```
 
-The ``morph`` function is the core function of the crate, and handles the bulk application of transformation rules to the tree. We input the set of rules, a decision function, and some metadata, returning a ``(tree, metadata)`` tuple. Running ``cargo test --test file_name`` in a directory containing the file with this code will verify that tree-morph is indeed doing what it should do! In the following sections we explore some of tree-morph's features in more depth.
+The ``morph`` function is the core function of the crate, and handles the bulk application of transformation rules to the tree. We input the set of rules, a decision function, and some metadata, returning a ``(tree, metadata)`` tuple. Running ``cargo nextest run --test file_name`` in a directory containing the file with this code will verify that tree-morph is indeed doing what it should do! In the following sections we explore some of tree-morph's features in more depth.
 
 ## Metadata
 
@@ -173,7 +173,7 @@ fn number_of_operations() {
 }
 ```
 
-Running ``cargo test --test file_name`` in a directory containing the file with this code will verify that indeed two addition operations are successfully undertaken.
+Running ``cargo nextest run --test file_name`` in a directory containing the file with this code will verify that indeed two addition operations are successfully undertaken.
 
 But wait! The original problem was solving ``(1+2)^2``, why have two addition operations been recorded? The answer is in how we grouped the rules together in the ``morph`` function.
 

--- a/crates/tree-morph/src/docs/lib.md
+++ b/crates/tree-morph/src/docs/lib.md
@@ -158,7 +158,7 @@ fn check_my_expression() {
 }
 check_my_expression();
 ```
-The ``morph`` function is the core function of the crate, and handles the bulk application of transformation rules to the tree. We input the set of rules, a decision function, and some metadata, returning a ``(tree, metadata)`` tuple. Running ``cargo test --test file_name`` in a directory containing the file with this code will verify that tree-morph is indeed doing what it should do! In the following sections we explore some of tree-morph's features in more depth.
+The ``morph`` function is the core function of the crate, and handles the bulk application of transformation rules to the tree. We input the set of rules, a decision function, and some metadata, returning a ``(tree, metadata)`` tuple. Running ``cargo nextest run --test file_name`` in a directory containing the file with this code will verify that tree-morph is indeed doing what it should do! In the following sections we explore some of tree-morph's features in more depth.
 
 ## Metadata
 Metadata refers to additional contextual information passed along during the tree transformation process. A simple usage of metadata is counting the number of transformation steps a process takes. We keep track of metadata via the ``Commands`` struct, which is used to capture any other side-effects to the transformation process apart from the pure rule changes. If, in our above example, we wanted to count the number of addition rule changes applies, we would first need to create a new struct to capture the metadata.
@@ -319,7 +319,7 @@ fn number_of_operations() {
 }
 number_of_operations();
 ```
-Running ``cargo test --test file_name`` in a directory containing the file with this code will verify that indeed two addition operations are successfully undertaken.
+Running ``cargo nextest run --test file_name`` in a directory containing the file with this code will verify that indeed two addition operations are successfully undertaken.
 
 But wait! The original problem was solving ``(1+2)^2``, why have two addition operations been recorded? The answer is in how we grouped the rules together in the ``morph`` function.
 

--- a/docs/src/developers-guide/architecture/lsp/diagnostics-api.md
+++ b/docs/src/developers-guide/architecture/lsp/diagnostics-api.md
@@ -68,11 +68,11 @@ API-specific tests are located in `crates/conjure-cp-essence-parser/tests` and c
 
 ```bash
 # to run all tests
-cargo test -p conjure-cp-essence-parser --test
+cargo nextest run -p conjure-cp-essence-parser
 
 # to run with a specific test target
-cargo test -p conjure-cp-essence-parser --test semantic_test
-cargo test -p conjure-cp-essence-parser --test keywords_as_ident
-cargo test -p conjure-cp-essence-parser --test missing_token
-cargo test -p conjure-cp-essence-parser --test unexpected_token
+cargo nextest run -p conjure-cp-essence-parser --test semantic_test
+cargo nextest run -p conjure-cp-essence-parser --test keywords_as_ident
+cargo nextest run -p conjure-cp-essence-parser --test missing_token
+cargo nextest run -p conjure-cp-essence-parser --test unexpected_token
 ```

--- a/docs/src/developers-guide/architecture/lsp/error-detection/semantic-errors.md
+++ b/docs/src/developers-guide/architecture/lsp/error-detection/semantic-errors.md
@@ -41,8 +41,8 @@ Called at the end of `parse_model_with_context`. Performs this validation by tra
 ## How To Test
 
  ```bash
-cargo test -p conjure-cp-essence-parser --test semantic_test
-cargo test -p conjure-cp-essence-parser --test keyword_as_ident
+cargo nextest run -p conjure-cp-essence-parser --test semantic_test
+cargo nextest run -p conjure-cp-essence-parser --test keyword_as_ident
 
 ```
 

--- a/docs/src/developers-guide/architecture/lsp/error-detection/syntactic-errors.md
+++ b/docs/src/developers-guide/architecture/lsp/error-detection/syntactic-errors.md
@@ -57,9 +57,9 @@ The different cases are distinguished based on the position of the `ERROR` node 
 ## How To Test
 
 ```bash
-cargo test -p conjure-cp-essence-parser --test malformed_top_level
-cargo test -p conjure-cp-essence-parser --test missing_token
-cargo test -p conjure-cp-essence-parser --test unexpected_token
+cargo nextest run -p conjure-cp-essence-parser --test malformed_top_level
+cargo nextest run -p conjure-cp-essence-parser --test missing_token
+cargo nextest run -p conjure-cp-essence-parser --test unexpected_token
 ```
 
 ## Examples

--- a/docs/src/developers-guide/architecture/lsp/tests.md
+++ b/docs/src/developers-guide/architecture/lsp/tests.md
@@ -21,23 +21,23 @@ Test cases that test the coverage of the Native parser use [Roundtrip testing](.
 
 These test cases will run alongside all the integration tests in the `test-suite` crate, which can be done by using:
 ```bash
-cargo test
+cargo nextest run
 ```
 
 Alternatively, to run only the Roundtrip tests, use the command:
 ```bash
-cargo test tests_roundtrip
+cargo nextest run -E 'test(tests_roundtrip)'
 ```
 
 ### Diagnostics API
 For testing the Diagnostics API, test cases are written in the `tests` directory of the `conjure-cp-essence-parser` crate, which uses normal [Rust unit testing](https://doc.rust-lang.org/book/ch11-01-writing-tests.html). To run these tests, use the command:
 ```bash
-cargo test -p conjure-cp-essence-parser
+cargo nextest run -p conjure-cp-essence-parser
 ```
 
 Or, to run the test files individually, use the command:
 ```bash
-cargo test -p conjure-cp-essence-parser --test {file_name}
+cargo nextest run -p conjure-cp-essence-parser --test {file_name}
 ```
 
 The sections below will categorise all test cases into one of the categories based on the error classification, with an explanation of the purpose of each test case.

--- a/docs/src/developers-guide/testing/writing-custom-tests.md
+++ b/docs/src/developers-guide/testing/writing-custom-tests.md
@@ -2,12 +2,12 @@
 [//]: # (Last Updated: 08/05/2025)
 
 # Overview
-Custom tests were created as a solution to the problem that integration tests do not allow for testing of error messages, which automatically return from the integration test method and therefore cannot be analyzed. The custom tests, however, work for both erroneous and non-erroneous code. Each test contains an input, a `run.sh` file to execute the test, and an expected standard output/error (or both) to compare against. Conjure Oxide is set up to automatically create and execute a test for each test folder in the `tests/custom `directory when `cargo test` is run, so to add a test case all one must do is add a folder in the directory which contains the necessary components.
+Custom tests were created as a solution to the problem that integration tests do not allow for testing of error messages, which automatically return from the integration test method and therefore cannot be analyzed. The custom tests, however, work for both erroneous and non-erroneous code. Each test contains an input, a `run.sh` file to execute the test, and an expected standard output/error (or both) to compare against. Conjure Oxide is set up to automatically create and execute a test for each test folder in the `tests/custom `directory when `cargo nextest run` is run, so to add a test case all one must do is add a folder in the directory which contains the necessary components.
 
 # How to add a test case
 Adding a test case is simple. First add a folder with the test case name to the `tests/custom` directory. Tests can be organized within folders in the directory--only folders with a `run.sh` file will be treated as a test case. Within the test folder, add these components:
 
-1. `run.sh` file: This will typically be in the format `conjure-oxide <options> <command>` with the command being `solve model.eprime` (assuming the input file is named `model.eprime`). Custom tests simply use whichever `conjure-oxide` is available on `PATH`. The usual workflow is `make install` or `make test`, which refreshes `~/.cargo/bin/conjure-oxide`, and `make test` prepends `~/.cargo/bin` to `PATH` before running `cargo test`.
+1. `run.sh` file: This will typically be in the format `conjure-oxide <options> <command>` with the command being `solve model.eprime` (assuming the input file is named `model.eprime`). Custom tests simply use whichever `conjure-oxide` is available on `PATH`. The usual workflow is `make install` or `make test`, which refreshes `~/.cargo/bin/conjure-oxide`, and `make test` prepends `~/.cargo/bin` to `PATH` before running `cargo nextest run`.
    
       ex) `conjure-oxide --solver Minion --enable-native-parser solve model.eprime`
 
@@ -17,7 +17,7 @@ Adding a test case is simple. First add a folder with the test case name to the 
 
 3. `stdout.expected`/`stderr.expected`: These files will be what the output is compared against. They will also be what is overwritten if the test is run with `ACCEPT=true`. Avoid creating empty files: if there is no expected error from the input, do not create a `stderr.expected` file and if there is no output, do not create a `stdout.expected` file.
 
-The custom tests are run automatically when `cargo test` is run. You can run just the custom tests with `cargo test custom` and a specific test with `cargo test custom_<test_path>`. To overwrite the expected output/error with the actual output/error, run the tests with `ACCEPT=true`.
+The custom tests are run automatically when `cargo nextest run` is run. You can run just the custom tests with `cargo nextest run -E 'test(custom)'` and a specific test with `cargo nextest run -E 'test(custom_<test_path>)'`. To run one of several tests, use `or`, for example `cargo nextest run -E 'test(custom_foo) or test(custom_bar)'`. To overwrite the expected output/error with the actual output/error, run the tests with `ACCEPT=true`.
 
 # Code structure
 The code to run the custom tests is integrated into the `build.rs` file. Much like for the integration tests, the custom tests directory is traversed and a test is dynamically written at compile time for any folder containing a `run.sh` file. Tests are based on a custom test template (shown below) which calls the `custom_test` function (passing in the test folder path). They are written into a generated file, which is included at the bottom of the `custom_tests.rs` file (which contains the `custom_test` function). 

--- a/docs/src/users-guide/command-line-guide/logging.md
+++ b/docs/src/users-guide/command-line-guide/logging.md
@@ -60,7 +60,7 @@ This will show:
 For more detailed testing output (including JSON traces and rewritten models), run specific tests:
 
 ```bash
-cargo test <test_name>
+cargo nextest run -E 'test(<test_name>)'
 ```
 
 This generates `.json` and `.txt` files containing rule traces, parsed Essence, solutions, and the rewritten model.

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -7,7 +7,7 @@ Integration tests for `conjure-oxide`
 Run the integration tests from the repository root with:
 
 ```sh
-cargo test
+cargo nextest run -p test-suite
 ```
 
 ### How tests work
@@ -21,7 +21,7 @@ Each test runs `conjure-oxide` on an `input.essence` file and checks that the re
 3. Run the following to generate the expected solution and JSON files:
 
 ```sh
-ACCEPT=true cargo test
+ACCEPT=true cargo nextest run -p test-suite
 ```
 
 ### Updating tests with `ACCEPT=true`
@@ -29,7 +29,7 @@ ACCEPT=true cargo test
 If you expect the rewritten AST to change (e.g. after a refactor), you can overwrite the stored output files by running:
 
 ```sh
-ACCEPT=true cargo test
+ACCEPT=true cargo nextest run -p test-suite
 ```
 
 Instead of comparing against the existing JSON files, the test harness will:

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -122,8 +122,8 @@ cargo +nightly build --workspace
 ln -sf conjure-oxide "${TARGET_DIR}/debug/conjure-oxide-debug"
 
 echo_err "info: running tests"
-cargo +nightly nextest run --workspace
 cargo +nightly test --workspace --doc
+cargo +nightly nextest run --workspace
 
 echo_err "info: generating coverage reports"
 grcov "${TARGET_DIR}/coverage" -s . --binary-path ./target/debug -t html\

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -33,6 +33,11 @@ then
   exit 1
 fi
 
+if ! command -v cargo-nextest &> /dev/null; then
+  echo_err "info: installing cargo-nextest"
+  cargo install cargo-nextest --locked
+fi
+
 if ! command -v jq &> /dev/null 
 then
   echo_err "jq is not found!"
@@ -117,7 +122,8 @@ cargo +nightly build --workspace
 ln -sf conjure-oxide "${TARGET_DIR}/debug/conjure-oxide-debug"
 
 echo_err "info: running tests"
-cargo +nightly test --workspace
+cargo +nightly nextest run --workspace
+cargo +nightly test --workspace --doc
 
 echo_err "info: generating coverage reports"
 grcov "${TARGET_DIR}/coverage" -s . --binary-path ./target/debug -t html\


### PR DESCRIPTION
Switch the main test runner from `cargo test` to `cargo nextest run`.

doctests are still covered via a separate `cargo test --doc` step, as nextest doesn't support them.

Why? `nextest` gives us better test selection and execution ergonomics than plain `cargo test`, including filter expressions like: `cargo nextest run -E 'test(foo) or test(bar)`

Also apparently it can be faster (better scheduler).