### PR TITLE
refactor(representation): identify representations by ReprId instead of name strings

### DIFF
--- a/crates/conjure-cp-core/src/ast/name.rs
+++ b/crates/conjure-cp-core/src/ast/name.rs
@@ -1,3 +1,4 @@
+use crate::representation::ReprId;
 use std::fmt::Display;
 
 use itertools::Itertools as _;
@@ -23,7 +24,7 @@ pub enum Name {
             // The source variable
             Name,
             // The representation rule used
-            Ustr,
+            ReprId,
             // Additional, rule dependent, information
             Ustr,
         )>,
@@ -33,7 +34,7 @@ pub enum Name {
     WithRepresentation(
         Box<Name>,
         /// representations chosen
-        Vec<Ustr>,
+        Vec<ReprId>,
     ),
 }
 
@@ -44,8 +45,8 @@ impl Name {
     }
 
     /// Creates a name for an auxiliary variable introduced by a representation.
-    pub fn repr(src: Name, rule_name: &str, suffix: &str) -> Self {
-        Name::Represented(Box::new((src, Ustr::from(rule_name), Ustr::from(suffix))))
+    pub fn repr(src: Name, rule: ReprId, suffix: &str) -> Self {
+        Name::Represented(Box::new((src, rule, Ustr::from(suffix))))
     }
 }
 
@@ -63,8 +64,8 @@ impl Display for Name {
             Name::User(s) => write!(f, "{s}"),
             Name::Machine(i) => write!(f, "__{i}"),
             Name::Represented(fields) => {
-                let (name, rule_string, suffix) = fields.as_ref();
-                write!(f, "{name}#{rule_string}_{suffix}")
+                let (name, rule, suffix) = fields.as_ref();
+                write!(f, "{name}#{rule}_{suffix}")
             }
             Name::WithRepresentation(name, items) => {
                 // TODO: what is the correct syntax for nested reprs?

--- a/crates/conjure-cp-core/src/ast/pretty.rs
+++ b/crates/conjure-cp-core/src/ast/pretty.rs
@@ -274,15 +274,11 @@ fn format_domain_with_selected_representation(
     decl: &crate::ast::DeclarationPtr,
     domain: &crate::ast::DomainPtr,
 ) -> String {
-    let selected = decl.reprs().iter().find_map(|(_, state)| {
-        let rule = state.rule();
-        // MatrixComponents is structural layout, not an abstract-domain representation name.
-        if rule.short_name() == "components" {
-            None
-        } else {
-            Some(rule.short_name())
-        }
-    });
+    let selected = decl
+        .reprs()
+        .iter()
+        .map(|(_, state)| state.rule().short_name())
+        .next();
 
     match selected {
         Some(short_name) if domain.representation_preference() != Some(short_name) => {

--- a/crates/conjure-cp-core/src/ast/symbol_table.rs
+++ b/crates/conjure-cp-core/src/ast/symbol_table.rs
@@ -10,6 +10,7 @@ fn default_context_hash_cache() -> AtomicU64 {
 }
 
 use crate::bug;
+use crate::representation::ReprId;
 use crate::representation::{Representation, get_repr_rule};
 use std::any::TypeId;
 
@@ -615,7 +616,7 @@ impl SymbolTable {
     pub fn get_representation(
         &self,
         name: &Name,
-        representation: &[&str],
+        representation: &[ReprId],
     ) -> Option<Vec<Box<dyn Representation>>> {
         // TODO: move representation stuff to declaration / variable to avoid cloning? (we have to
         // move inside of an rc here, so cannot return borrows)
@@ -633,7 +634,7 @@ impl SymbolTable {
 
         var.representations
             .iter()
-            .find(|x| &x.iter().map(|r| r.repr_name()).collect_vec()[..] == representation)
+            .find(|x| &x.iter().map(|r| r.repr_id()).collect_vec()[..] == representation)
             .cloned()
     }
 
@@ -666,7 +667,7 @@ impl SymbolTable {
     pub fn get_or_add_representation(
         &mut self,
         name: &Name,
-        representation: &[&str],
+        representation: &[ReprId],
     ) -> Option<Vec<Box<dyn Representation>>> {
         // Lookup the declaration reference
         let mut decl = self.lookup(name)?;
@@ -675,7 +676,7 @@ impl SymbolTable {
             && let Some(existing_reprs) = var
                 .representations
                 .iter()
-                .find(|x| &x.iter().map(|r| r.repr_name()).collect_vec()[..] == representation)
+                .find(|x| &x.iter().map(|r| r.repr_id()).collect_vec()[..] == representation)
                 .cloned()
         {
             return Some(existing_reprs); // Found: return early
@@ -686,8 +687,7 @@ impl SymbolTable {
         if representation.len() != 1 {
             bug!("nested representations not implemented")
         }
-        let repr_name_str = representation[0];
-        let repr_init_fn = get_repr_rule(repr_name_str)?;
+        let repr_init_fn = get_repr_rule(representation[0].name())?;
 
         let reprs = vec![repr_init_fn(name, self)?];
 

--- a/crates/conjure-cp-core/src/ast/symbol_table.rs
+++ b/crates/conjure-cp-core/src/ast/symbol_table.rs
@@ -9,9 +9,8 @@ fn default_context_hash_cache() -> AtomicU64 {
     AtomicU64::new(NO_CONTEXT_HASH)
 }
 
-use crate::bug;
 use crate::representation::ReprId;
-use crate::representation::{Representation, get_repr_rule};
+use crate::representation::Representation;
 use std::any::TypeId;
 
 use std::collections::BTreeMap;
@@ -646,65 +645,6 @@ impl SymbolTable {
     pub fn representations_for(&self, name: &Name) -> Option<Vec<Vec<Box<dyn Representation>>>> {
         let decl = self.lookup(name)?;
         decl.as_find().map(|x| x.representations.clone())
-    }
-
-    /// Gets the representation `representation` for `name`, creating it if it does not exist.
-    ///
-    /// If the representation does not exist, this method initialises the representation in this
-    /// symbol table, adding the representation to `name`, and the declarations for the represented
-    /// variables to the symbol table.
-    ///
-    /// # Usage
-    ///
-    /// Representations for variable references should be selected and created by the
-    /// `select_representation` rule. Therefore, this method should not be used in other rules.
-    /// Consider using [`get_representation`](`SymbolTable::get_representation`) instead.
-    ///
-    /// # Returns
-    ///
-    /// + `None` if `name` does not exist, is not a decision variable, or cannot be given that
-    ///   representation.
-    pub fn get_or_add_representation(
-        &mut self,
-        name: &Name,
-        representation: &[ReprId],
-    ) -> Option<Vec<Box<dyn Representation>>> {
-        // Lookup the declaration reference
-        let mut decl = self.lookup(name)?;
-
-        if let Some(var) = decl.as_find()
-            && let Some(existing_reprs) = var
-                .representations
-                .iter()
-                .find(|x| &x.iter().map(|r| r.repr_id()).collect_vec()[..] == representation)
-                .cloned()
-        {
-            return Some(existing_reprs); // Found: return early
-        }
-        // Representation not found
-
-        // TODO: nested representations logic...
-        if representation.len() != 1 {
-            bug!("nested representations not implemented")
-        }
-        let repr_init_fn = get_repr_rule(representation[0].name())?;
-
-        let reprs = vec![repr_init_fn(name, self)?];
-
-        for repr_instance in &reprs {
-            repr_instance
-                .declaration_down()
-                .ok()?
-                .into_iter()
-                .for_each(|x| self.update_insert(x));
-        }
-
-        // Do not hold the declaration write lock while inserting represented variables:
-        // `update_insert` may refresh content hashes and read this declaration.
-        let mut var = decl.as_find_mut()?;
-        var.representations.push(reprs.clone());
-
-        Some(reprs)
     }
 }
 

--- a/crates/conjure-cp-core/src/representation/default_impls.rs
+++ b/crates/conjure-cp-core/src/representation/default_impls.rs
@@ -58,7 +58,7 @@ where
     SF: Fn(&DecL) -> Vec<Expression>,
 {
     let src_name = decl.name();
-    let repr_name = <DomL as ReprDomainLevel>::RULE.short_name();
+    let repr_name = <DomL as ReprDomainLevel>::RULE.id();
     let mut symtab = SymbolTable::new();
     let mut counter = 1;
 

--- a/crates/conjure-cp-core/src/representation/id.rs
+++ b/crates/conjure-cp-core/src/representation/id.rs
@@ -1,0 +1,99 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::registry::get_repr_by_name;
+
+/// The identity of a representation rule.
+///
+/// Identity is the rule's [`NAME`](super::ReprRule::NAME) -- its Rust type name, which is unique
+/// across the registry. A representation's *short* name is not unique: nine representations are
+/// called `packed`, four `components`, four `occurrence`. Wrapping the identity in its own type
+/// keeps a short name from being used as one by accident, which has silently broken rules before.
+///
+/// The short name travels along for display, so rendering a represented name costs no lookup.
+#[derive(Clone, Copy, Debug)]
+pub struct ReprId {
+    name: &'static str,
+    short_name: &'static str,
+}
+
+impl ReprId {
+    /// Builds an id from a rule's name and short name.
+    ///
+    /// Prefer [`ReprRule::id`](super::ReprRule::id) or [`ReprRuleStored::id`](super::ReprRuleStored::id)
+    /// over calling this directly; those cannot disagree with the registry.
+    pub const fn new(name: &'static str, short_name: &'static str) -> Self {
+        ReprId { name, short_name }
+    }
+
+    /// The unique name identifying this representation.
+    pub fn name(self) -> &'static str {
+        self.name
+    }
+
+    /// The Essence-facing name, which several representations may share.
+    pub fn short_name(self) -> &'static str {
+        self.short_name
+    }
+}
+
+impl PartialEq for ReprId {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for ReprId {}
+
+impl std::hash::Hash for ReprId {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
+
+impl PartialOrd for ReprId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ReprId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(other.name)
+    }
+}
+
+/// Displays the short name, which is what Essence and represented variable names use.
+impl Display for ReprId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.short_name)
+    }
+}
+
+/// Serialises as the unique name, so stored models survive a short-name change.
+impl Serialize for ReprId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.name)
+    }
+}
+
+impl<'de> Deserialize<'de> for ReprId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let name = String::deserialize(deserializer)?;
+        get_repr_by_name(&name)
+            .map(|rule| rule.id())
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown representation `{name}`")))
+    }
+}
+
+impl polyquine::Quine for ReprId {
+    fn ctor_tokens(&self) -> proc_macro2::TokenStream {
+        let name = self.name;
+        quote::quote! {
+            conjure_cp::representation::get_repr_by_name(#name)
+                .expect("representation should be registered")
+                .id()
+        }
+    }
+}

--- a/crates/conjure-cp-core/src/representation/legacy.rs
+++ b/crates/conjure-cp-core/src/representation/legacy.rs
@@ -90,6 +90,9 @@ pub trait Representation: Send + Sync + Debug {
     /// The rule name for this representaion.
     fn repr_name(&self) -> &str;
 
+    /// The identity of this representation.
+    fn repr_id(&self) -> super::ReprId;
+
     /// Makes a clone of `self` into a `Representation` trait object.
     fn box_clone(&self) -> Box<dyn Representation>;
 }

--- a/crates/conjure-cp-core/src/representation/legacy.rs
+++ b/crates/conjure-cp-core/src/representation/legacy.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use core::fmt::Debug;
-use linkme::distributed_slice;
 
 //TODO: write good documentation on this! ~niklasdewally
 
@@ -10,59 +9,6 @@ use crate::{
     rule_engine::ApplicationError,
 };
 
-#[distributed_slice]
-#[doc(hidden)]
-pub static REPRESENTATION_RULES: [RepresentationRule];
-
-#[doc(hidden)]
-pub struct RepresentationRule {
-    pub name: &'static str,
-    pub init: fn(&Name, &SymbolTable) -> Option<Box<dyn Representation>>,
-}
-
-/// Gets the representation rule named `name`.
-#[allow(clippy::type_complexity)]
-pub fn get_repr_rule(
-    name: &str,
-) -> Option<fn(&Name, &SymbolTable) -> Option<Box<dyn Representation>>> {
-    REPRESENTATION_RULES
-        .iter()
-        .find(|x| x.name == name)
-        .map(|x| x.init)
-}
-
-#[macro_export]
-macro_rules! register_legacy_representation {
-    ($ruleType:ident, $ruleName:literal) => {
-        paste::paste!{
-        #[linkme::distributed_slice($crate::representation::REPRESENTATION_RULES)]
-        pub static [<__ $ruleType:snake:upper _REPRESENTATION_RULE>]: $crate::representation::RepresentationRule = $crate::representation::RepresentationRule {
-            name: $ruleName,
-            init: [<__create_representation_ $ruleType:snake>]
-        };
-
-
-        fn [<__create_representation_ $ruleType:snake>] (name: &$crate::ast::Name, symtab: &$crate::ast::SymbolTable) -> Option<Box<dyn Representation>>  {
-                $ruleType::init(name,symtab).map(|x| Box::new(x) as Box<dyn Representation>)
-            }
-        }
-    };
-}
-
-// This alongside Representation::box_clone() allows Representation to be a trait-object but still
-// cloneable.
-impl Clone for Box<dyn Representation> {
-    fn clone(&self) -> Self {
-        self.box_clone()
-    }
-}
-
-/// Encodes the two-way relationship between a non-atomic variable and multiple auxiliary variables.
-///
-/// For example, a 2x2 matrix X might be represented by a variable for each element X1_1 X1_2 X2_1 X2_2.
-/// The [`Representation`] for X then allows us to set the value of the matrix, and takes care of
-/// assigning the individual variables accordingly. Conversly, we can set the values of the elements, and
-/// the [`Representation`] will return an assignment for the matrix as a whole.
 pub trait Representation: Send + Sync + Debug {
     /// Creates a representation object for the given name.
     fn init(name: &Name, symtab: &SymbolTable) -> Option<Self>
@@ -95,4 +41,10 @@ pub trait Representation: Send + Sync + Debug {
 
     /// Makes a clone of `self` into a `Representation` trait object.
     fn box_clone(&self) -> Box<dyn Representation>;
+}
+
+impl Clone for Box<dyn Representation> {
+    fn clone(&self) -> Self {
+        self.box_clone()
+    }
 }

--- a/crates/conjure-cp-core/src/representation/mod.rs
+++ b/crates/conjure-cp-core/src/representation/mod.rs
@@ -1,5 +1,6 @@
 pub mod default_impls;
 pub mod errors;
+pub mod id;
 mod legacy;
 pub mod registry;
 mod serde;
@@ -10,10 +11,10 @@ pub mod util;
 
 pub use conjure_cp_rule_macros::register_representation;
 pub use errors::*;
+pub use id::ReprId;
 pub use legacy::*;
 pub use registry::{
-    ReprRulePtr, get_applicable_repr_by_short_name, get_repr_by_name, get_repr_by_short_name,
-    get_repr_rules,
+    ReprRulePtr, get_applicable_repr_by_short_name, get_repr_by_name, get_repr_rules,
 };
 pub use store::ReprStore;
 pub use stored::{ReprRuleStored, ReprStateStored};

--- a/crates/conjure-cp-core/src/representation/registry.rs
+++ b/crates/conjure-cp-core/src/representation/registry.rs
@@ -20,20 +20,11 @@ pub fn get_repr_by_name(name: &str) -> Option<ReprRulePtr> {
         .find(|rule| rule.name() == name)
 }
 
-/// Look up a representation rule by its Essence short name (e.g. `"packed"`, `"occurrence"`).
-///
-/// If multiple rules share the same short name (e.g. set and tuple both use `"packed"`), the first
-/// registration wins. Prefer [`get_applicable_repr_by_short_name`] when a declaration is available.
-pub fn get_repr_by_short_name(short_name: &str) -> Option<ReprRulePtr> {
-    REPR_RULES_DISTRIBUTED_SLICE
-        .iter()
-        .copied()
-        .find(|rule| rule.short_name() == short_name)
-}
-
 /// Look up a representation by short name that is applicable to `decl`.
 ///
-/// Disambiguates shared short names such as `"packed"` (set vs tuple) via [`ReprRuleStored::probe_for`].
+/// Short names are not unique -- nine representations are called `packed` -- so a declaration is
+/// required to disambiguate, via [`ReprRuleStored::probe_for`]. There is deliberately no lookup by
+/// short name alone.
 pub fn get_applicable_repr_by_short_name(
     decl: &crate::ast::DeclarationPtr,
     short_name: &str,

--- a/crates/conjure-cp-core/src/representation/stored.rs
+++ b/crates/conjure-cp-core/src/representation/stored.rs
@@ -69,6 +69,9 @@ pub trait ReprRuleStored: Send + Sync {
 
     fn short_name(&self) -> &'static str;
 
+    /// This representation's identity.
+    fn id(&self) -> super::ReprId;
+
     /// Whether this representation is available when targeting `family`.
     fn applies_to(&self, family: crate::settings::SolverFamily) -> bool;
 
@@ -99,6 +102,10 @@ pub trait ReprRuleStored: Send + Sync {
 impl<R: ReprRule> ReprRuleStored for R {
     fn name(&self) -> &'static str {
         R::NAME
+    }
+
+    fn id(&self) -> super::ReprId {
+        <R as ReprRule>::id()
     }
 
     fn short_name(&self) -> &'static str {
@@ -160,7 +167,7 @@ impl Debug for dyn ReprRuleStored {
 
 impl PartialEq for dyn ReprRuleStored {
     fn eq(&self, other: &Self) -> bool {
-        self.name() == other.name()
+        self.id() == other.id()
     }
 }
 

--- a/crates/conjure-cp-core/src/representation/types.rs
+++ b/crates/conjure-cp-core/src/representation/types.rs
@@ -85,6 +85,12 @@ pub type ReprGetOrInitResult<'a, D, E> =
 pub trait ReprRule: Send + Sync {
     const NAME: &'static str;
     const SHORT_NAME: &'static str;
+
+    /// This representation's identity.
+    fn id() -> super::ReprId {
+        super::ReprId::new(Self::NAME, Self::SHORT_NAME)
+    }
+
     const STORED: &'static dyn ReprRuleStored;
     type Assignment: ReprAssignment;
     type DeclLevel: ReprDeclLevel<Assignment = Self::Assignment>;
@@ -131,7 +137,7 @@ pub trait ReprRule: Send + Sync {
         if crate::settings::channelling() == crate::settings::Channelling::No {
             let existing_rule = decl.reprs().iter().next().map(|(_, state)| state.rule());
             if let Some(existing_rule) = existing_rule
-                && existing_rule.name() != Self::NAME
+                && existing_rule.id() != Self::id()
             {
                 return Err(ReprInstantiateError::ConflictingRepresentation {
                     declaration: decl.clone(),

--- a/crates/conjure-cp-core/src/solver/adaptors/minion/adaptor.rs
+++ b/crates/conjure-cp-core/src/solver/adaptors/minion/adaptor.rs
@@ -113,8 +113,6 @@ fn wall_time_limit(timeout: Duration) -> TimeLimit {
 fn parse_name(minion_name: &str) -> Name {
     static MACHINE_NAME_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"__conjure_machine_name_([0-9]+)").unwrap());
-    static REPRESENTED_NAME_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"__conjure_represented_name__(.*)__(.*)___(.*)").unwrap());
     const REPRESENTED_JSON_PREFIX: &str = "__conjure_represented_name_json_";
 
     if let Some(caps) = MACHINE_NAME_RE.captures(minion_name) {
@@ -125,12 +123,6 @@ fn parse_name(minion_name: &str) -> Name {
             .map(|i| u8::from_str_radix(&encoded[i..i + 2], 16).unwrap())
             .collect::<Vec<_>>();
         serde_json::from_slice(&bytes).unwrap()
-    } else if let Some(caps) = REPRESENTED_NAME_RE.captures(minion_name) {
-        conjure_ast::Name::Represented(Box::new((
-            parse_name(&caps[1]),
-            Ustr::from(&caps[2]),
-            Ustr::from(&caps[3]),
-        )))
     } else {
         conjure_ast::Name::User(Ustr::from(minion_name))
     }

--- a/crates/conjure-cp-rules/src/backends/minion/lex.rs
+++ b/crates/conjure-cp-rules/src/backends/minion/lex.rs
@@ -1,9 +1,11 @@
 use crate::shared::utils::{as_resolved_atom, to_aux_var_in};
+use crate::types::matrix::MatrixComponents;
 use crate::types::record::RecordComponents;
 use crate::types::tuple::{TupleComponents, TuplePacked};
 use conjure_cp::ast::{
     Atom, Expression as Expr, GroundDomain, IntVal, Metadata, Moo, Name, Range, SymbolTable, matrix,
 };
+use conjure_cp::representation::ReprRule;
 use conjure_cp::rule_engine::{
     ApplicationError, ApplicationError::RuleNotApplicable, ApplicationResult, RuleEffect,
     register_rule,
@@ -109,14 +111,14 @@ fn lex_represented_matrix_to_atoms(
     };
     if representations
         .first()
-        .is_none_or(|name| name.as_str() != "matrix_to_atom")
+        .is_none_or(|id| *id != MatrixComponents::id())
     {
         return Ok(None);
     }
 
     let declaration = symbols.lookup(name.as_ref()).ok_or(RuleNotApplicable)?;
     let representation = symbols
-        .get_representation(name.as_ref(), &["matrix_to_atom"])
+        .get_representation(name.as_ref(), &[MatrixComponents::id()])
         .ok_or(RuleNotApplicable)?[0]
         .clone();
     let domain = declaration.resolved_domain().ok_or(RuleNotApplicable)?;
@@ -133,7 +135,7 @@ fn lex_represented_matrix_to_atoms(
             matrix_values
                 .get(&Name::Represented(Box::new((
                     name.as_ref().clone(),
-                    "matrix_to_atom".into(),
+                    MatrixComponents::id(),
                     index.iter().join("_").into(),
                 ))))
                 .cloned()

--- a/crates/conjure-cp-rules/src/backends/minion/mod.rs
+++ b/crates/conjure-cp-rules/src/backends/minion/mod.rs
@@ -11,6 +11,9 @@ use std::{
     convert::TryInto,
 };
 
+use crate::types::matrix::MatrixComponents;
+use conjure_cp::representation::ReprRule;
+
 use crate::extra_check;
 use crate::shared::utils::{
     defer_aux_var, flatten_children_to_aux_vars, is_flat, rewrite_children, to_aux_var_in,
@@ -1684,7 +1687,7 @@ fn represented_matrix_to_atom_index(atom: &Atom) -> Option<i32> {
         return None;
     };
     let (_, rule, suffix) = fields.as_ref();
-    if rule.as_str() != "matrix_to_atom" {
+    if *rule != MatrixComponents::id() {
         return None;
     }
     suffix.as_str().parse().ok()

--- a/crates/conjure-cp-rules/src/passes/representation.rs
+++ b/crates/conjure-cp-rules/src/passes/representation.rs
@@ -1,7 +1,9 @@
 use crate::guard;
 use crate::shared::utils::as_cmp_or_lex_op;
+use crate::types::int::{IntDirect, IntLog, IntOrder, SmtBv, SmtLia};
 use conjure_cp::ast::pretty::pretty_find_with_representation;
 use conjure_cp::ast::{Domain, DomainPtr, HasDomain, UnresolvedDomain};
+use conjure_cp::representation::ReprRule;
 use conjure_cp::settings::{
     Channelling, Heuristic, channelling, heuristic, next_heuristic_all_index,
     next_heuristic_interactive_index, next_heuristic_random_index,
@@ -294,9 +296,9 @@ fn compact_representation_choice(candidates: &[(ReprRulePtr, usize)]) -> Option<
     candidates
         .iter()
         .min_by_key(|(rule, score)| {
-            let smt_integer_tie_break = match rule.name() {
-                "SmtLia" => 0,
-                "SmtBv" => 1,
+            let smt_integer_tie_break = match rule.id() {
+                id if id == SmtLia::id() => 0,
+                id if id == SmtBv::id() => 1,
                 _ => 0,
             };
             (*score, smt_integer_tie_break, rule.name())
@@ -312,10 +314,14 @@ fn compact_representation_choice(candidates: &[(ReprRulePtr, usize)]) -> Option<
 /// a matrix choose `array` and its integers choose `bv` as two independent decisions rather than
 /// one combined `bv-array`.
 fn is_encoding_repr(rule: ReprRulePtr) -> bool {
-    matches!(
-        rule.name(),
-        "SmtLia" | "SmtBv" | "IntLog" | "IntDirect" | "IntOrder"
-    )
+    [
+        SmtLia::id(),
+        SmtBv::id(),
+        IntLog::id(),
+        IntDirect::id(),
+        IntOrder::id(),
+    ]
+    .contains(&rule.id())
 }
 
 /// True if `decl` was introduced by a representation that left it holding the whole value, rather
@@ -548,10 +554,10 @@ mod tests {
     #[test]
     fn compact_prefers_lia_when_smt_integer_scores_saturate() {
         let lia = get_repr_rules()
-            .find(|rule| rule.name() == "SmtLia")
+            .find(|rule| rule.id() == SmtLia::id())
             .expect("SmtLia representation should be registered");
         let bv = get_repr_rules()
-            .find(|rule| rule.name() == "SmtBv")
+            .find(|rule| rule.id() == SmtBv::id())
             .expect("SmtBv representation should be registered");
 
         assert_eq!(

--- a/crates/conjure-cp-rules/src/passes/representation.rs
+++ b/crates/conjure-cp-rules/src/passes/representation.rs
@@ -356,6 +356,10 @@ fn source_has_encoding_repr(decl: &DeclarationPtr) -> bool {
 }
 
 /// Find a representation already chosen for another declaration with the same domain.
+///
+/// Any representation the sibling settled on is worth copying, component layouts included: a
+/// matrix chooses between `components`, `packed` and `array`, so `components` is a modelling
+/// choice like any other rather than a decomposition to see past.
 fn representation_for_identical_domain(
     decl: &DeclarationPtr,
     dom: &DomainPtr,
@@ -373,10 +377,6 @@ fn representation_for_identical_domain(
         }
         for (_, state) in other.reprs().iter() {
             let rule = state.rule();
-            // MatrixComponents is a structural layout, not an abstract-domain representation.
-            if rule.name() == "components" {
-                continue;
-            }
             if rule.probe_for(decl).is_ok() {
                 return Some(rule);
             }

--- a/crates/conjure-cp-rules/src/types/matrix/flatten.rs
+++ b/crates/conjure-cp-rules/src/types/matrix/flatten.rs
@@ -1,5 +1,7 @@
+use crate::types::matrix::MatrixComponents;
 use conjure_cp::ast::{Atom, Expression as Expr, GroundDomain, Name, SymbolTable, matrix};
 use conjure_cp::into_matrix_expr;
+use conjure_cp::representation::ReprRule;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, RuleEffect, register_rule,
 };
@@ -21,13 +23,13 @@ fn flatten_matrix(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
             return Err(RuleNotApplicable);
         };
 
-        if reprs.first().is_none_or(|x| x.as_str() != "matrix_to_atom") {
+        if reprs.first().is_none_or(|x| *x != MatrixComponents::id()) {
             return Err(RuleNotApplicable);
         }
 
         let decl = symbols.lookup(name.as_ref()).unwrap();
         let repr = symbols
-            .get_representation(name.as_ref(), &["matrix_to_atom"])
+            .get_representation(name.as_ref(), &[MatrixComponents::id()])
             .unwrap()[0]
             .clone();
 
@@ -45,7 +47,7 @@ fn flatten_matrix(expr: &Expr, symbols: &SymbolTable) -> ApplicationResult {
             .map(|i| {
                 matrix_values[&Name::Represented(Box::new((
                     name.as_ref().clone(),
-                    "matrix_to_atom".into(),
+                    MatrixComponents::id(),
                     i.iter().join("_").into(),
                 )))]
                     .clone()

--- a/crates/conjure-cp-rules/src/types/mset/counts/vertical/generator.rs
+++ b/crates/conjure-cp-rules/src/types/mset/counts/vertical/generator.rs
@@ -3,6 +3,7 @@ use conjure_cp::ast::{
     Atom, DeclarationPtr, Expression as Expr, Metadata, Moo, Name, Reference, SymbolTable,
     comprehension::ComprehensionQualifier,
 };
+use conjure_cp::representation::ReprRule;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, RuleEffect, register_rule,
 };
@@ -49,7 +50,7 @@ fn lower_counts_mset_generator(expr: &Expr, _: &SymbolTable) -> ApplicationResul
     let value_index =
         DeclarationPtr::new_quantified(old.name().clone(), domain_int!(1..repr.max_distinct));
     let repetition = DeclarationPtr::new_quantified(
-        Name::repr(old.name().clone(), "iterator", "count"),
+        Name::repr(old.name().clone(), MSetCounts::id(), "iterator"),
         domain_int!(1..repr.occurrence.1),
     );
     let index_expr = Expr::from(Reference::new(value_index.clone()));

--- a/crates/conjure-cp-rules/src/types/mset/occurrence/vertical/generator.rs
+++ b/crates/conjure-cp-rules/src/types/mset/occurrence/vertical/generator.rs
@@ -3,6 +3,7 @@ use conjure_cp::ast::{
     Atom, DeclarationPtr, Expression as Expr, Metadata, Moo, Name, Reference, SymbolTable,
     comprehension::ComprehensionQualifier,
 };
+use conjure_cp::representation::ReprRule;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, RuleEffect, register_rule,
 };
@@ -49,7 +50,7 @@ fn lower_occurrence_mset_generator(expr: &Expr, _: &SymbolTable) -> ApplicationR
     }
     let value_index = DeclarationPtr::new_quantified(old.name().clone(), domain_int!(1..length));
     let repetition = DeclarationPtr::new_quantified(
-        Name::repr(old.name().clone(), "iterator", "occurrence"),
+        Name::repr(old.name().clone(), MSetOccurrence::id(), "iterator"),
         domain_int!(1..repr.occurrence.1),
     );
     let i = Expr::from(Reference::new(value_index.clone()));

--- a/crates/conjure-cp-rules/src/types/mset/packed/vertical/generator.rs
+++ b/crates/conjure-cp-rules/src/types/mset/packed/vertical/generator.rs
@@ -3,6 +3,7 @@ use conjure_cp::ast::{
     Atom, DeclarationPtr, Expression as Expr, Metadata, Moo, Name, Reference, SymbolTable,
     comprehension::ComprehensionQualifier,
 };
+use conjure_cp::representation::ReprRule;
 use conjure_cp::rule_engine::{
     ApplicationError::RuleNotApplicable, ApplicationResult, RuleEffect, register_rule,
 };
@@ -49,7 +50,7 @@ fn lower_packed_mset_generator(expr: &Expr, _: &SymbolTable) -> ApplicationResul
     }
     let value_index = DeclarationPtr::new_quantified(old.name().clone(), domain_int!(1..length));
     let repetition = DeclarationPtr::new_quantified(
-        Name::repr(old.name().clone(), "iterator", "occurrence"),
+        Name::repr(old.name().clone(), MSetPacked::id(), "iterator"),
         domain_int!(1..repr.occurrence.1),
     );
     let i = Expr::from(Reference::new(value_index.clone()));


### PR DESCRIPTION
Representations are now identified by `ReprId` rather than by comparing strings. It is a newtype over the unique `NAME` that also carries the `SHORT_NAME` for display, threaded through `Name::Represented`, `Name::WithRepresentation` and `SymbolTable::get_representation`. Output is unchanged, since `Display` still renders the short name, so all tests pass with no expected-file updates.

Fixed along the way:

- Seven stale `"matrix_to_atom"` literals left by the `MatrixToAtom` -> `MatrixComponents("components")` rename in `cad550d580`. Nothing failed to compile, so `flatten_matrix` quietly stopped matching and has fired 0 times since July.
- `get_repr_by_short_name` picked whichever representation registered first. Short names are not unique: nine are called `packed`, four `components`. It is removed in favour of the lookup that disambiguates against a declaration.
- Remaining name literals replaced with constants, including `"SmtLia"` and `"SmtBv"`.
- The legacy representation registry is dead and removed: `SymbolTable::get_or_add_representation` had no callers, `get_repr_rule` had only that one, and `register_legacy_representation!` was never invoked.
- A `REPRESENTED_NAME_RE` branch in `minion/adaptor.rs` parsed a name spelling the writer no longer emits. Removed.
- A `rule.name() == "components"` guard compared a Rust ident against a short name, so it never fired. Its premise is also obsolete: a matrix genuinely chooses between `components`, `packed` and `array`, so copying a sibling's `components` choice is correct. Removed rather than repaired.
- Three call sites minted quantifier names with `Name::repr(src, "iterator", "occurrence")`, all three naming `occurrence` including the packed and counts generators. They now use their own representation's id. These rules never fire in the test suite, so this is compile-checked but not exercised.