### PR TITLE
ci: add workflow to build the VS Code extension

### DIFF
--- a/.github/workflows/ci-vscode-ext.yml
+++ b/.github/workflows/ci-vscode-ext.yml
@@ -1,0 +1,37 @@
+name: VS Code Extension
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/ci-vscode-ext.yml
+    - tools/vscode-ext/**
+  pull_request:
+    paths:
+    - .github/workflows/ci-vscode-ext.yml
+    - tools/vscode-ext/**
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/vscode-ext
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: tools/vscode-ext/package-lock.json
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Compile TypeScript
+      run: npx -p typescript@5.9.3 tsc -p .

--- a/tools/vscode-ext/tsconfig.json
+++ b/tools/vscode-ext/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "outDir": "./out",
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This is so @dependabot PRs that touch tools/vscode-ext get a build check.